### PR TITLE
fix: remove log noise from kratix start up reconciliation

### DIFF
--- a/controllers/destination_controller.go
+++ b/controllers/destination_controller.go
@@ -77,17 +77,17 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	logger = logger.WithValues("path", path)
 
 	if err := r.createDependenciesPathWithExample(writer); err != nil {
-		logger.Error(err, "unable to write dependencies to state store")
+		logger.Info("unable to write dependencies to state store", "error", err)
 		return defaultRequeue, nil
 	}
 
 	if err := r.createResourcePathWithExample(writer); err != nil {
-		logger.Error(err, "unable to write dependencies to state store")
+		logger.Info("unable to write resources to state store", "error", err)
 		return defaultRequeue, nil
 	}
 
 	if err := r.Scheduler.ReconcileDestination(); err != nil {
-		logger.Error(err, "unable to schedule destination resources")
+		logger.Info("unable to schedule destination resources", "error", err)
 		return defaultRequeue, nil
 	}
 	return ctrl.Result{}, nil

--- a/lib/writers/s3.go
+++ b/lib/writers/s3.go
@@ -66,6 +66,7 @@ func (b *S3Writer) WriteDirWithObjects(deleteExistingContentsInDir bool, dir str
 		var err error
 		objectsToDeleteMap, err = b.getObjectsInDir(ctx, dir, logger)
 		if err != nil {
+			logger.Error(err, "Error getting objects to delete")
 			return err
 		}
 	}
@@ -73,8 +74,9 @@ func (b *S3Writer) WriteDirWithObjects(deleteExistingContentsInDir bool, dir str
 	exists, errBucketExists := b.RepoClient.BucketExists(ctx, b.BucketName)
 	if errBucketExists != nil {
 		logger.Error(errBucketExists, "Could not verify bucket existence with provider")
+		return errBucketExists
 	} else if !exists {
-		logger.Info("Bucket provided does not exist (or the provided keys don't have permissions)")
+		return fmt.Errorf("Bucket provided does not exist (or the provided keys don't have permissions)")
 	}
 
 	for _, item := range toWrite {


### PR DESCRIPTION
When Kratix starts up in quick start it registers a destination. This creates a delay between when the state is declared and when the system is able to converge due to Minio coming up etc.

This change continues to provide output, but does so without the stack traces which are not useful for debugging and makes it seem more of an error than a eventual consistency state.

This error case is most impactful to new users trying Kratix with quick start, but it would also hit anyone adding a new destination that takes time to become available.

<details><summary>old logs on quickstart</summary>

```
2023-08-30T15:14:25Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
2023-08-30T15:14:25Z	INFO	setup	starting manager
2023-08-30T15:14:25Z	INFO	starting server	{"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8080"}
2023-08-30T15:14:25Z	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
I0830 15:14:25.324259       1 leaderelection.go:245] attempting to acquire leader lease kratix-platform-system/2743c979.kratix.io...
I0830 15:14:25.334040       1 leaderelection.go:255] successfully acquired lease kratix-platform-system/2743c979.kratix.io
2023-08-30T15:14:25Z	INFO	Starting EventSource	{"controller": "promise", "controllerGroup": "platform.kratix.io", "controllerKind": "Promise", "source": "kind source: *v1alpha1.Promise"}
2023-08-30T15:14:25Z	INFO	Starting Controller	{"controller": "promise", "controllerGroup": "platform.kratix.io", "controllerKind": "Promise"}
2023-08-30T15:14:25Z	INFO	Starting EventSource	{"controller": "destination", "controllerGroup": "platform.kratix.io", "controllerKind": "Destination", "source": "kind source: *v1alpha1.Destination"}
2023-08-30T15:14:25Z	INFO	Starting Controller	{"controller": "destination", "controllerGroup": "platform.kratix.io", "controllerKind": "Destination"}
2023-08-30T15:14:25Z	INFO	Starting EventSource	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work", "source": "kind source: *v1alpha1.Work"}
2023-08-30T15:14:25Z	INFO	Starting EventSource	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work", "source": "kind source: *v1alpha1.WorkPlacement"}
2023-08-30T15:14:25Z	INFO	Starting Controller	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work"}
2023-08-30T15:14:25Z	INFO	Starting EventSource	{"controller": "workplacement", "controllerGroup": "platform.kratix.io", "controllerKind": "WorkPlacement", "source": "kind source: *v1alpha1.WorkPlacement"}
2023-08-30T15:14:25Z	INFO	Starting Controller	{"controller": "workplacement", "controllerGroup": "platform.kratix.io", "controllerKind": "WorkPlacement"}
2023-08-30T15:14:25Z	DEBUG	events	kratix-platform-controller-manager-f574f8d8f-sl7xw_24183a41-f5c9-4194-86a0-b57e0bd29fcf became leader	{"type": "Normal", "object": {"kind":"Lease","namespace":"kratix-platform-system","name":"2743c979.kratix.io","uid":"1a280ea0-fdcd-4d34-893f-1dc1144e6ae0","apiVersion":"coordination.k8s.io/v1","resourceVersion":"604"}, "reason": "LeaderElection"}
2023-08-30T15:14:25Z	INFO	Starting workers	{"controller": "destination", "controllerGroup": "platform.kratix.io", "controllerKind": "Destination", "worker count": 1}
2023-08-30T15:14:25Z	INFO	Starting workers	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work", "worker count": 1}
2023-08-30T15:14:25Z	INFO	Starting workers	{"controller": "workplacement", "controllerGroup": "platform.kratix.io", "controllerKind": "WorkPlacement", "worker count": 1}
2023-08-30T15:14:25Z	INFO	Starting workers	{"controller": "promise", "controllerGroup": "platform.kratix.io", "controllerKind": "Promise", "worker count": 1}
2023-08-30T15:14:28Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T15:14:28Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Bucket provided does not exist (or the provided keys don't have permissions)	{"destination": {"name":"platform-cluster"}, "bucketName": "kratix", "path": "platform-cluster"}
2023-08-30T15:14:28Z	ERROR	controllers.DestinationController.writers.BucketStateStoreWriter	Error fetching object	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/dependencies/kratix-canary-namespace.yaml", "error": "The specified bucket does not exist"}
github.com/syntasso/kratix/lib/writers.(*S3Writer).WriteDirWithObjects
	/workspace/lib/writers/s3.go:97
github.com/syntasso/kratix/controllers.(*DestinationReconciler).createDependenciesPathWithExample
	/workspace/controllers/destination_controller.go:128
github.com/syntasso/kratix/controllers.(*DestinationReconciler).Reconcile
	/workspace/controllers/destination_controller.go:79
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:118
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:314
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:265
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:226
2023-08-30T15:14:28Z	ERROR	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "The specified bucket does not exist"}
github.com/syntasso/kratix/controllers.(*DestinationReconciler).Reconcile
	/workspace/controllers/destination_controller.go:80
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:118
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:314
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:265
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:226
2023-08-30T15:14:33Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T15:14:33Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Bucket provided does not exist (or the provided keys don't have permissions)	{"destination": {"name":"platform-cluster"}, "bucketName": "kratix", "path": "platform-cluster"}
2023-08-30T15:14:33Z	ERROR	controllers.DestinationController.writers.BucketStateStoreWriter	Error fetching object	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/dependencies/kratix-canary-namespace.yaml", "error": "The specified bucket does not exist"}
github.com/syntasso/kratix/lib/writers.(*S3Writer).WriteDirWithObjects
	/workspace/lib/writers/s3.go:97
github.com/syntasso/kratix/controllers.(*DestinationReconciler).createDependenciesPathWithExample
	/workspace/controllers/destination_controller.go:128
github.com/syntasso/kratix/controllers.(*DestinationReconciler).Reconcile
	/workspace/controllers/destination_controller.go:79
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:118
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:314
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:265
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:226
2023-08-30T15:14:33Z	ERROR	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "The specified bucket does not exist"}
github.com/syntasso/kratix/controllers.(*DestinationReconciler).Reconcile
	/workspace/controllers/destination_controller.go:80
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:118
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:314
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:265
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:226
2023-08-30T15:14:38Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T15:14:38Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Object does not exist yet	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/dependencies/kratix-canary-namespace.yaml"}
2023-08-30T15:14:38Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Writing object to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/dependencies/kratix-canary-namespace.yaml"}
2023-08-30T15:14:38Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Object written to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/dependencies/kratix-canary-namespace.yaml"}
2023-08-30T15:14:38Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Object does not exist yet	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/resources/kratix-canary-configmap.yaml"}
2023-08-30T15:14:38Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Writing object to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/resources/kratix-canary-configmap.yaml"}
2023-08-30T15:14:38Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Object written to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/resources/kratix-canary-configmap.yaml"}
```

</details>

<details><summary>logs with this PR</summary>

```
2023-08-30T14:22:27Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
2023-08-30T14:22:27Z	INFO	setup	starting manager
2023-08-30T14:22:27Z	INFO	starting server	{"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8080"}
2023-08-30T14:22:27Z	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
I0830 14:22:27.016988       1 leaderelection.go:245] attempting to acquire leader lease kratix-platform-system/2743c979.kratix.io...
I0830 14:22:27.026780       1 leaderelection.go:255] successfully acquired lease kratix-platform-system/2743c979.kratix.io
2023-08-30T14:22:27Z	DEBUG	events	kratix-platform-controller-manager-f574f8d8f-hfltc_5cf13ec6-44ae-414c-a24b-7cd1c2605680 became leader	{"type": "Normal", "object": {"kind":"Lease","namespace":"kratix-platform-system","name":"2743c979.kratix.io","uid":"23649c66-d036-44b6-aab8-3b9377d1bbd9","apiVersion":"coordination.k8s.io/v1","resourceVersion":"732"}, "reason": "LeaderElection"}
2023-08-30T14:22:27Z	INFO	Starting EventSource	{"controller": "promise", "controllerGroup": "platform.kratix.io", "controllerKind": "Promise", "source": "kind source: *v1alpha1.Promise"}
2023-08-30T14:22:27Z	INFO	Starting Controller	{"controller": "promise", "controllerGroup": "platform.kratix.io", "controllerKind": "Promise"}
2023-08-30T14:22:27Z	INFO	Starting EventSource	{"controller": "destination", "controllerGroup": "platform.kratix.io", "controllerKind": "Destination", "source": "kind source: *v1alpha1.Destination"}
2023-08-30T14:22:27Z	INFO	Starting Controller	{"controller": "destination", "controllerGroup": "platform.kratix.io", "controllerKind": "Destination"}
2023-08-30T14:22:27Z	INFO	Starting EventSource	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work", "source": "kind source: *v1alpha1.Work"}
2023-08-30T14:22:27Z	INFO	Starting EventSource	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work", "source": "kind source: *v1alpha1.WorkPlacement"}
2023-08-30T14:22:27Z	INFO	Starting Controller	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work"}
2023-08-30T14:22:27Z	INFO	Starting EventSource	{"controller": "workplacement", "controllerGroup": "platform.kratix.io", "controllerKind": "WorkPlacement", "source": "kind source: *v1alpha1.WorkPlacement"}
2023-08-30T14:22:27Z	INFO	Starting Controller	{"controller": "workplacement", "controllerGroup": "platform.kratix.io", "controllerKind": "WorkPlacement"}
2023-08-30T14:22:27Z	INFO	Starting workers	{"controller": "destination", "controllerGroup": "platform.kratix.io", "controllerKind": "Destination", "worker count": 1}
2023-08-30T14:22:27Z	INFO	Starting workers	{"controller": "workplacement", "controllerGroup": "platform.kratix.io", "controllerKind": "WorkPlacement", "worker count": 1}
2023-08-30T14:22:27Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T14:22:27Z	INFO	Starting workers	{"controller": "promise", "controllerGroup": "platform.kratix.io", "controllerKind": "Promise", "worker count": 1}
2023-08-30T14:22:27Z	INFO	Starting workers	{"controller": "work", "controllerGroup": "platform.kratix.io", "controllerKind": "Work", "worker count": 1}
2023-08-30T14:22:27Z	INFO	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "Bucket provided does not exist (or the provided keys don't have permissions)"}
2023-08-30T14:22:32Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T14:22:32Z	INFO	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "Bucket provided does not exist (or the provided keys don't have permissions)"}
2023-08-30T14:22:37Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T14:22:37Z	INFO	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "Bucket provided does not exist (or the provided keys don't have permissions)"}
2023-08-30T14:22:42Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T14:22:42Z	INFO	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "Bucket provided does not exist (or the provided keys don't have permissions)"}
2023-08-30T14:22:47Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T14:22:47Z	INFO	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "Bucket provided does not exist (or the provided keys don't have permissions)"}
2023-08-30T14:22:52Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T14:22:52Z	INFO	controllers.DestinationController	unable to write dependencies to state store	{"destination": {"name":"platform-cluster"}, "path": "platform-cluster", "error": "Bucket provided does not exist (or the provided keys don't have permissions)"}
2023-08-30T14:22:57Z	INFO	controllers.DestinationController	Registering Destination	{"destination": {"name":"platform-cluster"}, "requestName": "platform-cluster"}
2023-08-30T14:22:57Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Writing object to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/dependencies/kratix-canary-namespace.yaml"}
2023-08-30T14:22:57Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Object written to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/dependencies/kratix-canary-namespace.yaml"}
2023-08-30T14:22:57Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Writing object to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/resources/kratix-canary-configmap.yaml"}
2023-08-30T14:22:57Z	INFO	controllers.DestinationController.writers.BucketStateStoreWriter	Object written to bucket	{"destination": {"name":"platform-cluster"}, "objectName": "platform-cluster/resources/kratix-canary-configmap.yaml"}
```

</details>