### PR TITLE
Pin k8s version to 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ delete-int-test-infra: ## Removes all test infrastructure
 	kind delete cluster --name platform
 
 create-int-test-infra: delete-int-test-infra ## Builds and runs pre-reqs to run int-test
-	kind create cluster --name platform --config <(echo "{kind: Cluster, apiVersion: kind.x-k8s.io/v1alpha4, nodes: [{role: control-plane, extraPortMappings: [{containerPort: 31337, hostPort: 31337}]}]}")
+	kind create cluster --name platform --image kindest/node:v1.24.0 --config <(echo "{kind: Cluster, apiVersion: kind.x-k8s.io/v1alpha4, nodes: [{role: control-plane, extraPortMappings: [{containerPort: 31337, hostPort: 31337}]}]}")
 
 deploy-int-test-env: create-int-test-infra ## Builds and deploys dev version software on int-test infrastructure
 	make build-and-load-int-test-images

--- a/docs/detailed-start.md
+++ b/docs/detailed-start.md
@@ -38,7 +38,7 @@ This will create our platform cluster and install Kratix. We'll also install Min
 
 ```bash
 # Create the platform cluster using kind. It also switch the kubectl context to the newly created cluster.
-kind create cluster --name platform
+kind create cluster --name platform --image kindest/node:v1.24.0
 ```
 
 You can validate if your cluster was created successfully by running the following commands:
@@ -120,7 +120,7 @@ This will create a cluster for running the _X-as-a-service_ workloads, and insta
 
 ```bash
 # Creates a new cluster with kind. It also switch the kubectl context to the newly created cluster.
-kind create cluster --name worker
+kind create cluster --name worker --image kindest/node:v1.24.0
 
 # Register the worker cluster with the platform cluster
 kubectl --context kind-platform apply --filename config/samples/platform_v1alpha1_worker_cluster.yaml

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -39,7 +39,7 @@ Promise.
 The below commands will create our platform cluster and install Kratix.
 
 ```
-kind create cluster --name platform
+kind create cluster --name platform --image kindest/node:v1.24.0
 kubectl apply -f distribution/kratix.yaml
 kubectl apply -f hack/platform/minio-install.yaml
 ```
@@ -71,7 +71,7 @@ sed -i'' -e "s/172.18.0.2/$PLATFORM_CLUSTER_IP/g" hack/worker/gitops-tk-resource
 This will create a cluster for running the X-as-a-service workloads:
 
 ```
-kind create cluster --name worker #Also switches kubectl context to worker
+kind create cluster --name worker --image kindest/node:v1.24.0 #Also switches kubectl context to worker
 kubectl apply -f config/samples/platform_v1alpha1_worker_cluster.yaml --context kind-platform #register the worker cluster with the platform cluster
 kubectl apply -f hack/worker/gitops-tk-install.yaml
 kubectl apply -f hack/worker/gitops-tk-resources.yaml

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -175,7 +175,7 @@ install_kratix() {
     verify_prerequisites
 
     log -n "Creating platform cluster..."
-    if ! run kind create cluster --name platform \
+    if ! run kind create cluster --name platform --image kindest/node:v1.24.0 \
         --config ${ROOT}/hack/platform/kind-minio-portforward.yaml
     then
         error "Could not create platform cluster"
@@ -195,7 +195,7 @@ install_kratix() {
     patch_kind_networking
 
     log -n "Creating worker cluster..."
-    if ! run kind create cluster --name worker; then
+    if ! run kind create cluster --name worker --image kindest/node:v1.24.0; then
         error "Could not create worker cluster"
         exit 1
     fi


### PR DESCRIPTION
Our current workshop falls over on kubernetes `1.25` as the postgres operator isn't supported for `1.25` 

https://github.com/zalando/postgres-operator/issues/1999
```
Looks like PodDisruptionBudget policy/v1beta1 got removed (policy/v1 is the new apiVersion), which is causing the Postgres Operator to fail to creat the instances
$ k logs postgres-operator-6649b754cd-5w42h msg="could not create cluster: could not create pod disruption budget: the server could not find the requested resource" cluster-name=default/acid-minimal-cluster pkg=controller worker=0
```

this PR pins all of our `kind create cluster` to `1.24`


```
rg "kind create"
scripts/quick-start.sh
176:    if ! run kind create cluster --name platform --image kindest/node:v1.24.0 \
196:    if ! run kind create cluster --name worker --image kindest/node:v1.24.0; then

docs/detailed-start.md
41:kind create cluster --name platform --image kindest/node:v1.24.0
123:kind create cluster --name worker --image kindest/node:v1.24.0

docs/quick-start.md
42:kind create cluster --name platform --image kindest/node:v1.24.0
74:kind create cluster --name worker --image kindest/node:v1.24.0 #Also switches kubectl context to worker

Makefile
86:     kind create cluster --name platform --image kindest/node:v1.24.0 --config <(echo "{kind: Cluster, apiVersion: kind.x-k8s.io/v1alpha4, nodes: [{role: control-plane, extraPortMappings: [{containerPort: 31337, hostPort: 31337}]}]}")

```