### PR TITLE
feat: allow for non-k8s resources on WCR

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -57,7 +57,6 @@ type PromiseSpec struct {
 type WorkerClusterResource struct {
 	// Manifests represents a list of kubernetes resources to be deployed on the worker cluster.
 	// +optional
-	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:pruning:PreserveUnknownFields
 	unstructured.Unstructured `json:",inline"`
 }

--- a/api/v1alpha1/work_types.go
+++ b/api/v1alpha1/work_types.go
@@ -75,7 +75,6 @@ type WorkloadTemplate struct {
 
 // Manifest represents a resource to be deployed on worker cluster
 type Manifest struct {
-	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:pruning:PreserveUnknownFields
 	unstructured.Unstructured `json:",inline"`
 }

--- a/config/crd/bases/platform.kratix.io_promises.yaml
+++ b/config/crd/bases/platform.kratix.io_promises.yaml
@@ -44,7 +44,6 @@ spec:
                   description: Resources represents the manifest workload to be deployed
                     on worker cluster
                   type: object
-                  x-kubernetes-embedded-resource: true
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               xaasCrd:

--- a/config/crd/bases/platform.kratix.io_works.yaml
+++ b/config/crd/bases/platform.kratix.io_works.yaml
@@ -56,7 +56,6 @@ spec:
                       description: Manifest represents a resource to be deployed on
                         worker cluster
                       type: object
-                      x-kubernetes-embedded-resource: true
                       x-kubernetes-preserve-unknown-fields: true
                     type: array
                 type: object

--- a/samples/jenkins/request-pipeline-image/jenkins_instance.yaml
+++ b/samples/jenkins/request-pipeline-image/jenkins_instance.yaml
@@ -15,6 +15,8 @@ spec:
   jenkinsAPISettings:
     authorizationStrategy: createUser
   master:
+    labels:
+      backstage.io/kubernetes-id: jenkins-server
     basePlugins:
     - name: kubernetes
       version: "1.31.3"


### PR DESCRIPTION
for backstage, we want to include non-k8s resources to the WCR; the kubebuilder annotation includes validations on the presence of `metadata` and `spec`, and only accepts certain keys under those objects.

[#184161539]