### PR TITLE
fix: overwriting status on pipeline re-run

### DIFF
--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -142,7 +142,10 @@ func SetStatus(rr *unstructured.Unstructured, logger logr.Logger, statuses ...st
 		return
 	}
 
-	nestedMap := map[string]interface{}{}
+	if rr.Object["status"] == nil {
+		rr.Object["status"] = map[string]interface{}{}
+	}
+	nestedMap := rr.Object["status"].(map[string]interface{})
 	for i := 0; i < len(statuses); i += 2 {
 		key := statuses[i]
 		value := statuses[i+1]

--- a/lib/resourceutil/util_test.go
+++ b/lib/resourceutil/util_test.go
@@ -321,4 +321,21 @@ var _ = Describe("Conditions", func() {
 			Expect(resourceutil.SuspendablePipelines(logger, jobs)[0].GetName()).To(Equal("unactive"))
 		})
 	})
+
+	Describe("SetStatus", func() {
+		It("sets the status of a resource", func() {
+			rr = &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			}
+			resourceutil.SetStatus(rr, logger, "test", "val")
+
+			Expect(rr.Object).To(HaveKey("status"))
+			Expect(rr.Object["status"]).To(HaveKeyWithValue("foo", "bar"))
+			Expect(rr.Object["status"]).To(HaveKeyWithValue("test", "val"))
+		})
+	})
 })


### PR DESCRIPTION
  when the pipeline gets retriggered for a particular resource, the
  controller will add a 'message: Pending' status to the resource.

  however, the old code was accidentaly wiping out any other status from
  the object; as a side effect, pipelines that relied on information
  persisted in the `status` field wouldn't have that information
  available.

  this commit changes the `SetStatus` utils to utilise the existing
  resource `status` as a base (if that exists).