### PR TITLE
chore: migrate Scheduler tests from envtest to fake client

### DIFF
--- a/controllers/destination_controller.go
+++ b/controllers/destination_controller.go
@@ -92,7 +92,9 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return defaultRequeue, nil
 	}
 
-	if err := r.Scheduler.ReconcileDestination(); err != nil {
+	// TODO: Instead of this function call, we could watch for changes to the Destination
+	// CRD and triggering all Works to reconcile on every change.
+	if err := r.Scheduler.ReconcileAllDependencyWorks(); err != nil {
 		logger.Error(err, "unable to schedule destination resources")
 		return defaultRequeue, nil
 	}

--- a/controllers/scheduler_test.go
+++ b/controllers/scheduler_test.go
@@ -49,13 +49,14 @@ var _ = FDescribe("Controllers/Scheduler", func() {
 		Expect(fakeK8sClient.Create(context.Background(), &prodDestination)).To(Succeed())
 	})
 
-	Describe("#ReconcileDestination", func() {
+	Describe("#ReconcileAllDependencyWorks", func() {
 		var devDestination3 Destination
 		BeforeEach(func() {
 			// register new destination dev
 			devDestination3 = newDestination("dev-3", map[string]string{"environment": "dev"})
 			Expect(fakeK8sClient.Create(context.Background(), &devDestination3)).To(Succeed())
-			scheduler.ReconcileDestination()
+
+			scheduler.ReconcileAllDependencyWorks()
 		})
 
 		When("a new destination is added", func() {

--- a/controllers/scheduler_test.go
+++ b/controllers/scheduler_test.go
@@ -2,6 +2,8 @@ package controllers_test
 
 import (
 	"context"
+	"sort"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,270 +19,500 @@ import (
 	. "github.com/syntasso/kratix/controllers"
 )
 
-var rootDirectoryWorkloadGroupID = hash.ComputeHash(".")
-
-var _ = FDescribe("Controllers/Scheduler", func() {
+var _ = Describe("Controllers/Scheduler", func() {
 	var devDestination, devDestination2, pciDestination, prodDestination Destination
-	var dependencyWork, dependencyWorkForDev, dependencyWorkForProd, resourceWork, resourceWorkWithMultipleGroup Work
 	var workPlacements WorkPlacementList
 	var scheduler *Scheduler
 
 	BeforeEach(func() {
+		// create a set of destinations to be used throughout the tests
 		devDestination = newDestination("dev-1", map[string]string{"environment": "dev"})
 		devDestination2 = newDestination("dev-2", map[string]string{"environment": "dev"})
 		pciDestination = newDestination("pci", map[string]string{"pci": "true"})
 		prodDestination = newDestination("prod", map[string]string{"environment": "prod"})
 
-		dependencyWork = newWork("work-name", DependencyReplicas)
-		dependencyWorkForDev = newWork("dev-work-name", DependencyReplicas, schedulingFor(devDestination))
-		dependencyWorkForProd = newWork("prod-work-name", DependencyReplicas, schedulingFor(prodDestination))
-
-		resourceWork = newWork("rr-work-name", ResourceRequestReplicas, schedulingFor(devDestination))
-		resourceWorkWithMultipleGroup = newWorkWithTwoWorkloadGroups("rr-work-name-with-two-groups", ResourceRequestReplicas, schedulingFor(devDestination), map[string]string{"pci": "true"})
+		Expect(fakeK8sClient.Create(context.Background(), &devDestination)).To(Succeed())
+		Expect(fakeK8sClient.Create(context.Background(), &devDestination2)).To(Succeed())
+		Expect(fakeK8sClient.Create(context.Background(), &pciDestination)).To(Succeed())
+		Expect(fakeK8sClient.Create(context.Background(), &prodDestination)).To(Succeed())
 
 		scheduler = &Scheduler{
 			Client: fakeK8sClient,
 			Log:    ctrl.Log.WithName("controllers").WithName("Scheduler"),
 		}
-
-		Expect(fakeK8sClient.Create(context.Background(), &devDestination)).To(Succeed())
-		Expect(fakeK8sClient.Create(context.Background(), &devDestination2)).To(Succeed())
-		Expect(fakeK8sClient.Create(context.Background(), &pciDestination)).To(Succeed())
-		Expect(fakeK8sClient.Create(context.Background(), &prodDestination)).To(Succeed())
 	})
 
 	Describe("#ReconcileAllDependencyWorks", func() {
 		var devDestination3 Destination
-		BeforeEach(func() {
-			// register new destination dev
-			devDestination3 = newDestination("dev-3", map[string]string{"environment": "dev"})
-			Expect(fakeK8sClient.Create(context.Background(), &devDestination3)).To(Succeed())
+		var dependencyWorkForDev Work
 
-			scheduler.ReconcileAllDependencyWorks()
+		BeforeEach(func() {
+			// dependency Work which is scheduled to all Destinations
+			newWork("work-name", DependencyReplicas)
+
+			// dependency Work scheduled only to devDestination
+			dependencyWorkForDev = newWork("dev-work-name", DependencyReplicas, schedulingFor(devDestination))
+
+			// dependency Work scheduled only to prodDestination
+			newWork("prod-work-name", DependencyReplicas, schedulingFor(prodDestination))
+
+			// resource Work scheduled only to devDestination
+			newWork("rr-work-name", ResourceRequestReplicas, schedulingFor(devDestination))
 		})
 
-		When("a new destination is added", func() {
-			It("schedules Works with matching labels to the new destination that match the labels", func() {
-				workplacementList := WorkPlacementList{}
+		When("a new Destination is added which matches a Work's scheduling", func() {
+			BeforeEach(func() {
+				// register new destination which matches both the dependency and resource schedulings
+				devDestination3 = newDestination("dev-3", schedulingFor(devDestination).MatchLabels)
+				Expect(fakeK8sClient.Create(context.Background(), &devDestination3)).To(Succeed())
+
+				scheduler.ReconcileAllDependencyWorks()
+			})
+
+			It("schedules dependency Works with matching labels to the new Destination", func() {
+				// get all the WorkPlacements for the dependency Work
 				lo := &client.ListOptions{}
 				selector, err := labels.Parse(labels.FormatLabels(map[string]string{"kratix.io/work": "dev-work-name"}))
 				Expect(err).NotTo(HaveOccurred())
-
 				lo.LabelSelector = selector
-				Expect(fakeK8sClient.List(context.Background(), &workplacementList, lo)).To(Succeed())
-				Expect(workplacementList.Items).To(HaveLen(3))
-				Expect(workplacementList.Items[0].Name).To(HavePrefix("dev-work-name.dev-1"))
-				Expect(workplacementList.Items[0].Namespace).To(Equal(KratixSystemNamespace))
-				Expect(workplacementList.Items[0].Spec.TargetDestinationName).To(Equal(devDestination.Name))
-				Expect(workplacementList.Items[0].Spec.Workloads).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].Workloads))
-				Expect(workplacementList.Items[0].Spec.ID).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].ID))
+				Expect(fakeK8sClient.List(context.Background(), &workPlacements, lo)).To(Succeed())
 
-				Expect(workplacementList.Items[1].Name).To(HavePrefix("dev-work-name.dev-2"))
-				Expect(workplacementList.Items[1].Namespace).To(Equal(KratixSystemNamespace))
-				Expect(workplacementList.Items[1].Spec.TargetDestinationName).To(Equal(devDestination2.Name))
-				Expect(workplacementList.Items[1].Spec.Workloads).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].Workloads))
-				Expect(workplacementList.Items[1].Spec.ID).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].ID))
+				// check that the dependency work is scheduled to all destinations, including the new one (dev-3)
+				Expect(workPlacements.Items).To(HaveLen(3))
 
-				Expect(workplacementList.Items[2].Name).To(HavePrefix("dev-work-name.dev-3"))
-				Expect(workplacementList.Items[2].Namespace).To(Equal(KratixSystemNamespace))
-				Expect(workplacementList.Items[2].Spec.TargetDestinationName).To(Equal(devDestination3.Name))
-				Expect(workplacementList.Items[2].Spec.Workloads).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].Workloads))
-				Expect(workplacementList.Items[2].Spec.ID).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].ID))
+				Expect(workPlacements.Items[0].Name).To(HavePrefix("dev-work-name.dev-1"))
+				Expect(workPlacements.Items[0].Namespace).To(Equal(KratixSystemNamespace))
+				Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal(devDestination.Name))
+				Expect(workPlacements.Items[0].Spec.Workloads).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].Workloads))
+				Expect(workPlacements.Items[0].Spec.ID).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].ID))
+
+				Expect(workPlacements.Items[1].Name).To(HavePrefix("dev-work-name.dev-2"))
+				Expect(workPlacements.Items[1].Namespace).To(Equal(KratixSystemNamespace))
+				Expect(workPlacements.Items[1].Spec.TargetDestinationName).To(Equal(devDestination2.Name))
+				Expect(workPlacements.Items[1].Spec.Workloads).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].Workloads))
+				Expect(workPlacements.Items[1].Spec.ID).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].ID))
+
+				Expect(workPlacements.Items[2].Name).To(HavePrefix("dev-work-name.dev-3"))
+				Expect(workPlacements.Items[2].Namespace).To(Equal(KratixSystemNamespace))
+				Expect(workPlacements.Items[2].Spec.TargetDestinationName).To(Equal(devDestination3.Name))
+				Expect(workPlacements.Items[2].Spec.Workloads).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].Workloads))
+				Expect(workPlacements.Items[2].Spec.ID).To(Equal(dependencyWorkForDev.Spec.WorkloadGroups[0].ID))
 			})
 		})
 	})
 
 	Describe("#ReconcileWork", func() {
 		Describe("Scheduling Resources (replicas=1)", func() {
-			It("creates a WorkPlacement for a given Work", func() {
-				_, err := scheduler.ReconcileWork(&resourceWork)
-				Expect(err).ToNot(HaveOccurred())
+			var resourceWork, resourceWorkWithMultipleGroups Work
 
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-
-				Expect(workPlacements.Items).To(HaveLen(1))
-				workPlacement := workPlacements.Items[0]
-				Expect(workPlacement.Namespace).To(Equal("default"))
-				Expect(workPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name"))
-				Expect(workPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(rootDirectoryWorkloadGroupID))
-				Expect(workPlacement.Name).To(Equal("rr-work-name." + workPlacement.Spec.TargetDestinationName + "-" + rootDirectoryWorkloadGroupID[0:5]))
-				Expect(workPlacement.Spec.Workloads).To(Equal(resourceWork.Spec.WorkloadGroups[0].Workloads))
-				Expect(workPlacement.Spec.ID).To(Equal(resourceWork.Spec.WorkloadGroups[0].ID))
-				Expect(workPlacement.Spec.TargetDestinationName).To(MatchRegexp("prod|dev\\-\\d"))
-				Expect(workPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
-				Expect(workPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
-				Expect(workPlacement.Spec.PromiseName).To(Equal("promise"))
-				Expect(workPlacement.Spec.ResourceName).To(Equal("resource"))
-
-				Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
-				Expect(resourceWork.Status.Conditions).To(HaveLen(2))
-				Expect(resourceWork.Status.Conditions[0].Type).To(Equal("Scheduled"))
-				Expect(resourceWork.Status.Conditions[0].Status).To(Equal(v1.ConditionTrue))
-				Expect(resourceWork.Status.Conditions[0].Message).To(Equal("All WorkloadGroups scheduled to Destination(s)"))
-				Expect(resourceWork.Status.Conditions[0].Reason).To(Equal("ScheduledToDestinations"))
-
-				Expect(resourceWork.Status.Conditions[1].Type).To(Equal("Misscheduled"))
-				Expect(resourceWork.Status.Conditions[1].Status).To(Equal(v1.ConditionFalse))
-				Expect(resourceWork.Status.Conditions[1].Message).To(Equal("WorkGroups that have been scheduled are at the correct Destination(s)"))
-				Expect(resourceWork.Status.Conditions[1].Reason).To(Equal("ScheduledToCorrectDestinations"))
+			BeforeEach(func() {
+				resourceWork = newWork("rr-work-name", ResourceRequestReplicas, schedulingFor(devDestination))
+				resourceWorkWithMultipleGroups = newWorkWithTwoWorkloadGroups("rr-work-name-with-two-groups", ResourceRequestReplicas, schedulingFor(devDestination), schedulingFor(pciDestination))
 			})
 
-			It("updates workplacements for existing works", func() {
-				_, err := scheduler.ReconcileWork(&resourceWork)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-
-				Expect(workPlacements.Items).To(HaveLen(1))
-				workPlacement := workPlacements.Items[0]
-				Expect(workPlacement.Spec.Workloads).To(HaveLen(1))
-
-				Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
-				resourceWork.Spec.WorkloadGroups[0].Workloads = append(resourceWork.Spec.WorkloadGroups[0].Workloads, Workload{
-					Content: "fake: content",
+			When("a resource Work with scheduling is reconciled", func() {
+				BeforeEach(func() {
+					_, err := scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
 				})
 
-				_, err = scheduler.ReconcileWork(&resourceWork)
-				Expect(err).ToNot(HaveOccurred())
+				It("creates a WorkPlacement for the new Work", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(1))
 
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					workPlacement := workPlacements.Items[0]
+					Expect(workPlacement.Namespace).To(Equal("default"))
+					Expect(workPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name"))
+					Expect(workPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(hash.ComputeHash(".")))
+					Expect(workPlacement.Name).To(Equal("rr-work-name." + workPlacement.Spec.TargetDestinationName + "-" + hash.ComputeHash(".")[0:5]))
+					Expect(workPlacement.Spec.Workloads).To(Equal(resourceWork.Spec.WorkloadGroups[0].Workloads))
+					Expect(workPlacement.Spec.ID).To(Equal(resourceWork.Spec.WorkloadGroups[0].ID))
+					Expect(workPlacement.Spec.TargetDestinationName).To(MatchRegexp("prod|dev\\-\\d"))
+					Expect(workPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
+					Expect(workPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
+					Expect(workPlacement.Spec.PromiseName).To(Equal("promise"))
+					Expect(workPlacement.Spec.ResourceName).To(Equal("resource"))
+				})
 
-				Expect(workPlacements.Items).To(HaveLen(1))
-				workPlacement = workPlacements.Items[0]
-				Expect(workPlacement.Spec.Workloads).To(HaveLen(2))
-				Expect(workPlacement.Spec.Workloads).To(ContainElement(Workload{
-					Content: "fake: content",
-				}))
+				It("sets the scheduling conditions on the Work", func() {
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
+					Expect(resourceWork.Status.Conditions).To(HaveLen(2))
+
+					Expect(resourceWork.Status.Conditions[0].Type).To(Equal("Scheduled"))
+					Expect(resourceWork.Status.Conditions[0].Status).To(Equal(v1.ConditionTrue))
+					Expect(resourceWork.Status.Conditions[0].Message).To(Equal("All WorkloadGroups scheduled to Destination(s)"))
+					Expect(resourceWork.Status.Conditions[0].Reason).To(Equal("ScheduledToDestinations"))
+
+					Expect(resourceWork.Status.Conditions[1].Type).To(Equal("Misscheduled"))
+					Expect(resourceWork.Status.Conditions[1].Status).To(Equal(v1.ConditionFalse))
+					Expect(resourceWork.Status.Conditions[1].Message).To(Equal("WorkGroups that have been scheduled are at the correct Destination(s)"))
+					Expect(resourceWork.Status.Conditions[1].Reason).To(Equal("ScheduledToCorrectDestinations"))
+				})
 			})
 
-			When("an update removes a workload group", func() {
-				It("removes the workplacements for the deleted workloadgroup", func() {
+			When("a resource Work with scheduling is reconciled twice", func() {
+				var workPlacement WorkPlacement
+
+				BeforeEach(func() {
 					_, err := scheduler.ReconcileWork(&resourceWork)
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					latestWork := &Work{}
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), latestWork)).To(Succeed())
 
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
 					Expect(workPlacements.Items).To(HaveLen(1))
+					workPlacement = workPlacements.Items[0]
+
+					_, err = scheduler.ReconcileWork(latestWork)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("does not change the existing WorkPlacement", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(1))
+					newWorkPlacement := workPlacements.Items[0]
+
+					// compare each field in the work placements to ensure they are the same
+					Expect(newWorkPlacement.Name).To(Equal(workPlacement.Name))
+					Expect(newWorkPlacement.Namespace).To(Equal(workPlacement.Namespace))
+					Expect(newWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal(workPlacement.ObjectMeta.Labels["kratix.io/work"]))
+					Expect(newWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(workPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]))
+					Expect(newWorkPlacement.Spec.Workloads).To(Equal(workPlacement.Spec.Workloads))
+					Expect(newWorkPlacement.Spec.ID).To(Equal(workPlacement.Spec.ID))
+					Expect(newWorkPlacement.Spec.TargetDestinationName).To(Equal(workPlacement.Spec.TargetDestinationName))
+					Expect(newWorkPlacement.Finalizers).To(Equal(workPlacement.Finalizers))
+					Expect(newWorkPlacement.Spec.PromiseName).To(Equal(workPlacement.Spec.PromiseName))
+					Expect(newWorkPlacement.Spec.ResourceName).To(Equal(workPlacement.Spec.ResourceName))
+				})
+			})
+
+			When("a resource Work with scheduling is reconciled with an updated WorkloadGroup", func() {
+				BeforeEach(func() {
+					_, err := scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("updates the WorkPlacement", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(1))
+
 					workPlacement := workPlacements.Items[0]
 					Expect(workPlacement.Spec.Workloads).To(HaveLen(1))
 
-					preexistingWorkplacementName := workPlacement.Name
+					previousResourceVersion, err := strconv.Atoi(workPlacement.ResourceVersion)
 
-					resourceWork.Spec.WorkloadGroups[0].Directory = "foo"
-					resourceWork.Spec.WorkloadGroups[0].ID = hash.ComputeHash("foo")
+					// update the Work's WorkloadGroup with an extra Workload
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
 					resourceWork.Spec.WorkloadGroups[0].Workloads = append(resourceWork.Spec.WorkloadGroups[0].Workloads, Workload{
 						Content: "fake: content",
 					})
 
-					//Remove finalizers so it can be deleted
-					workPlacement.Finalizers = nil
-					Expect(fakeK8sClient.Update(context.Background(), &workPlacement)).To(Succeed())
 					_, err = scheduler.ReconcileWork(&resourceWork)
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-
 					Expect(workPlacements.Items).To(HaveLen(1))
+
+					// expect the new Workload to be added to the existing WorkPlacement
 					workPlacement = workPlacements.Items[0]
-					Expect(workPlacement.Name).NotTo(Equal(preexistingWorkplacementName))
 					Expect(workPlacement.Spec.Workloads).To(HaveLen(2))
 					Expect(workPlacement.Spec.Workloads).To(ContainElement(Workload{
 						Content: "fake: content",
 					}))
+
+					newResourceVersion, err := strconv.Atoi(workPlacement.ResourceVersion)
+					Expect(newResourceVersion).To(BeNumerically(">", previousResourceVersion))
+				})
+			})
+
+			When("an update to the resource Work deletes the only WorkloadGroup", func() {
+				BeforeEach(func() {
+					_, err := scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(1))
+
+					// set WorkloadGroups to an empty list and reconcile again
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork)).To(Succeed())
+					resourceWork.Spec.WorkloadGroups = []WorkloadGroup{}
+					_, err = scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("removes the WorkPlacements for the deleted WorkloadGroup", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+
+					// until the finalizer is removed on the WorkPlacement, it will not be deleted
+					Expect(workPlacements.Items).To(HaveLen(1))
+
+					// remove finalizers so the old WorkPlacement can be deleted
+					workPlacement := workPlacements.Items[0]
+					workPlacement.Finalizers = nil
+					Expect(fakeK8sClient.Update(context.Background(), &workPlacement)).To(Succeed())
+
+					// the WorkPlacement should now be deleted
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(0))
+				})
+			})
+
+			When("an update to the resource Work adds a new WorkloadGroup", func() {
+				BeforeEach(func() {
+					_, err := scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(1))
+
+					// append a new WorkloadGroup to the Work and reconcile again
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork)).To(Succeed())
+					resourceWork.Spec.WorkloadGroups = append(resourceWork.Spec.WorkloadGroups, WorkloadGroup{
+						Directory: "foo",
+						ID:        hash.ComputeHash("foo"),
+						Workloads: []Workload{
+							{
+								Content: "fake: content",
+							},
+						},
+						DestinationSelectors: []WorkloadGroupScheduling{schedulingFor(devDestination)},
+					})
+					_, err = scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("creates a WorkPlacement for the new WorkloadGroup", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+
+					// expect the new WorkloadGroup to create a new WorkPlacement
+					Expect(workPlacements.Items).To(HaveLen(2))
+
+					var newWorkPlacement WorkPlacement
+					for _, wp := range workPlacements.Items {
+						if wp.Spec.ID == hash.ComputeHash("foo") {
+							newWorkPlacement = wp
+						}
+					}
+					Expect(newWorkPlacement.Namespace).To(Equal("default"))
+					Expect(newWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name"))
+					Expect(newWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(hash.ComputeHash("foo")))
+					Expect(newWorkPlacement.Name).To(Equal("rr-work-name." + newWorkPlacement.Spec.TargetDestinationName + "-" + hash.ComputeHash("foo")[0:5]))
+					Expect(newWorkPlacement.Spec.Workloads).To(Equal(resourceWork.Spec.WorkloadGroups[1].Workloads))
+					Expect(newWorkPlacement.Spec.ID).To(Equal(resourceWork.Spec.WorkloadGroups[1].ID))
+					Expect(newWorkPlacement.Spec.TargetDestinationName).To(MatchRegexp("prod|dev\\-\\d"))
+					Expect(newWorkPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
+					Expect(newWorkPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
+					Expect(newWorkPlacement.Spec.PromiseName).To(Equal("promise"))
+					Expect(newWorkPlacement.Spec.ResourceName).To(Equal("resource"))
+				})
+			})
+
+			When("an update to the resource Work replaces a WorkloadGroup with a new WorkloadGroup", func() {
+				BeforeEach(func() {
+					_, err := scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(1))
+
+					// replace the WorkloadGroup in the Work and reconcile again
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork)).To(Succeed())
+					resourceWork.Spec.WorkloadGroups = []WorkloadGroup{
+						{
+							Directory: "foo",
+							ID:        hash.ComputeHash("foo"),
+							Workloads: []Workload{
+								{
+									Content: "fake: content",
+								},
+							},
+						},
+					}
+					_, err = scheduler.ReconcileWork(&resourceWork)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("deletes the WorkPlacement for the old WorkloadGroup and creates a WorkPlacement for the new WorkloadGroup", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+
+					// until the finalizer is removed on the replaced WorkPlacement, it will not be deleted
+					Expect(workPlacements.Items).To(HaveLen(2))
+
+					// remove finalizers on the old WorkPlacement so it can be deleted
+					for _, wp := range workPlacements.Items {
+						if wp.Spec.ID == hash.ComputeHash(".") {
+							wp.Finalizers = nil
+							Expect(fakeK8sClient.Update(context.Background(), &wp)).To(Succeed())
+						}
+					}
+
+					// the old WorkPlacement should now be deleted
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(1))
+
+					workPlacement := workPlacements.Items[0]
+					Expect(workPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(hash.ComputeHash("foo")))
+					Expect(workPlacement.Name).To(Equal("rr-work-name." + workPlacement.Spec.TargetDestinationName + "-" + hash.ComputeHash("foo")[0:5]))
+					Expect(workPlacement.Spec.Workloads).To(Equal(resourceWork.Spec.WorkloadGroups[0].Workloads))
+					Expect(workPlacement.Spec.ID).To(Equal(resourceWork.Spec.WorkloadGroups[0].ID))
 				})
 			})
 
 			When("the Work needs to schedule to multiple destinations", func() {
-				It("creates a WorkPlacement per workloadGroup", func() {
-					_, err := scheduler.ReconcileWork(&resourceWorkWithMultipleGroup)
-					Expect(err).ToNot(HaveOccurred())
+				When("the Work is reconciled", func() {
+					BeforeEach(func() {
+						_, err := scheduler.ReconcileWork(&resourceWorkWithMultipleGroups)
+						Expect(err).ToNot(HaveOccurred())
+					})
 
-					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-					Expect(workPlacements.Items).To(HaveLen(2))
-
-					var pciWorkPlacement, devOrProdWorkPlacement WorkPlacement
-					for _, wp := range workPlacements.Items {
-						if wp.Spec.TargetDestinationName == "pci" {
-							pciWorkPlacement = wp
-						} else {
-							devOrProdWorkPlacement = wp
-						}
-					}
-
-					workloadGroupID := rootDirectoryWorkloadGroupID
-					Expect(devOrProdWorkPlacement.Namespace).To(Equal("default"))
-					Expect(devOrProdWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name-with-two-groups"))
-					Expect(devOrProdWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(workloadGroupID))
-					Expect(devOrProdWorkPlacement.Name).To(Equal("rr-work-name-with-two-groups." + devOrProdWorkPlacement.Spec.TargetDestinationName + "-" + workloadGroupID[0:5]))
-					Expect(devOrProdWorkPlacement.Spec.Workloads).To(Equal(resourceWorkWithMultipleGroup.Spec.WorkloadGroups[0].Workloads))
-					Expect(devOrProdWorkPlacement.Spec.TargetDestinationName).To(MatchRegexp("prod|dev\\-\\d"))
-					Expect(devOrProdWorkPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
-					Expect(devOrProdWorkPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
-					Expect(devOrProdWorkPlacement.Spec.PromiseName).To(Equal("promise"))
-					Expect(devOrProdWorkPlacement.Spec.ResourceName).To(Equal("resource"))
-
-					workloadGroupID = hash.ComputeHash("foo")
-					Expect(pciWorkPlacement.Namespace).To(Equal("default"))
-					Expect(pciWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name-with-two-groups"))
-					Expect(pciWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(workloadGroupID))
-					Expect(pciWorkPlacement.Name).To(Equal("rr-work-name-with-two-groups." + pciWorkPlacement.Spec.TargetDestinationName + "-" + workloadGroupID[0:5]))
-					Expect(pciWorkPlacement.Spec.TargetDestinationName).To(Equal("pci"))
-					Expect(pciWorkPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
-					Expect(pciWorkPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
-					Expect(pciWorkPlacement.Spec.Workloads).To(Equal(resourceWorkWithMultipleGroup.Spec.WorkloadGroups[1].Workloads))
-					Expect(pciWorkPlacement.Spec.PromiseName).To(Equal("promise"))
-					Expect(pciWorkPlacement.Spec.ResourceName).To(Equal("resource"))
-				})
-
-				When("one of the workloadgroups is unschedulable", func() {
-					It("still schedules the remaining workload groups, and returns an error indicating what was unschedulable", func() {
-						resourceWorkWithMultipleGroup.Spec.WorkloadGroups[0].DestinationSelectors[0].MatchLabels = map[string]string{"not": "scheduable"}
-						unschedulable, err := scheduler.ReconcileWork(&resourceWorkWithMultipleGroup)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(unschedulable).To(ConsistOf(hash.ComputeHash(".")))
-
+					It("creates a WorkPlacement per WorkloadGroup", func() {
 						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-						Expect(workPlacements.Items).To(HaveLen(1))
+						Expect(workPlacements.Items).To(HaveLen(2))
 
-						pciWorkPlacement := workPlacements.Items[0]
-						workloadGroupID := hash.ComputeHash("foo")
+						var pciWorkPlacement, devOrProdWorkPlacement WorkPlacement
+						for _, wp := range workPlacements.Items {
+							if wp.Spec.TargetDestinationName == "pci" {
+								pciWorkPlacement = wp
+							} else {
+								devOrProdWorkPlacement = wp
+							}
+						}
+
+						Expect(devOrProdWorkPlacement.Namespace).To(Equal("default"))
+						Expect(devOrProdWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name-with-two-groups"))
+						Expect(devOrProdWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(hash.ComputeHash(".")))
+						Expect(devOrProdWorkPlacement.Name).To(Equal("rr-work-name-with-two-groups." + devOrProdWorkPlacement.Spec.TargetDestinationName + "-" + hash.ComputeHash(".")[0:5]))
+						Expect(devOrProdWorkPlacement.Spec.Workloads).To(Equal(resourceWorkWithMultipleGroups.Spec.WorkloadGroups[0].Workloads))
+						Expect(devOrProdWorkPlacement.Spec.TargetDestinationName).To(MatchRegexp("prod|dev\\-\\d"))
+						Expect(devOrProdWorkPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
+						Expect(devOrProdWorkPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
+						Expect(devOrProdWorkPlacement.Spec.PromiseName).To(Equal("promise"))
+						Expect(devOrProdWorkPlacement.Spec.ResourceName).To(Equal("resource"))
+
 						Expect(pciWorkPlacement.Namespace).To(Equal("default"))
 						Expect(pciWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name-with-two-groups"))
-						Expect(pciWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(workloadGroupID))
-						Expect(pciWorkPlacement.Name).To(Equal("rr-work-name-with-two-groups." + pciWorkPlacement.Spec.TargetDestinationName + "-" + workloadGroupID[0:5]))
+						Expect(pciWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(hash.ComputeHash("foo")))
+						Expect(pciWorkPlacement.Name).To(Equal("rr-work-name-with-two-groups." + pciWorkPlacement.Spec.TargetDestinationName + "-" + hash.ComputeHash("foo")[0:5]))
+						Expect(pciWorkPlacement.Spec.Workloads).To(Equal(resourceWorkWithMultipleGroups.Spec.WorkloadGroups[1].Workloads))
 						Expect(pciWorkPlacement.Spec.TargetDestinationName).To(Equal("pci"))
 						Expect(pciWorkPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
 						Expect(pciWorkPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
-						Expect(pciWorkPlacement.Spec.Workloads).To(Equal(resourceWorkWithMultipleGroup.Spec.WorkloadGroups[1].Workloads))
 						Expect(pciWorkPlacement.Spec.PromiseName).To(Equal("promise"))
 						Expect(pciWorkPlacement.Spec.ResourceName).To(Equal("resource"))
 					})
 				})
+
+				When("an update to the resource Work deletes one of the WorkloadGroups", func() {
+					var pciWorkPlacement WorkPlacement
+
+					BeforeEach(func() {
+						_, err := scheduler.ReconcileWork(&resourceWorkWithMultipleGroups)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(2))
+
+						for _, wp := range workPlacements.Items {
+							if wp.Spec.TargetDestinationName == "pci" {
+								pciWorkPlacement = wp
+							}
+						}
+
+						// remove the pci WorkloadGroup from the Work and reconcile again
+						pciWorkloadGroupID := hash.ComputeHash("foo")
+						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWorkWithMultipleGroups), &resourceWorkWithMultipleGroups)).To(Succeed())
+						for i, wg := range resourceWorkWithMultipleGroups.Spec.WorkloadGroups {
+							if wg.ID == pciWorkloadGroupID {
+								resourceWorkWithMultipleGroups.Spec.WorkloadGroups = append(resourceWorkWithMultipleGroups.Spec.WorkloadGroups[:i], resourceWorkWithMultipleGroups.Spec.WorkloadGroups[i+1:]...)
+							}
+						}
+
+						_, err = scheduler.ReconcileWork(&resourceWorkWithMultipleGroups)
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("removes the WorkPlacements for the deleted WorkloadGroup", func() {
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+
+						// until the finalizer is removed on the WorkPlacement, it will not be deleted
+						Expect(workPlacements.Items).To(HaveLen(2))
+
+						// remove finalizers so the old WorkPlacement can be deleted
+						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&pciWorkPlacement), &pciWorkPlacement)).To(Succeed())
+						pciWorkPlacement.Finalizers = nil
+						Expect(fakeK8sClient.Update(context.Background(), &pciWorkPlacement)).To(Succeed())
+
+						// the pci WorkPlacement should now be deleted
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(1))
+						Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(MatchRegexp("prod|dev\\-\\d"))
+					})
+				})
+
+				When("one of the WorkloadGroups is unschedulable", func() {
+					var unschedulable []string
+
+					BeforeEach(func() {
+						var err error
+
+						// set the dev/prod WorkloadGroup to be unschedulable (i.e. no matching Destinations)
+						resourceWorkWithMultipleGroups.Spec.WorkloadGroups[0].DestinationSelectors[0].MatchLabels = map[string]string{"not": "schedulable"}
+
+						unschedulable, err = scheduler.ReconcileWork(&resourceWorkWithMultipleGroups)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("still schedules the remaining workload groups", func() {
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(1))
+
+						pciWorkPlacement := workPlacements.Items[0]
+						Expect(pciWorkPlacement.Namespace).To(Equal("default"))
+						Expect(pciWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal("rr-work-name-with-two-groups"))
+						Expect(pciWorkPlacement.ObjectMeta.Labels["kratix.io/workload-group-id"]).To(Equal(hash.ComputeHash("foo")))
+						Expect(pciWorkPlacement.Name).To(Equal("rr-work-name-with-two-groups." + pciWorkPlacement.Spec.TargetDestinationName + "-" + hash.ComputeHash("foo")[0:5]))
+						Expect(pciWorkPlacement.Spec.TargetDestinationName).To(Equal("pci"))
+						Expect(pciWorkPlacement.Finalizers).To(HaveLen(1), "expected one finalizer")
+						Expect(pciWorkPlacement.Finalizers[0]).To(Equal("finalizers.workplacement.kratix.io/repo-cleanup"))
+						Expect(pciWorkPlacement.Spec.Workloads).To(Equal(resourceWorkWithMultipleGroups.Spec.WorkloadGroups[1].Workloads))
+						Expect(pciWorkPlacement.Spec.PromiseName).To(Equal("promise"))
+						Expect(pciWorkPlacement.Spec.ResourceName).To(Equal("resource"))
+					})
+
+					It("returns an error indicating what was unschedulable", func() {
+						Expect(unschedulable).To(ConsistOf(hash.ComputeHash(".")))
+					})
+				})
 			})
 
-			When("the scheduling changes such that the WorkPlacement is not on a correct destination", func() {
+			When("the scheduling changes such that the WorkPlacement is not on a correct Destination", func() {
 				var preUpdateDestination string
+
 				BeforeEach(func() {
 					_, err := scheduler.ReconcileWork(&resourceWork)
 					Expect(err).ToNot(HaveOccurred())
+
 					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
 					Expect(workPlacements.Items).To(HaveLen(1))
-					preUpdateDestination = workPlacements.Items[0].Spec.TargetDestinationName
-				})
 
-				It("does not reschedule the WorkPlacement but does label the resource to indicate it's misscheduled", func() {
+					preUpdateDestination = workPlacements.Items[0].Spec.TargetDestinationName
+
+					// change the scheduling on the resource work from devDestination to prodDestination
 					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
 					resourceWork.Spec.WorkloadGroups[0].DestinationSelectors[0] = schedulingFor(prodDestination)
-					_, err := scheduler.ReconcileWork(&resourceWork)
+					_, err = scheduler.ReconcileWork(&resourceWork)
 					Expect(err).ToNot(HaveOccurred())
+				})
 
+				It("does not reschedule the WorkPlacement", func() {
 					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
 					Expect(workPlacements.Items).To(HaveLen(1))
+
 					workPlacement := workPlacements.Items[0]
 					Expect(workPlacement.Spec.TargetDestinationName).To(Equal(preUpdateDestination))
 					Expect(workPlacement.GetLabels()).To(HaveKeyWithValue("kratix.io/misscheduled", "true"))
-					Expect(workPlacement.GetLabels()).To(HaveKeyWithValue("kratix.io/workload-group-id", rootDirectoryWorkloadGroupID))
+					Expect(workPlacement.GetLabels()).To(HaveKeyWithValue("kratix.io/workload-group-id", hash.ComputeHash(".")))
 					Expect(workPlacement.Status.Conditions).To(HaveLen(1))
 					//ignore time for assertion
 					workPlacement.Status.Conditions[0].LastTransitionTime = v1.Time{}
@@ -290,7 +522,9 @@ var _ = FDescribe("Controllers/Scheduler", func() {
 						Type:    "Misscheduled",
 						Status:  v1.ConditionTrue,
 					}))
+				})
 
+				It("labels the resource Work to indicate it's misscheduled", func() {
 					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
 					Expect(resourceWork.Status.Conditions).To(HaveLen(2))
 
@@ -304,8 +538,8 @@ var _ = FDescribe("Controllers/Scheduler", func() {
 				})
 			})
 
-			When("scheduling is defined in the promise and workflows", func() {
-				It("prioritises promise scheduling", func() {
+			When("scheduling is defined in the Promise, Promise Workflow and Resource Workflow", func() {
+				BeforeEach(func() {
 					resourceWork.Spec.WorkloadGroups[0].DestinationSelectors = []WorkloadGroupScheduling{
 						{
 							MatchLabels: map[string]string{
@@ -328,211 +562,311 @@ var _ = FDescribe("Controllers/Scheduler", func() {
 					}
 					_, err := scheduler.ReconcileWork(&resourceWork)
 					Expect(err).ToNot(HaveOccurred())
+				})
 
+				It("prioritises Promise scheduling", func() {
 					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-
 					Expect(workPlacements.Items).To(HaveLen(1))
+
 					workPlacement := workPlacements.Items[0]
 					Expect(workPlacement.Spec.TargetDestinationName).To(Equal("prod"))
 				})
 			})
 		})
-	})
 
-	Describe("Scheduling Dependencies (replicas=-1)", func() {
-		When("the Work has no selector", func() {
-			It("creates and updates Workplacements for all registered Destinations", func() {
-				_, err := scheduler.ReconcileWork(&dependencyWork)
-				Expect(err).ToNot(HaveOccurred())
+		Describe("Scheduling Dependencies (replicas=-1)", func() {
+			var dependencyWork, dependencyWorkForDev, dependencyWorkForProd Work
 
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-				Expect(len(workPlacements.Items)).To(Equal(4))
-				for _, workPlacement := range workPlacements.Items {
-					Expect(workPlacement.Spec.Workloads).To(ConsistOf(Workload{
-						Content: "key: value",
-					}))
-				}
-
-				Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
-				dependencyWork.Spec.WorkloadGroups[0].Workloads = append(dependencyWork.Spec.WorkloadGroups[0].Workloads, Workload{
-					Content: "fake: new-content",
-				})
-
-				_, err = scheduler.ReconcileWork(&dependencyWork)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-
-				Expect(workPlacements.Items).To(HaveLen(4))
-				for _, workPlacement := range workPlacements.Items {
-					Expect(workPlacement.Spec.Workloads).To(ConsistOf(
-						Workload{Content: "key: value"},
-						Workload{Content: "fake: new-content"},
-					))
-				}
-			})
-		})
-
-		When("the Work is updated to no longer match a previous destination", func() {
-			It("marks the old WorkPlacement as misscheduled but keeps it updated", func() {
-				_, err := scheduler.ReconcileWork(&dependencyWork)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-				Expect(len(workPlacements.Items)).To(Equal(4))
-				for _, workPlacement := range workPlacements.Items {
-					Expect(workPlacement.Spec.Workloads).To(ConsistOf(Workload{
-						Content: "key: value",
-					}))
-				}
-
-				Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
-				dependencyWork.Spec.WorkloadGroups[0].DestinationSelectors = []v1alpha1.WorkloadGroupScheduling{
-					{
-						MatchLabels: map[string]string{"environment": "dev"},
-					},
-				}
-
-				dependencyWork.Spec.WorkloadGroups[0].Workloads = append(dependencyWork.Spec.WorkloadGroups[0].Workloads, Workload{
-					Content: "fake: new-content",
-				})
-
-				_, err = scheduler.ReconcileWork(&dependencyWork)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-
-				Expect(workPlacements.Items).To(HaveLen(4))
-				Expect(workPlacements.Items[0].GetLabels()).NotTo(HaveKey("kratix.io/misscheduled"))
-				Expect(workPlacements.Items[1].GetLabels()).NotTo(HaveKey("kratix.io/misscheduled"))
-				Expect(workPlacements.Items[2].GetLabels()).To(HaveKeyWithValue("kratix.io/misscheduled", "true"))
-				Expect(workPlacements.Items[2].Status.Conditions).To(HaveLen(1))
-				//ignore time for assertion
-				workPlacements.Items[2].Status.Conditions[0].LastTransitionTime = v1.Time{}
-				Expect(workPlacements.Items[2].Status.Conditions).To(ConsistOf(v1.Condition{
-					Message: "Target destination no longer matches destinationSelectors",
-					Reason:  "DestinationSelectorMismatch",
-					Type:    "Misscheduled",
-					Status:  v1.ConditionTrue,
-				}))
-
-				Expect(workPlacements.Items[3].GetLabels()).To(HaveKeyWithValue("kratix.io/misscheduled", "true"))
-				Expect(workPlacements.Items[3].Status.Conditions).To(HaveLen(1))
-				//ignore time for assertion
-				workPlacements.Items[3].Status.Conditions[0].LastTransitionTime = v1.Time{}
-				Expect(workPlacements.Items[3].Status.Conditions).To(ConsistOf(v1.Condition{
-					Message: "Target destination no longer matches destinationSelectors",
-					Reason:  "DestinationSelectorMismatch",
-					Type:    "Misscheduled",
-					Status:  v1.ConditionTrue,
-				}))
-
-				for _, workPlacement := range workPlacements.Items {
-					Expect(workPlacement.Spec.Workloads).To(ConsistOf(
-						Workload{Content: "key: value"},
-						Workload{Content: "fake: new-content"},
-					))
-				}
-			})
-		})
-
-		When("the Work matches a single Destination", func() {
-			It("creates a single WorkPlacement", func() {
-				_, err := scheduler.ReconcileWork(&dependencyWorkForProd)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-				Expect(workPlacements.Items).To(HaveLen(1))
-				Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal(prodDestination.Name))
-				Expect(workPlacements.Items[0].ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForProd.Name))
-			})
-		})
-
-		When("the Work matches multiple Destinations", func() {
-			It("creates WorkPlacements for the Destinations with the label", func() {
-				_, err := scheduler.ReconcileWork(&dependencyWorkForDev)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-				Expect(workPlacements.Items).To(HaveLen(2))
-
-				devWorkPlacement := workPlacements.Items[0]
-				Expect(devWorkPlacement.Spec.TargetDestinationName).To(Equal(devDestination.Name))
-				Expect(devWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
-
-				devWorkPlacement2 := workPlacements.Items[1]
-				Expect(devWorkPlacement2.Spec.TargetDestinationName).To(Equal(devDestination2.Name))
-				Expect(devWorkPlacement2.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
-			})
-
-			When("a WorkPlacement is deleted", func() {
-				It("gets recreated on next reconciliation", func() {
-					//1st reconciliation
-					_, err := scheduler.ReconcileWork(&dependencyWorkForDev)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-					Expect(workPlacements.Items).To(HaveLen(2))
-
-					devWorkPlacement := workPlacements.Items[0]
-					Expect(devWorkPlacement.Spec.TargetDestinationName).To(Equal(devDestination.Name))
-					Expect(devWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
-
-					devWorkPlacement2 := workPlacements.Items[1]
-					Expect(devWorkPlacement2.Spec.TargetDestinationName).To(Equal(devDestination2.Name))
-					Expect(devWorkPlacement2.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
-
-					//Remove finalizer
-					devWorkPlacement.Finalizers = nil
-					Expect(fakeK8sClient.Update(context.Background(), &devWorkPlacement)).To(Succeed())
-					//manually delete workPlacement
-					Expect(fakeK8sClient.Delete(context.Background(), &devWorkPlacement)).To(Succeed())
-
-					//re-reconcile
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWorkForDev), &dependencyWorkForDev))
-					_, err = scheduler.ReconcileWork(&dependencyWorkForDev)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-					Expect(workPlacements.Items).To(HaveLen(2))
-
-					devWorkPlacement = workPlacements.Items[0]
-					Expect(devWorkPlacement.Spec.TargetDestinationName).To(Equal(devDestination.Name))
-					Expect(devWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
-
-					devWorkPlacement2 = workPlacements.Items[1]
-					Expect(devWorkPlacement2.Spec.TargetDestinationName).To(Equal(devDestination2.Name))
-					Expect(devWorkPlacement2.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
-				})
-			})
-		})
-
-		When("the Work selector matches no Destinations", func() {
 			BeforeEach(func() {
-				dependencyWork.Spec.WorkloadGroups[0].DestinationSelectors = []v1alpha1.WorkloadGroupScheduling{
-					{
-						MatchLabels: map[string]string{"environment": "staging"},
-					},
-				}
+				dependencyWork = newWork("work-name", DependencyReplicas)
+				dependencyWorkForDev = newWork("dev-work-name", DependencyReplicas, schedulingFor(devDestination))
+				dependencyWorkForProd = newWork("prod-work-name", DependencyReplicas, schedulingFor(prodDestination))
 			})
 
-			It("creates no workplacements", func() {
-				unschedulable, err := scheduler.ReconcileWork(&dependencyWork)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(unschedulable).To(ConsistOf(hash.ComputeHash(".")))
+			When("the Work matches a single Destination", func() {
+				When("the Work is reconciled", func() {
+					BeforeEach(func() {
+						_, err := scheduler.ReconcileWork(&dependencyWorkForProd)
+						Expect(err).ToNot(HaveOccurred())
+					})
 
-				Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-				Expect(workPlacements.Items).To(BeEmpty())
+					It("creates a single WorkPlacement", func() {
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(1))
+						Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal(prodDestination.Name))
+						Expect(workPlacements.Items[0].ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForProd.Name))
+					})
+				})
 
-				Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
-				Expect(dependencyWork.Status.Conditions).To(HaveLen(2))
-				Expect(dependencyWork.Status.Conditions[0].Type).To(Equal("Scheduled"))
-				Expect(dependencyWork.Status.Conditions[0].Status).To(Equal(v1.ConditionFalse))
-				Expect(dependencyWork.Status.Conditions[0].Message).To(Equal("No Destinations available work WorkloadGroups: [" + dependencyWork.Spec.WorkloadGroups[0].ID + "]"))
-				Expect(dependencyWork.Status.Conditions[0].Reason).To(Equal("UnscheduledWorkloadGroups"))
+				When("the WorkPlacement is deleted", func() {
+					BeforeEach(func() {
+						_, err := scheduler.ReconcileWork(&dependencyWorkForProd)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(1))
 
-				Expect(dependencyWork.Status.Conditions[1].Type).To(Equal("Misscheduled"))
-				Expect(dependencyWork.Status.Conditions[1].Status).To(Equal(v1.ConditionFalse))
+						// remove finalizer so the WorkPlacement can be deleted
+						workPlacement := workPlacements.Items[0]
+						workPlacement.Finalizers = nil
+						Expect(fakeK8sClient.Update(context.Background(), &workPlacement)).To(Succeed())
+
+						// manually delete the WorkPlacement
+						Expect(fakeK8sClient.Delete(context.Background(), &workPlacement)).To(Succeed())
+
+						// check that the WorkPlacement has been deleted
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(0))
+					})
+
+					It("gets recreated on next reconciliation", func() {
+						// re-reconcile the Work
+						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWorkForProd), &dependencyWorkForProd))
+						_, err := scheduler.ReconcileWork(&dependencyWorkForProd)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(1))
+						Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal(prodDestination.Name))
+						Expect(workPlacements.Items[0].ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForProd.Name))
+					})
+				})
+			})
+
+			When("the Work matches multiple Destinations", func() {
+				When("the Work is reconciled", func() {
+					BeforeEach(func() {
+						_, err := scheduler.ReconcileWork(&dependencyWorkForDev)
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("creates WorkPlacements for the Destinations with the label", func() {
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(2))
+
+						devWorkPlacement := workPlacements.Items[0]
+						Expect(devWorkPlacement.Spec.TargetDestinationName).To(Equal(devDestination.Name))
+						Expect(devWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
+
+						devWorkPlacement2 := workPlacements.Items[1]
+						Expect(devWorkPlacement2.Spec.TargetDestinationName).To(Equal(devDestination2.Name))
+						Expect(devWorkPlacement2.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
+					})
+				})
+
+				When("a WorkPlacement is deleted", func() {
+					BeforeEach(func() {
+						_, err := scheduler.ReconcileWork(&dependencyWorkForDev)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(2))
+
+						Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal(devDestination.Name))
+						devWorkPlacement := workPlacements.Items[0]
+
+						Expect(workPlacements.Items[1].Spec.TargetDestinationName).To(Equal(devDestination2.Name))
+
+						// remove finalizers on the devDestination WorkPlacement so it can be deleted
+						devWorkPlacement.Finalizers = nil
+						Expect(fakeK8sClient.Update(context.Background(), &devWorkPlacement)).To(Succeed())
+
+						// manually delete the WorkPlacement
+						Expect(fakeK8sClient.Delete(context.Background(), &devWorkPlacement)).To(Succeed())
+
+						// check that the devDestination WorkPlacement has been deleted
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(1))
+						Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal(devDestination2.Name))
+					})
+
+					It("gets recreated on next reconciliation", func() {
+						// re-reconcile the Work
+						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWorkForDev), &dependencyWorkForDev))
+						_, err := scheduler.ReconcileWork(&dependencyWorkForDev)
+						Expect(err).ToNot(HaveOccurred())
+
+						// check the devDestination WorkPlacement has been recreated
+						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+						Expect(workPlacements.Items).To(HaveLen(2))
+
+						Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal(devDestination.Name))
+						devWorkPlacement := workPlacements.Items[0]
+
+						Expect(workPlacements.Items[1].Spec.TargetDestinationName).To(Equal(devDestination2.Name))
+						devWorkPlacement2 := workPlacements.Items[1]
+
+						Expect(devWorkPlacement.Spec.TargetDestinationName).To(Equal(devDestination.Name))
+						Expect(devWorkPlacement.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
+
+						// check that the devDestination2 WorkPlacement is still there
+						Expect(devWorkPlacement2.Spec.TargetDestinationName).To(Equal(devDestination2.Name))
+						Expect(devWorkPlacement2.ObjectMeta.Labels["kratix.io/work"]).To(Equal(dependencyWorkForDev.Name))
+						// TODO it would be nice if we could check this is exactly the same
+						// object as the original WorkPlacement for devWorkPlacement2:
+						// https://github.com/syntasso/kratix/pull/59#discussion_r1435163108
+					})
+				})
+			})
+
+			When("the Work selector matches no Destinations", func() {
+				var unschedulable []string
+
+				BeforeEach(func() {
+					dependencyWork.Spec.WorkloadGroups[0].DestinationSelectors = []v1alpha1.WorkloadGroupScheduling{
+						{
+							MatchLabels: map[string]string{"environment": "non-matching"},
+						},
+					}
+
+					var err error
+					unschedulable, err = scheduler.ReconcileWork(&dependencyWork)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+				})
+
+				It("creates no workplacements", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(BeEmpty())
+				})
+
+				It("marks the Work as unscheduled", func() {
+					Expect(dependencyWork.Status.Conditions).To(HaveLen(2))
+					Expect(dependencyWork.Status.Conditions[0].Type).To(Equal("Scheduled"))
+					Expect(dependencyWork.Status.Conditions[0].Status).To(Equal(v1.ConditionFalse))
+					Expect(dependencyWork.Status.Conditions[0].Message).To(Equal("No Destinations available work WorkloadGroups: [" + dependencyWork.Spec.WorkloadGroups[0].ID + "]"))
+					Expect(dependencyWork.Status.Conditions[0].Reason).To(Equal("UnscheduledWorkloadGroups"))
+				})
+
+				It("does not mark the Work as misscheduled", func() {
+					Expect(dependencyWork.Status.Conditions[1].Type).To(Equal("Misscheduled"))
+					Expect(dependencyWork.Status.Conditions[1].Status).To(Equal(v1.ConditionFalse))
+				})
+
+				It("returns an error indicating what was unschedulable", func() {
+					Expect(unschedulable).To(ConsistOf(hash.ComputeHash(".")))
+				})
+			})
+
+			When("the Work has no selector", func() {
+				BeforeEach(func() {
+					_, err := scheduler.ReconcileWork(&dependencyWork)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("creates WorkPlacements for all registered Destinations", func() {
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(len(workPlacements.Items)).To(Equal(4))
+					for _, workPlacement := range workPlacements.Items {
+						Expect(workPlacement.Spec.Workloads).To(ConsistOf(Workload{
+							Content: "key: value",
+						}))
+					}
+				})
+
+				It("updates WorkPlacements for all registered Destinations", func() {
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+					dependencyWork.Spec.WorkloadGroups[0].Workloads = append(dependencyWork.Spec.WorkloadGroups[0].Workloads, Workload{
+						Content: "fake: new-content",
+					})
+
+					_, err := scheduler.ReconcileWork(&dependencyWork)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(4))
+					for _, workPlacement := range workPlacements.Items {
+						Expect(workPlacement.Spec.Workloads).To(ConsistOf(
+							Workload{Content: "key: value"},
+							Workload{Content: "fake: new-content"},
+						))
+					}
+				})
+			})
+
+			When("the Work is updated to no longer match a previous Destination", func() {
+				BeforeEach(func() {
+					_, err := scheduler.ReconcileWork(&dependencyWork)
+					Expect(err).ToNot(HaveOccurred())
+
+					// add scheduling for the devDestination, so that the WorkPlacements
+					// for prod and pci are now misscheduled
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+					dependencyWork.Spec.WorkloadGroups[0].DestinationSelectors = []v1alpha1.WorkloadGroupScheduling{
+						schedulingFor(devDestination),
+					}
+
+					_, err = scheduler.ReconcileWork(&dependencyWork)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(4))
+
+					// ensure the WorkPlacements are sorted by name, so the tests aren't
+					// flaky by varying the order they are returned from the API!
+					sort.Slice(workPlacements.Items, func(i, j int) bool {
+						return workPlacements.Items[i].Spec.TargetDestinationName < workPlacements.Items[j].Spec.TargetDestinationName
+					})
+				})
+
+				It("marks existing WorkPlacements which no longer match as misscheduled", func() {
+					// the two dev WorkPlacements should not be marked as misscheduled
+					Expect(workPlacements.Items[0].Spec.TargetDestinationName).To(Equal("dev-1"))
+					Expect(workPlacements.Items[0].GetLabels()).NotTo(HaveKey("kratix.io/misscheduled"))
+
+					Expect(workPlacements.Items[1].Spec.TargetDestinationName).To(Equal("dev-2"))
+					Expect(workPlacements.Items[1].GetLabels()).NotTo(HaveKey("kratix.io/misscheduled"))
+
+					// the pci and prod WorkPlacements should be marked as misscheduled
+
+					Expect(workPlacements.Items[2].Spec.TargetDestinationName).To(Equal("pci"))
+					Expect(workPlacements.Items[2].GetLabels()).To(HaveKeyWithValue("kratix.io/misscheduled", "true"))
+					Expect(workPlacements.Items[2].Status.Conditions).To(HaveLen(1))
+					//ignore time for assertion
+					workPlacements.Items[2].Status.Conditions[0].LastTransitionTime = v1.Time{}
+					Expect(workPlacements.Items[2].Status.Conditions).To(ConsistOf(v1.Condition{
+						Message: "Target destination no longer matches destinationSelectors",
+						Reason:  "DestinationSelectorMismatch",
+						Type:    "Misscheduled",
+						Status:  v1.ConditionTrue,
+					}))
+
+					Expect(workPlacements.Items[3].Spec.TargetDestinationName).To(Equal("prod"))
+					Expect(workPlacements.Items[3].GetLabels()).To(HaveKeyWithValue("kratix.io/misscheduled", "true"))
+					Expect(workPlacements.Items[3].Status.Conditions).To(HaveLen(1))
+					//ignore time for assertion
+					workPlacements.Items[3].Status.Conditions[0].LastTransitionTime = v1.Time{}
+					Expect(workPlacements.Items[3].Status.Conditions).To(ConsistOf(v1.Condition{
+						Message: "Target destination no longer matches destinationSelectors",
+						Reason:  "DestinationSelectorMismatch",
+						Type:    "Misscheduled",
+						Status:  v1.ConditionTrue,
+					}))
+				})
+
+				It("keeps the misscheduled WorkPlacements updated", func() {
+					// update the Work's WorkloadGroup with an extra Workload
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+					dependencyWork.Spec.WorkloadGroups[0].Workloads = append(dependencyWork.Spec.WorkloadGroups[0].Workloads, Workload{
+						Content: "fake: new-content",
+					})
+
+					_, err := scheduler.ReconcileWork(&dependencyWork)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
+					Expect(workPlacements.Items).To(HaveLen(4))
+
+					// check that all WorkPlacements have been updated, including the two
+					// misscheduled ones
+					for _, workPlacement := range workPlacements.Items {
+						Expect(workPlacement.Spec.Workloads).To(ConsistOf(
+							Workload{Content: "key: value"},
+							Workload{Content: "fake: new-content"},
+						))
+					}
+				})
 			})
 		})
 	})
@@ -547,9 +881,9 @@ func newDestination(name string, labels map[string]string) Destination {
 	}
 }
 
-func newWork(name string, workType int, scheduling ...WorkloadGroupScheduling) Work {
+func newWork(name string, replicas int, scheduling ...WorkloadGroupScheduling) Work {
 	namespace := "default"
-	if workType == DependencyReplicas {
+	if replicas == DependencyReplicas {
 		namespace = KratixSystemNamespace
 	}
 	work := &Work{
@@ -559,7 +893,7 @@ func newWork(name string, workType int, scheduling ...WorkloadGroupScheduling) W
 			UID:       types.UID(name),
 		},
 		Spec: WorkSpec{
-			Replicas: workType,
+			Replicas: replicas,
 			WorkloadCoreFields: WorkloadCoreFields{
 				PromiseName:  "promise",
 				ResourceName: "resource",
@@ -579,16 +913,16 @@ func newWork(name string, workType int, scheduling ...WorkloadGroupScheduling) W
 
 	Expect(fakeK8sClient.Create(context.Background(), work)).To(Succeed())
 
-	//sets object UID etc
+	//sets the APIVersion, Kind, and ResourceVersion
 	workWithDefaultFields := &Work{}
 	Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(work), workWithDefaultFields)).To(Succeed())
 
 	return *workWithDefaultFields
 }
 
-func newWorkWithTwoWorkloadGroups(name string, workType int, promiseScheduling WorkloadGroupScheduling, directoryOverrideScheduling map[string]string) Work {
+func newWorkWithTwoWorkloadGroups(name string, replicas int, promiseScheduling, directoryOverrideScheduling WorkloadGroupScheduling) Work {
 	namespace := "default"
-	if workType == DependencyReplicas {
+	if replicas == DependencyReplicas {
 		namespace = KratixSystemNamespace
 	}
 
@@ -598,7 +932,7 @@ func newWorkWithTwoWorkloadGroups(name string, workType int, promiseScheduling W
 			Namespace: namespace,
 		},
 		Spec: WorkSpec{
-			Replicas: workType,
+			Replicas: replicas,
 			WorkloadCoreFields: WorkloadCoreFields{
 				PromiseName:  "promise",
 				ResourceName: "resource",
@@ -615,7 +949,7 @@ func newWorkWithTwoWorkloadGroups(name string, workType int, promiseScheduling W
 						Workloads: []Workload{
 							{Content: "foo: bar"},
 						},
-						DestinationSelectors: []WorkloadGroupScheduling{{MatchLabels: directoryOverrideScheduling}},
+						DestinationSelectors: []WorkloadGroupScheduling{directoryOverrideScheduling},
 						Directory:            "foo",
 						ID:                   hash.ComputeHash("foo"),
 					},
@@ -628,6 +962,7 @@ func newWorkWithTwoWorkloadGroups(name string, workType int, promiseScheduling W
 
 	workWithDefaultFields := &Work{}
 	Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(work), workWithDefaultFields)).To(Succeed())
+
 	return *workWithDefaultFields
 }
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -243,34 +243,36 @@ setup_worker_2_destination() {
 }
 
 wait_for_gitea() {
-    kubectl wait pod --context kind-platform -n gitea --selector app=gitea --for=condition=ready ${opts}
+    wait_opts=$1
+    kubectl wait pod --context kind-platform -n gitea --selector app=gitea --for=condition=ready ${wait_opts}
 }
 
 wait_for_minio() {
+    wait_opts=$1
     while ! kubectl get pods --context kind-platform -n kratix-platform-system | grep minio; do
         sleep 1
     done
-    kubectl wait pod --context kind-platform -n kratix-platform-system --selector run=minio --for=condition=ready ${opts}
+    kubectl wait pod --context kind-platform -n kratix-platform-system --selector run=minio --for=condition=ready ${wait_opts}
 
     while ! kubectl get job --context kind-platform -n default | grep minio-create-bucket; do
         sleep 1
     done
-    kubectl --context kind-platform wait job minio-create-bucket --for condition=Complete
+    kubectl --context kind-platform wait job minio-create-bucket --for condition=Complete ${wait_opts}
 }
 
 wait_for_local_repository() {
     local timeout_flag="${1:-""}"
-    opts=""
+    wait_opts=""
     if [ -z "${timeout_flag}" ]; then
-        opts="--timeout=${WAIT_TIMEOUT}"
+        wait_opts="--timeout=${WAIT_TIMEOUT}"
     fi
 
     if ${INSTALL_AND_CREATE_GITEA_REPO}; then
-        wait_for_gitea
+        wait_for_gitea ${wait_opts}
     fi
 
     if ${INSTALL_AND_CREATE_MINIO_BUCKET}; then
-        wait_for_minio
+        wait_for_minio ${wait_opts}
     fi
 }
 


### PR DESCRIPTION
finishes: #186442323

https://www.pivotaltracker.com/story/show/186442323

Scheduler tests are now fast, and have some additional coverage.

Best reviewed commit-by-commit (see commit messages for more context on each one!).

-----

End result: 27 Scheduler tests take 0.032s to run, and including setup/teardown they take 2.7s ⏱️

```
[Syntassos-MBP] [scheduler-envtest-removal] [kratix] 
  > ginkgo run -r controllers
Running Suite: Controller Suite - /Users/richbartoncooper/Projects/kratix/controllers
=====================================================================================
Random Seed: 1703155204

Will run 27 of 74 specs
SSSSSS•••••••••••••••••••••••••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 27 of 74 Specs in 0.032 seconds
SUCCESS! -- 27 Passed | 0 Failed | 0 Pending | 47 Skipped
PASS | FOCUSED

Ginkgo ran 1 suite in 2.78743775s
Test Suite Passed
Detected Programmatic Focus - setting exit status to 197
```