### PR TITLE
feat: add targets to cleanup a kratix installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: System tests
           command: |
-            SYSTEM_TEST_STORE_TYPE=git DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true make --jobs=4 system-test
+            SYSTEM_TEST_STORE_TYPE=git DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true make system-test
 
   system-tests-bucket:
     executor: machine-large
@@ -121,7 +121,7 @@ jobs:
       - run:
           name: System tests
           command: |
-            SYSTEM_TEST_STORE_TYPE=bucket DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true make --jobs=4 system-test
+            SYSTEM_TEST_STORE_TYPE=bucket DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true make system-test
 
   e2e-demo-test-helm-git:
     executor: machine-large

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ docker-build-and-push: ## Push multi-arch docker image with the manager.
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG} .
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG_MIRROR} .
 
-work-creator-docker-build-and-push:
+build-and-push-work-creator:
 	WC_IMG=${WC_IMG} WC_IMG_MIRROR=${WC_IMG_MIRROR} $(MAKE) -C work-creator docker-build-and-push
 
 # If not installed, use: go install github.com/goreleaser/goreleaser@latest
@@ -157,7 +157,7 @@ chart:
 	  yq 'select(.kind != "CustomResourceDefinition")' > \
           ${CHART_DISTRIBUTION}
 
-release: distribution docker-build-and-push work-creator-docker-build-and-push ## Create a release. Set VERSION env var to "vX.Y.Z-n".
+release: distribution docker-build-and-push build-and-push-work-creator ## Create a release. Set VERSION env var to "vX.Y.Z-n".
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ CRD_OPTIONS ?= "crd:ignoreUnexportedFields=true"
 DOCKER_BUILDKIT ?= 1
 export DOCKER_BUILDKIT
 
+# Recreate Kind Clusters by default
+RECREATE ?= true
+export RECREATE
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -47,7 +51,7 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-##@ Development
+##@ Kubebuilder
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
@@ -55,104 +59,46 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-fmt: ## Run go fmt against code.
-	go fmt ./...
+##@ Environment
 
-vet: ## Run go vet against code.
-	go vet ./...
+teardown: ## Delete all Kratix resources from the Platform cluster
+	./scripts/teardown
 
-build-and-load-bash:
-	docker build --tag syntassodev/bash-promise-test-c0:dev ./test/system/assets/bash-promise --build-arg CONTAINER_INDEX=0
-	docker build --tag syntassodev/bash-promise-test-c1:dev ./test/system/assets/bash-promise --build-arg CONTAINER_INDEX=1
-	docker build --tag syntassodev/bash-promise-test-c2:dev ./test/system/assets/bash-promise --build-arg CONTAINER_INDEX=2
-	docker build --tag syntassodev/bash-promise-configure:v1alpha1 -f ./test/system/assets/bash-promise/Dockerfile.promise ./test/system/assets/bash-promise --build-arg VERSION="v1alpha1"
-	docker build --tag syntassodev/bash-promise-configure:v1alpha2 -f ./test/system/assets/bash-promise/Dockerfile.promise ./test/system/assets/bash-promise --build-arg VERSION="v1alpha2"
-	kind load docker-image syntassodev/bash-promise-test-c0:dev --name platform
-	kind load docker-image syntassodev/bash-promise-test-c1:dev --name platform
-	kind load docker-image syntassodev/bash-promise-test-c2:dev --name platform
-	kind load docker-image syntassodev/bash-promise-configure:v1alpha1 --name platform
-	kind load docker-image syntassodev/bash-promise-configure:v1alpha2 --name platform
+fast-quick-start: teardown ## Install Kratix without recreating the local clusters
+	RECREATE=false make quick-start
 
-install-cert-manager:
+quick-start: generate distribution ## Recreates the clusters and install Kratix
+	if [ "$(SYSTEM_TEST_STORE_TYPE)" == "git" ]; then \
+		VERSION=dev DOCKER_BUILDKIT=1 ./scripts/quick-start.sh --local --git; \
+	else \
+		VERSION=dev DOCKER_BUILDKIT=1 ./scripts/quick-start.sh --local; \
+	fi
+
+prepare-platform-as-destination: ## Installs flux onto platform cluster and registers as a destination
+	./scripts/register-destination --with-label environment=platform --context kind-platform --name platform-cluster
+
+single-cluster: distribution ## Deploys Kratix on a single cluster
+	VERSION=dev DOCKER_BUILDKIT=1 ./scripts/quick-start.sh --recreate --local --single-cluster
+
+dev-env: quick-start prepare-platform-as-destination ## Quick-start + prepare-platform-as-destination
+
+install-cert-manager: ## Install cert-manager on the platform cluster; used in the helm test
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
 	kubectl wait --for condition=available -n cert-manager deployment/cert-manager --timeout 120s
 	kubectl wait --for condition=available -n cert-manager deployment/cert-manager-cainjector --timeout 120s
 	kubectl wait --for condition=available -n cert-manager deployment/cert-manager-webhook --timeout 120s
 
-build-and-load-kratix: kind-load-image
+##@ Container Images
 
-build-and-reload-kratix: kind-load-image  ## Build and reload Kratix on local KinD cluster
-	kubectl rollout restart deployment -n kratix-platform-system kratix-platform-controller-manager
-
-build-and-load-worker-creator:
-	WC_IMG=${WC_IMG} WC_IMG_MIRROR=${WC_IMG_MIRROR} make -C work-creator kind-load-image
-
-load-pipeline-images:
-	docker pull docker.io/bitnami/kubectl:1.20.10
-	kind load docker-image docker.io/bitnami/kubectl:1.20.10 --name platform
-	docker pull syntasso/knative-serving-pipeline:latest
-	kind load docker-image syntasso/knative-serving-pipeline:latest --name platform
-	docker pull syntasso/postgres-configure-pipeline:latest
-	kind load docker-image syntasso/postgres-configure-pipeline:latest --name platform
-	docker pull syntasso/paved-path-demo-configure-pipeline:latest
-	kind load docker-image syntasso/paved-path-demo-configure-pipeline:latest --name platform
-
-
-prepare-platform-as-destination: ## Installs flux onto platform cluster and registers as a destination
-	./scripts/register-destination --with-label environment=platform --context kind-platform --name platform-cluster
-
-install-minio: ## Install test Minio server
-	kubectl --context kind-platform apply -f hack/platform/minio-install.yaml
-
-install-gitea: ## Install test gitea server
-	kubectl --context kind-platform apply -f hack/platform/gitea-install.yaml
-
-install-flux-to-platform:
-	kubectl apply -f ./hack/destination/gitops-tk-install.yaml
-	kubectl wait --namespace flux-system --for=condition=Available deployment source-controller --timeout=120s
-	kubectl wait --namespace flux-system --for=condition=Available deployment kustomize-controller --timeout=120s
-
-system-test: generate fmt vet ## Run integrations tests.
-	make distribution
-	if [ "$(SYSTEM_TEST_STORE_TYPE)" == "git" ]; then \
-	  VERSION=dev DOCKER_BUILDKIT=1 ./scripts/quick-start.sh --recreate --local --git; \
-	else \
-	  VERSION=dev DOCKER_BUILDKIT=1 ./scripts/quick-start.sh --recreate --local; \
-	fi
-	make build-and-load-bash
-	make install-flux-to-platform
-	PLATFORM_DESTINATION_IP=`docker inspect platform-control-plane | grep '"IPAddress": "172' | awk -F '"' '{print $$4}'` make ginkgo-system-test
-
-ginkgo-system-test:
-	go run ${GINKGO} ./test/system/ -r  --coverprofile cover.out
-
-kind-load-image: docker-build ## Load locally built image into KinD, use export IMG=syntasso/kratix-platform:${VERSION}
+kind-load-image: docker-build ## Load locally built image into KinD
 	kind load docker-image ${IMG} --name platform
 	kind load docker-image ${IMG_MIRROR} --name platform
 
-quick-start: distribution
-	VERSION=dev DOCKER_BUILDKIT=1 ./scripts/quick-start.sh --recreate --local --git-and-minio
+build-and-load-kratix: kind-load-image ## Build kratix container image and reloads
+	kubectl rollout restart deployment -n kratix-platform-system -l control-plane=controller-manager
 
-single-cluster: distribution
-	VERSION=dev DOCKER_BUILDKIT=1 ./scripts/quick-start.sh --recreate --local --single-cluster
-
-dev-env: distribution quick-start prepare-platform-as-destination ## Tears down existing resources and sets up a local development environment
-
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
-# kubebuilder-tools does not yet support darwin/arm64. The following is a workaround (see https://github.com/kubernetes-sigs/controller-runtime/issues/1657)
-ARCH_FLAG =
-ifeq ($(shell uname -sm),Darwin arm64)
-	ARCH_FLAG = --arch=amd64
-endif
-.PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) $(ARCH_FLAG) use $(ENVTEST_K8S_VERSION) -p path)" WC_IMG=${WC_IMG} go run ${GINKGO} -r -v --coverprofile cover.out --skip-package=system
-
-ENVTEST = $(shell pwd)/bin/setup-envtest
-.PHONY: envtest
-envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+build-and-load-worker-creator: ## Build worker-creator container image and reloads
+	WC_IMG=${WC_IMG} WC_IMG_MIRROR=${WC_IMG_MIRROR} make -C work-creator kind-load-image
 
 ##@ Build
 
@@ -168,7 +114,7 @@ debug-run: manifests generate fmt vet ## Run a controller in debug mode from you
 
 docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .
-	docker build -t ${IMG_MIRROR} .
+	docker tag ${IMG} ${IMG_MIRROR}
 
 docker-build-and-push: ## Push multi-arch docker image with the manager.
 	if ! docker buildx ls | grep -q "kratix-image-builder"; then \
@@ -176,6 +122,13 @@ docker-build-and-push: ## Push multi-arch docker image with the manager.
 	fi;
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG} .
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG_MIRROR} .
+
+work-creator-docker-build-and-push:
+	WC_IMG=${WC_IMG} WC_IMG_MIRROR=${WC_IMG_MIRROR} $(MAKE) -C work-creator docker-build-and-push
+
+# If not installed, use: go install github.com/goreleaser/goreleaser@latest
+build-worker-resource-builder-binary: ## Uses the goreleaser config to generate binaries
+	WRB_VERSION=${WRB_VERSION} WRB_ON_BRANCH=${WRB_ON_BRANCH} ./scripts/release-worker-resource-builder
 
 ##@ Deployment
 
@@ -206,15 +159,8 @@ chart:
 
 release: distribution docker-build-and-push work-creator-docker-build-and-push ## Create a release. Set VERSION env var to "vX.Y.Z-n".
 
-work-creator-docker-build-and-push:
-	WC_IMG=${WC_IMG} WC_IMG_MIRROR=${WC_IMG_MIRROR} $(MAKE) -C work-creator docker-build-and-push
-
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
-
-# If not installed, use: go install github.com/goreleaser/goreleaser@latest
-build-worker-resource-builder-binary: ## Uses the goreleaser config to generate binaries
-	WRB_VERSION=${WRB_VERSION} WRB_ON_BRANCH=${WRB_ON_BRANCH} ./scripts/release-worker-resource-builder
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
@@ -241,3 +187,89 @@ endef
 .PHONY: list
 list:
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
+
+##@ Tests
+system-test: ## Recreate the clusters and run system tests
+	make quick-start
+	make -j4 run-system-test
+
+fast-system-test: fast-quick-start ## Run the system tests without recreating the clusters
+	make -j4 run-system-test
+
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+ENVTEST_K8S_VERSION = 1.23
+# kubebuilder-tools does not yet support darwin/arm64. The following is a workaround (see https://github.com/kubernetes-sigs/controller-runtime/issues/1657)
+ARCH_FLAG =
+ifeq ($(shell uname -sm),Darwin arm64)
+	ARCH_FLAG = --arch=amd64
+endif
+.PHONY: test
+test: manifests generate fmt vet envtest ## Run unit tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) $(ARCH_FLAG) use $(ENVTEST_K8S_VERSION) -p path)" WC_IMG=${WC_IMG} go run ${GINKGO} -r -v --coverprofile cover.out --skip-package=system
+
+.PHONY: run-system-test
+run-system-test: fmt vet build-and-load-bash prepare-platform-as-destination
+	PLATFORM_DESTINATION_IP=`docker inspect platform-control-plane | grep '"IPAddress": "172' | awk -F '"' '{print $$4}'` go run ${GINKGO} ./test/system/ -r  --coverprofile cover.out
+
+fmt: ## Run go fmt against code.
+	go fmt ./...
+
+vet: ## Run go vet against code.
+	go vet ./...
+
+build-and-load-bash: # Build and load all test pipeline images
+	docker build --tag syntassodev/bash-promise-test-c0:dev ./test/system/assets/bash-promise --build-arg CONTAINER_INDEX=0
+	docker build --tag syntassodev/bash-promise-test-c1:dev ./test/system/assets/bash-promise --build-arg CONTAINER_INDEX=1
+	docker build --tag syntassodev/bash-promise-test-c2:dev ./test/system/assets/bash-promise --build-arg CONTAINER_INDEX=2
+	docker build --tag syntassodev/bash-promise-configure:v1alpha1 -f ./test/system/assets/bash-promise/Dockerfile.promise ./test/system/assets/bash-promise --build-arg VERSION="v1alpha1"
+	docker build --tag syntassodev/bash-promise-configure:v1alpha2 -f ./test/system/assets/bash-promise/Dockerfile.promise ./test/system/assets/bash-promise --build-arg VERSION="v1alpha2"
+	kind load docker-image syntassodev/bash-promise-test-c0:dev --name platform
+	kind load docker-image syntassodev/bash-promise-test-c1:dev --name platform
+	kind load docker-image syntassodev/bash-promise-test-c2:dev --name platform
+	kind load docker-image syntassodev/bash-promise-configure:v1alpha1 --name platform
+	kind load docker-image syntassodev/bash-promise-configure:v1alpha2 --name platform
+
+ENVTEST = $(shell pwd)/bin/setup-envtest
+.PHONY: envtest
+envtest: ## Download envtest-setup locally if necessary.
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+
+
+## Unused?
+# load-pipeline-images:
+# 	docker pull docker.io/bitnami/kubectl:1.20.10
+# 	kind load docker-image docker.io/bitnami/kubectl:1.20.10 --name platform
+# 	docker pull syntasso/knative-serving-pipeline:latest
+# 	kind load docker-image syntasso/knative-serving-pipeline:latest --name platform
+# 	docker pull syntasso/postgres-configure-pipeline:latest
+# 	kind load docker-image syntasso/postgres-configure-pipeline:latest --name platform
+# 	docker pull syntasso/paved-path-demo-configure-pipeline:latest
+# 	kind load docker-image syntasso/paved-path-demo-configure-pipeline:latest --name platform
+#
+#
+# install-minio: ## Install test Minio server
+# 	kubectl --context kind-platform apply -f hack/platform/minio-install.yaml
+#
+# install-gitea: ## Install test gitea server
+# 	kubectl --context kind-platform apply -f hack/platform/gitea-install.yaml
+#
+# install-flux-to-platform:
+# 	kubectl apply -f ./hack/destination/gitops-tk-install.yaml
+# 	kubectl wait --namespace flux-system --for=condition=Available deployment source-controller --timeout=120s
+# 	kubectl wait --namespace flux-system --for=condition=Available deployment kustomize-controller --timeout=120s
+
+
+##@ Deprecated: will be deleted soon
+
+# build-and-reload-kratix is deprecated in favor of build-and-load-kratix
+build-and-reload-kratix: DEPRECATED ## Build and reload Kratix on local KinD cluster
+	make kind-load-image
+	kubectl rollout restart deployment -n kratix-platform-system kratix-platform-controller-manager
+
+.SILENT: DEPRECATED
+DEPRECATED:
+	@echo
+	@echo [WARN] Target has been deprecated. See Makefile for more information.
+	@echo
+	read -p 'Press any key to continue...'
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ docker-build-and-push: ## Push multi-arch docker image with the manager.
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG} .
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG_MIRROR} .
 
-build-and-push-work-creator:
+build-and-push-work-creator: ## Build and push the Work Creator image
 	WC_IMG=${WC_IMG} WC_IMG_MIRROR=${WC_IMG_MIRROR} $(MAKE) -C work-creator docker-build-and-push
 
 # If not installed, use: go install github.com/goreleaser/goreleaser@latest

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -19,7 +19,7 @@ case "$1" in
         ;;
     work-creator)
         # Work Creator image
-        make work-creator-docker-build-and-push
+        make build-and-push-work-creator
         ;;
     samples)
         # Build workshop images

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -251,6 +251,7 @@ wait_for_minio() {
         sleep 1
     done
     kubectl wait pod --context kind-platform -n kratix-platform-system --selector run=minio --for=condition=ready ${opts}
+    kubectl wait job minio-create-bucket --for condition=Complete
 }
 
 wait_for_local_repository() {

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -255,7 +255,7 @@ wait_for_minio() {
     while ! kubectl get job --context kind-platform -n default | grep minio-create-bucket; do
         sleep 1
     done
-    kubectl wait job minio-create-bucket --for condition=Complete
+    kubectl --context kind-platform wait job minio-create-bucket --for condition=Complete
 }
 
 wait_for_local_repository() {

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -251,6 +251,10 @@ wait_for_minio() {
         sleep 1
     done
     kubectl wait pod --context kind-platform -n kratix-platform-system --selector run=minio --for=condition=ready ${opts}
+
+    while ! kubectl get job --context kind-platform -n default | grep minio-create-bucket; do
+        sleep 1
+    done
     kubectl wait job minio-create-bucket --for condition=Complete
 }
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -7,7 +7,7 @@ source "${ROOT}/scripts/utils.sh"
 source "${ROOT}/scripts/install-gitops"
 
 BUILD_KRATIX_IMAGES=false
-RECREATE=false
+RECREATE=${RECREATE:-false}
 SINGLE_DESTINATION=false
 THIRD_DESTINATION=false
 
@@ -136,17 +136,6 @@ verify_prerequisites() {
             log -n "Deleting third destination..."
             run kind delete clusters worker-2
         fi
-    else
-        log -n "Verifying no clusters exist..."
-        if kind get clusters 2>&1 | grep --quiet --regexp "platform\|worker"; then
-            error_mark
-            log ""
-            log "🚨 Please ensure there's no KinD clusters named $(info platform) or $(info worker)."
-            log "You can run this script with $(info --recreate)"
-            log "Or you can manually remove the current clusters by running: "
-            log "\tkind delete clusters platform worker"
-            exit 1
-        fi
     fi
 }
 
@@ -166,6 +155,11 @@ _build_work_creator_image() {
     fi
     docker build --tag $docker_org/kratix-platform-pipeline-adapter:${VERSION} --quiet --file ${ROOT}/Dockerfile.pipeline-adapter ${ROOT} &&
     kind load docker-image $docker_org/kratix-platform-pipeline-adapter:${VERSION} --name platform
+}
+
+cluster_exists() {
+    local cluster_name="$1"
+    kind get clusters | grep -q "$cluster_name"
 }
 
 step_build_and_load_kratix() {
@@ -342,6 +336,10 @@ load_images() {
 }
 
 step_create_platform_cluster() {
+    if cluster_exists platform; then
+        log "Platform cluster already exists, skipping..."
+        return
+    fi
     log "Creating platform destination..."
     if ! run kind create cluster --name platform --image $KIND_IMAGE \
         --config ${ROOT}/hack/platform/kind-platform-config.yaml
@@ -354,6 +352,10 @@ step_create_platform_cluster() {
 
 step_create_worker_cluster(){
     if ! $SINGLE_DESTINATION; then
+        if cluster_exists worker; then
+            log "Worker cluster already exists, skipping..."
+            return
+        fi
         log "Creating worker destination..."
         if ! run kind create cluster --name worker --image $KIND_IMAGE \
             --config ${ROOT}/hack/destination/kind-worker-config.yaml
@@ -368,6 +370,10 @@ step_create_worker_cluster(){
 
 step_create_third_worker_cluster() {
     if $THIRD_DESTINATION; then
+        if cluster_exists worker-2; then
+            log "Worker cluster already exists, skipping..."
+            return
+        fi
         log "Creating worker destination..."
         if ! run kind create cluster --name worker-2 --image $KIND_IMAGE \
             --config ${ROOT}/config/samples/kind-worker-2-config.yaml

--- a/scripts/teardown
+++ b/scripts/teardown
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+shopt -s expand_aliases
+alias kp="kubectl --context kind-platform"
+
+main() {
+    if ! kind get clusters | grep -q "platform"; then
+        echo "No kind-platform cluster found; nothing to teardown."
+        exit 0
+    fi
+
+    resources=(promises destinations gitstatestores bucketstatestores)
+    for resource in "${resources[@]}"; do
+        kp delete "$resource" --all
+    done
+
+    kp -n kratix-platform-system delete deployment kratix-platform-controller-manager || true
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/teardown
+++ b/scripts/teardown
@@ -4,6 +4,7 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 shopt -s expand_aliases
 alias kp="kubectl --context kind-platform"
+alias kw="kubectl --context kind-worker"
 
 main() {
     if ! kind get clusters | grep -q "platform"; then
@@ -16,7 +17,10 @@ main() {
         kp delete "$resource" --all
     done
 
-    kp -n kratix-platform-system delete deployment kratix-platform-controller-manager || true
+    kw delete namespace kratix-worker-system || true
+    kp -n kratix-platform-system delete deployment kratix-platform-controller-manager 2>/dev/null || true
+    kp -n kratix-platform-system delete deployment minio 2>/dev/null || true
+    kp delete -f $root/hack/platform/gitea-install.yaml 2>/dev/null || true
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
oftentimes we don't need to fully recreate the kubernetes environment to run the system tests. this commit adds a few extra targets to make it possible to reuse an existing kind cluster

[#186442211]

This commit updates the Makefile as follows

```diff
Usage:
  make <target>

General
  help             Display this help.

Kubebuilder
  manifests        Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
  generate         Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

Environment
+ teardown         Delete all Kratix resources from the Platform cluster
+ fast-quick-start  Install Kratix without recreating the local clusters
  quick-start      Recreates the clusters and install Kratix
  prepare-platform-as-destination  Installs flux onto platform cluster and registers as a destination
  single-cluster   Deploys Kratix on a single cluster
  dev-env          Quick-start + prepare-platform-as-destination
  install-cert-manager  Install cert-manager on the platform cluster; used in the helm test

Container Images
+ build-and-load-kratix  Build kratix container image and reloads
  kind-load-image  Load locally built image into KinD
  build-and-load-worker-creator  Build worker-creator container image and reloads

Build
  build            Build manager binary.
  run              Run a controller from your host.
  debug-run        Run a controller in debug mode from your host
  docker-build     Build docker image with the manager.
  docker-build-and-push  Push multi-arch docker image with the manager.
  build-worker-resource-builder-binary  Uses the goreleaser config to generate binaries

Deployment
  install          Install CRDs into the K8s cluster specified in ~/.kube/config.
  uninstall        Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
  deploy           Deploy controller to the K8s cluster specified in ~/.kube/config.
  distribution     Create a deployment manifest in /distribution/kratix.yaml
  release          Create a release. Set VERSION env var to "vX.Y.Z-n".
  undeploy         Undeploy controller from the K8s cluster specified in ~/.kube/config.
  controller-gen   Download controller-gen locally if necessary.
  kustomize        Download kustomize locally if necessary.

Tests
  system-test      Recreate the clusters and run system tests
+ fast-system-test  Run the system tests without recreating the clusters
  test             Run unit tests.
  fmt              Run go fmt against code.
  vet              Run go vet against code.
  envtest          Download envtest-setup locally if necessary.

- Removed:
- load-pipeline-images  Load the images for the Postgres and Paved Path promise pipelines # unused
- install-minio  Install test Minio server # unused
- install-gitea   Install test gitea server # unused
- install-flux-to-platform  Install flux on the platform cluster # unused / duplicated

+ Deprecated: will be deleted soon
+   build-and-reload-kratix  Build and reload Kratix on local KinD cluster # same as build-and-load-kratix
```
