### PR TITLE
feat: release to respect promise-defined version

### DIFF
--- a/controllers/assets/redis-simple-promise-updated.yaml
+++ b/controllers/assets/redis-simple-promise-updated.yaml
@@ -3,6 +3,7 @@ kind: Promise
 metadata:
   name: redis
   labels:
+    kratix.io/promise-version: v1.2.0
     clashing-label: "new-promise-v2-value"
     new-promise-v2-label: "value"
   annotations:

--- a/controllers/assets/redis-simple-promise.yaml
+++ b/controllers/assets/redis-simple-promise.yaml
@@ -3,6 +3,7 @@ kind: Promise
 metadata:
   name: redis
   labels:
+    kratix.io/promise-version: v1.1.0
     clashing-label: "new-promise-value"
     new-promise-label: "value"
   annotations:

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -117,7 +117,7 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.deletePromise(opts, promise)
 	}
 
-	if value, found := promise.Labels[promiseReleaseVersionLabel]; found {
+	if value, found := promise.Labels[promiseVersionLabel]; found {
 		if promise.Status.Version != value {
 			promise.Status.Version = value
 			return ctrl.Result{}, r.Client.Status().Update(ctx, promise)

--- a/controllers/promise_controller_test.go
+++ b/controllers/promise_controller_test.go
@@ -52,9 +52,9 @@ var _ = Describe("PromiseController", func() {
 			})
 		})
 
-		When("the promise is created via a PromiseRelease", func() {
+		When("the promise contains a version label", func() {
 			BeforeEach(func() {
-				promise.Labels["kratix.io/promise-release-version"] = "v1.2.3"
+				promise.Labels["kratix.io/promise-version"] = "v1.2.3"
 				Expect(fakeK8sClient.Create(ctx, promise)).To(Succeed())
 
 				result, err := reconcile(&reconciler, promise, &opts{singleReconcile: true})
@@ -62,7 +62,7 @@ var _ = Describe("PromiseController", func() {
 				Expect(result).To(Equal(ctrl.Result{}))
 			})
 
-			It("persists the value labels in the Status", func() {
+			It("it gets its status updated with the version", func() {
 				promise := fetchPromise(promiseName)
 				Expect(promise.Status.Version).To(Equal("v1.2.3"))
 			})

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	kratixPrefix               = "kratix.io/"
-	promiseReleaseVersionLabel = kratixPrefix + "promise-release-version"
-	promiseReleaseNameLabel    = kratixPrefix + "promise-release-name"
+	kratixPrefix            = "kratix.io/"
+	promiseVersionLabel     = kratixPrefix + "promise-version"
+	promiseReleaseNameLabel = kratixPrefix + "promise-release-name"
 )
 
 type StateStore interface {

--- a/test/system/assets/bash-promise/promise-release.yaml
+++ b/test/system/assets/bash-promise/promise-release.yaml
@@ -3,7 +3,7 @@ kind: PromiseRelease
 metadata:
   name: bash
 spec:
-  version: v1.1.0
+  version: v1.0.0
   sourceRef:
     type: http
-    url: https://raw.githubusercontent.com/syntasso/kratix/main/test/system/assets/bash-promise/promise-with-destination-selectors.yaml
+    url: http://LOCALHOST:8081/promise

--- a/test/system/assets/bash-promise/promise-with-destination-selectors-updated.yaml
+++ b/test/system/assets/bash-promise/promise-with-destination-selectors-updated.yaml
@@ -2,6 +2,8 @@ apiVersion: platform.kratix.io/v1alpha1
 kind: Promise
 metadata:
   name: bash
+  labels:
+    kratix.io/promise-version: v1.0.0
 spec:
   api:
     apiVersion: apiextensions.k8s.io/v1

--- a/test/system/assets/bash-promise/promise-with-destination-selectors.yaml
+++ b/test/system/assets/bash-promise/promise-with-destination-selectors.yaml
@@ -2,6 +2,8 @@ apiVersion: platform.kratix.io/v1alpha1
 kind: Promise
 metadata:
   name: bash
+  labels:
+    kratix.io/promise-version: v1.0.0
 spec:
   api:
     apiVersion: apiextensions.k8s.io/v1

--- a/test/system/assets/bash-promise/promise.yaml
+++ b/test/system/assets/bash-promise/promise.yaml
@@ -29,6 +29,8 @@ kind: Promise
 metadata:
   name: bash
   namespace: default
+  labels:
+    kratix.io/promise-version: v1.0.0
 spec:
   api:
     apiVersion: apiextensions.k8s.io/v1

--- a/test/system/system_suite_test.go
+++ b/test/system/system_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -46,7 +47,12 @@ func catAndReplace(tmpDir, file string) string {
 	Expect(err).NotTo(HaveOccurred())
 	//Set via the Makefile
 	ip := os.Getenv("PLATFORM_DESTINATION_IP")
+	hostIP := "host.docker.internal"
+	if runtime.GOOS == "linux" {
+		hostIP = "172.17.0.1"
+	}
 	output := strings.ReplaceAll(string(bytes), "PLACEHOLDER", ip)
+	output = strings.ReplaceAll(output, "LOCALHOST", hostIP)
 	tmpFile := filepath.Join(tmpDir, filepath.Base(file))
 	err = os.WriteFile(tmpFile, []byte(output), 0777)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -460,7 +460,7 @@ var _ = Describe("Kratix", func() {
 		BeforeEach(func() {
 			router := mux.NewRouter()
 			router.HandleFunc("/promise", func(w gohttp.ResponseWriter, _ *gohttp.Request) {
-				bytes, err := os.ReadFile(promisePath)
+				bytes, err := os.ReadFile(promiseWithSchedulingPath)
 				Expect(err).NotTo(HaveOccurred())
 				w.Write(bytes)
 			}).Methods("GET")
@@ -483,7 +483,10 @@ var _ = Describe("Kratix", func() {
 
 		When("a PromiseRelease is installed", func() {
 			BeforeEach(func() {
-				platform.kubectl("apply", "-f", promiseReleasePath)
+				tmpDir, err := os.MkdirTemp(os.TempDir(), "systest")
+				Expect(err).NotTo(HaveOccurred())
+				platform.kubectl("apply", "-f", catAndReplace(tmpDir, promiseReleasePath))
+				os.RemoveAll(tmpDir)
 			})
 
 			It("installs the Promises specified", func() {


### PR DESCRIPTION
the promise version should be defined in the promise yaml itself.

the promise can define its version by setting the following label:
    kratix.io/promise-version: <version>

* if a promise release sets a version, and the version matches the version in the promise release, all is good
* if a promise release doesn't set a version, its version will be set to the version of the promise found on the url
* if the promise release version doesn't match the promise version found on the url, the promise won't be installed.

[#186673378](https://www.pivotaltracker.com/story/show/186673378)