### PR TITLE
Fix delete pipelines

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -34,6 +34,7 @@ import (
 const (
 	PromiseStatusAvailable   = "Available"
 	PromiseStatusUnavailable = "Unavailable"
+	PromisePlural            = "promises"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/controllers/dynamic_resource_request_controller.go
+++ b/controllers/dynamic_resource_request_controller.go
@@ -187,7 +187,7 @@ func (r *DynamicResourceRequestController) deleteResources(o opts, resourceReque
 		pipelineLabels := pipeline.LabelsForDeleteResource(resourceRequestIdentifier, r.PromiseIdentifier)
 
 		pipelineResources := pipeline.NewDeleteResource(
-			resourceRequest, r.DeletePipelines, resourceRequestIdentifier, r.PromiseIdentifier,
+			resourceRequest, r.DeletePipelines, resourceRequestIdentifier, r.PromiseIdentifier, r.CRD.Spec.Names.Plural,
 		)
 
 		jobOpts := jobOpts{

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -159,18 +159,12 @@ func ensureDeletePipelineIsReconciled(jobOpts jobOpts) (ctrl.Result, error) {
 	}
 
 	if existingDeletePipeline == nil {
+		jobOpts.logger.Info("Creating Delete Pipeline. The pipeline will now execute...")
+
+		//TODO retrieve error information from applyResources to return to the caller
 		applyResources(jobOpts.opts, jobOpts.pipelineResources...)
+
 		return defaultRequeue, nil
-		// jobOpts.logger.Info("Creating Delete Pipeline. The pipeline will now execute...")
-		// //TODO come back and address- do we know for sure that the cluster roles and service accounts will exist?
-		// err = jobOpts.client.Create(jobOpts.ctx, jobOpts.pipelineResources[0])
-		// if err != nil {
-		// 	jobOpts.logger.Error(err, "Error creating delete pipeline")
-		// 	y, _ := yaml.Marshal(&jobOpts.pipelineResources[0])
-		// 	jobOpts.logger.Error(err, string(y))
-		// 	return ctrl.Result{}, err
-		// }
-		// return defaultRequeue, nil
 	}
 
 	jobOpts.logger.Info("Checking status of Delete Pipeline")
@@ -180,9 +174,9 @@ func ensureDeletePipelineIsReconciled(jobOpts jobOpts) (ctrl.Result, error) {
 		if err := jobOpts.client.Update(jobOpts.ctx, jobOpts.obj); err != nil {
 			return ctrl.Result{}, err
 		}
+	} else {
+		jobOpts.logger.Info("Delete Pipeline not finished", "status", existingDeletePipeline.Status)
 	}
-
-	jobOpts.logger.Info("Delete Pipeline not finished", "status", existingDeletePipeline.Status)
 
 	return fastRequeue, nil
 }
@@ -327,6 +321,7 @@ func getJobsWithLabels(o opts, jobLabels map[string]string, namespace string) ([
 	return jobs.Items, nil
 }
 
+// TODO return error info (summary of errors from resources?) to the caller, instead of just logging
 func applyResources(o opts, resources ...client.Object) {
 	o.logger.Info("Reconciling pipeline resources")
 

--- a/lib/pipeline/assets/promise.yaml
+++ b/lib/pipeline/assets/promise.yaml
@@ -1,7 +1,7 @@
 apiVersion: platform.kratix.io/v1alpha1
 kind: Promise
 metadata:
-  name: redis
+  name: custom-namespace
   labels:
     kratix.io/promise-version: v1.2.0
     clashing-label: "new-promise-v2-value"
@@ -14,13 +14,13 @@ spec:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      name: redis.marketplace.kratix.io
+      name: custom-namespaces.marketplace.kratix.io
     spec:
       group: marketplace.kratix.io
       names:
-        kind: redis
-        plural: redis
-        singular: redis
+        kind: custom-namespace
+        plural: custom-namespaces
+        singular: custom-namespace
       scope: Namespaced
       versions:
         - name: v1alpha1
@@ -34,12 +34,6 @@ spec:
                         List of key:value pairs to use as cluster selectors when scheduling
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    size:
-                      default: small
-                      description: |
-                        Size of this Redis deployment. If small, it deploy redis with a single replica; if large, deploy redis with 3 replicas.
-                      pattern: ^(small|large)$
-                      type: string
                     newConfig:
                       default: "1"
                       description: example config
@@ -52,7 +46,7 @@ spec:
   - apiVersion: v1
     kind: Namespace
     metadata:
-      name: updated-namespace
+      name: custom
   destinationSelectors:
   - matchLabels:
       environment: dev
@@ -66,8 +60,8 @@ spec:
             namespace: default
           spec:
             containers:
-              - image: syntasso/demo-redis-configure-pipeline:v1.1.0
-                name: demo-redis-resource-configure-pipeline
+              - image: syntasso/demo-custom-namespace-configure-pipeline:v1.1.0
+                name: demo-custom-namespace-resource-configure-pipeline
       delete:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
@@ -76,8 +70,8 @@ spec:
             namespace: default
           spec:
             containers:
-              - image: syntasso/demo-redis-delete-pipeline:v1.1.0
-                name: demo-redis-resource-delete-pipeline
+              - image: syntasso/demo-custom-namespace-delete-pipeline:v1.1.0
+                name: demo-custom-namespace-resource-delete-pipeline
     promise:
       delete:
         - apiVersion: platform.kratix.io/v1alpha1
@@ -87,5 +81,5 @@ spec:
             namespace: default
           spec:
             containers:
-              - image: syntasso/demo-redis-delete-pipeline:v1.1.0
-                name: demo-redis-promise-delete-pipeline
+              - image: syntasso/demo-custom-namespace-delete-pipeline:v1.1.0
+                name: demo-custom-namespace-promise-delete-pipeline

--- a/lib/pipeline/assets/resource-request.yaml
+++ b/lib/pipeline/assets/resource-request.yaml
@@ -1,7 +1,7 @@
 apiVersion: marketplace.kratix.io/v1alpha1
-kind: redis
+kind: custom-namespace
 metadata:
   name: example
   namespace: default
 spec:
-  size: small
+  newConfig: "1"

--- a/lib/pipeline/delete.go
+++ b/lib/pipeline/delete.go
@@ -12,15 +12,15 @@ import (
 
 const kratixActionDelete = "delete"
 
-func NewDeleteResource(rr *unstructured.Unstructured, pipelines []platformv1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier string) []client.Object {
-	return newDelete(rr, pipelines, resourceRequestIdentifier, promiseIdentifier)
+func NewDeleteResource(rr *unstructured.Unstructured, pipelines []platformv1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier, crdPlural string) []client.Object {
+	return newDelete(rr, pipelines, resourceRequestIdentifier, promiseIdentifier, crdPlural)
 }
 
 func NewDeletePromise(promise *unstructured.Unstructured, pipelines []platformv1alpha1.Pipeline) []client.Object {
-	return newDelete(promise, pipelines, "", promise.GetName())
+	return newDelete(promise, pipelines, "", promise.GetName(), "promises")
 }
 
-func newDelete(obj *unstructured.Unstructured, pipelines []platformv1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier string) []client.Object {
+func newDelete(obj *unstructured.Unstructured, pipelines []platformv1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier, objPlural string) []client.Object {
 	isPromise := resourceRequestIdentifier == ""
 	namespace := obj.GetNamespace()
 	if isPromise {
@@ -33,7 +33,7 @@ func newDelete(obj *unstructured.Unstructured, pipelines []platformv1alpha1.Pipe
 
 	resources := []client.Object{
 		serviceAccount(args),
-		role(obj, obj.GetKind(), args),
+		role(obj, objPlural, args),
 		roleBinding(args),
 		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{

--- a/lib/pipeline/delete.go
+++ b/lib/pipeline/delete.go
@@ -17,7 +17,7 @@ func NewDeleteResource(rr *unstructured.Unstructured, pipelines []platformv1alph
 }
 
 func NewDeletePromise(promise *unstructured.Unstructured, pipelines []platformv1alpha1.Pipeline) []client.Object {
-	return newDelete(promise, pipelines, "", promise.GetName(), "promises")
+	return newDelete(promise, pipelines, "", promise.GetName(), platformv1alpha1.PromisePlural)
 }
 
 func newDelete(obj *unstructured.Unstructured, pipelines []platformv1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier, objPlural string) []client.Object {

--- a/lib/pipeline/delete_test.go
+++ b/lib/pipeline/delete_test.go
@@ -37,10 +37,10 @@ var _ = Describe("Delete Pipeline", func() {
 	Describe("Promise", func() {
 		var (
 			expectedObjectMeta = metav1.ObjectMeta{
-				Name:      "redis-promise-pipeline",
+				Name:      "custom-namespace-promise-pipeline",
 				Namespace: "kratix-platform-system",
 				Labels: map[string]string{
-					"kratix-promise-id": "redis",
+					"kratix-promise-id": "custom-namespace",
 				},
 			}
 		)
@@ -86,7 +86,7 @@ var _ = Describe("Delete Pipeline", func() {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{"platform.kratix.io"},
-							Resources: []string{"Promise", "Promise/status"},
+							Resources: []string{"promises", "promises/status"},
 							Verbs:     []string{"get", "list", "update", "create", "patch"},
 						},
 						{
@@ -106,13 +106,13 @@ var _ = Describe("Delete Pipeline", func() {
 					RoleRef: rbacv1.RoleRef{
 						Kind:     "Role",
 						APIGroup: "rbac.authorization.k8s.io",
-						Name:     "redis-promise-pipeline",
+						Name:     "custom-namespace-promise-pipeline",
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
 							Namespace: "kratix-platform-system",
-							Name:      "redis-promise-pipeline",
+							Name:      "custom-namespace-promise-pipeline",
 						},
 					},
 				}
@@ -127,12 +127,12 @@ var _ = Describe("Delete Pipeline", func() {
 					"kratix-workflow-promise-version": Equal("v1alpha1"),
 					"kratix-workflow-type":            Equal("promise"),
 					"kratix-workflow-action":          Equal("delete"),
-					"kratix-promise-id":               Equal("redis"),
+					"kratix-promise-id":               Equal("custom-namespace"),
 				})
 
 				Expect(job).To(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Name":      HavePrefix("delete-pipeline-redis-"),
+						"Name":      HavePrefix("delete-pipeline-custom-namespace-"),
 						"Namespace": Equal("kratix-platform-system"),
 						"Labels":    labelsMatcher,
 					}),
@@ -143,11 +143,11 @@ var _ = Describe("Delete Pipeline", func() {
 							}),
 							"Spec": MatchFields(IgnoreExtras, Fields{
 								"RestartPolicy":      Equal(v1.RestartPolicyOnFailure),
-								"ServiceAccountName": Equal("redis-promise-pipeline"),
+								"ServiceAccountName": Equal("custom-namespace-promise-pipeline"),
 								"Containers": MatchAllElementsWithIndex(IndexIdentity, Elements{
 									"0": MatchFields(IgnoreExtras, Fields{
-										"Name":  Equal("demo-redis-promise-delete-pipeline"),
-										"Image": Equal("syntasso/demo-redis-delete-pipeline:v1.1.0"),
+										"Name":  Equal("demo-custom-namespace-promise-delete-pipeline"),
+										"Image": Equal("syntasso/demo-custom-namespace-delete-pipeline:v1.1.0"),
 										"VolumeMounts": ConsistOf(
 											MatchFields(IgnoreExtras, Fields{
 												"MountPath": Equal("/kratix/input"),
@@ -185,7 +185,7 @@ var _ = Describe("Delete Pipeline", func() {
 											}),
 											MatchFields(IgnoreExtras, Fields{
 												"Name":  Equal("OBJECT_NAME"),
-												"Value": Equal("redis"),
+												"Value": Equal("custom-namespace"),
 											}),
 											MatchFields(IgnoreExtras, Fields{
 												"Name":  Equal("OBJECT_NAMESPACE"),
@@ -224,10 +224,10 @@ var _ = Describe("Delete Pipeline", func() {
 	Describe("Resource", func() {
 		var (
 			expectedObjectMeta = metav1.ObjectMeta{
-				Name:      "redis-resource-pipeline",
+				Name:      "custom-namespace-resource-pipeline",
 				Namespace: "default",
 				Labels: map[string]string{
-					"kratix-promise-id": "redis",
+					"kratix-promise-id": "custom-namespace",
 				},
 			}
 		)
@@ -243,8 +243,9 @@ var _ = Describe("Delete Pipeline", func() {
 				pipelineResources = pipeline.NewDeleteResource(
 					resourceRequest,
 					pipelines.DeleteResource,
-					"example-redis",
-					"redis",
+					"example-custom-namespace",
+					"custom-namespace",
+					"custom-namespaces",
 				)
 			})
 
@@ -274,7 +275,7 @@ var _ = Describe("Delete Pipeline", func() {
 					Rules: []rbacv1.PolicyRule{
 						{
 							APIGroups: []string{"marketplace.kratix.io"},
-							Resources: []string{"redis", "redis/status"},
+							Resources: []string{"custom-namespaces", "custom-namespaces/status"},
 							Verbs:     []string{"get", "list", "update", "create", "patch"},
 						},
 						{
@@ -294,13 +295,13 @@ var _ = Describe("Delete Pipeline", func() {
 					RoleRef: rbacv1.RoleRef{
 						Kind:     "Role",
 						APIGroup: "rbac.authorization.k8s.io",
-						Name:     "redis-resource-pipeline",
+						Name:     "custom-namespace-resource-pipeline",
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
 							Namespace: "default",
-							Name:      "redis-resource-pipeline",
+							Name:      "custom-namespace-resource-pipeline",
 						},
 					},
 				}
@@ -315,13 +316,13 @@ var _ = Describe("Delete Pipeline", func() {
 					"kratix-workflow-promise-version":    Equal("v1alpha1"),
 					"kratix-workflow-type":               Equal("resource"),
 					"kratix-workflow-action":             Equal("delete"),
-					"kratix-promise-id":                  Equal("redis"),
-					"kratix-promise-resource-request-id": Equal("example-redis"),
+					"kratix-promise-id":                  Equal("custom-namespace"),
+					"kratix-promise-resource-request-id": Equal("example-custom-namespace"),
 				})
 
 				Expect(job).To(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Name":      HavePrefix("delete-pipeline-redis-"),
+						"Name":      HavePrefix("delete-pipeline-custom-namespace-"),
 						"Namespace": Equal("default"),
 						"Labels":    labelsMatcher,
 					}),
@@ -332,11 +333,11 @@ var _ = Describe("Delete Pipeline", func() {
 							}),
 							"Spec": MatchFields(IgnoreExtras, Fields{
 								"RestartPolicy":      Equal(v1.RestartPolicyOnFailure),
-								"ServiceAccountName": Equal("redis-resource-pipeline"),
+								"ServiceAccountName": Equal("custom-namespace-resource-pipeline"),
 								"Containers": MatchAllElementsWithIndex(IndexIdentity, Elements{
 									"0": MatchFields(IgnoreExtras, Fields{
-										"Name":  Equal("demo-redis-resource-delete-pipeline"),
-										"Image": Equal("syntasso/demo-redis-delete-pipeline:v1.1.0"),
+										"Name":  Equal("demo-custom-namespace-resource-delete-pipeline"),
+										"Image": Equal("syntasso/demo-custom-namespace-delete-pipeline:v1.1.0"),
 										"VolumeMounts": ConsistOf(
 											MatchFields(IgnoreExtras, Fields{
 												"MountPath": Equal("/kratix/input"),
@@ -366,7 +367,7 @@ var _ = Describe("Delete Pipeline", func() {
 										"Env": ConsistOf(
 											MatchFields(IgnoreExtras, Fields{
 												"Name":  Equal("OBJECT_KIND"),
-												"Value": Equal("redis"),
+												"Value": Equal("custom-namespace"),
 											}),
 											MatchFields(IgnoreExtras, Fields{
 												"Name":  Equal("OBJECT_GROUP"),

--- a/lib/pipeline/shared.go
+++ b/lib/pipeline/shared.go
@@ -97,7 +97,7 @@ func clusterRole(args PipelineArgs) *rbacv1.ClusterRole {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"platform.kratix.io"},
-				Resources: []string{"promises", "promises/status", "works"},
+				Resources: []string{v1alpha1.PromisePlural, v1alpha1.PromisePlural + "/status", "works"},
 				Verbs:     []string{"get", "list", "update", "create", "patch"},
 			},
 		},

--- a/test/system/assets/bash-promise/promise-v1alpha2.yaml
+++ b/test/system/assets/bash-promise/promise-v1alpha2.yaml
@@ -37,12 +37,12 @@ spec:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      name: bash.test.kratix.io
+      name: bashes.test.kratix.io
     spec:
       group: test.kratix.io
       names:
         kind: bash
-        plural: bash
+        plural: bashes
         singular: bash
       scope: Namespaced
       versions:

--- a/test/system/assets/bash-promise/promise-with-destination-selectors-updated.yaml
+++ b/test/system/assets/bash-promise/promise-with-destination-selectors-updated.yaml
@@ -9,12 +9,12 @@ spec:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      name: bash.test.kratix.io
+      name: bashes.test.kratix.io
     spec:
       group: test.kratix.io
       names:
         kind: bash
-        plural: bash
+        plural: bashes
         singular: bash
       scope: Namespaced
       versions:

--- a/test/system/assets/bash-promise/promise-with-destination-selectors.yaml
+++ b/test/system/assets/bash-promise/promise-with-destination-selectors.yaml
@@ -9,12 +9,12 @@ spec:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      name: bash.test.kratix.io
+      name: bashes.test.kratix.io
     spec:
       group: test.kratix.io
       names:
         kind: bash
-        plural: bash
+        plural: bashes
         singular: bash
       scope: Namespaced
       versions:

--- a/test/system/assets/bash-promise/promise.yaml
+++ b/test/system/assets/bash-promise/promise.yaml
@@ -39,12 +39,12 @@ spec:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      name: bash.test.kratix.io
+      name: bashes.test.kratix.io
     spec:
       group: test.kratix.io
       names:
         kind: bash
-        plural: bash
+        plural: bashes
         singular: bash
       scope: Namespaced
       versions:

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Kratix", func() {
 			By("installing the promise", func() {
 				platform.kubectl("apply", "-f", promisePath)
 
-				platform.eventuallyKubectl("get", "crd", "bash.test.kratix.io")
+				platform.eventuallyKubectl("get", "crd", "bashes.test.kratix.io")
 				worker.eventuallyKubectl("get", "namespace", "bash-dep-namespace-v1alpha1")
 				worker.eventuallyKubectl("get", "namespace", "bash-workflow-namespace-v1alpha1")
 				platform.eventuallyKubectl("get", "namespace", "bash-workflow-imperative-namespace")
@@ -137,7 +137,7 @@ var _ = Describe("Kratix", func() {
 					g.Expect(platform.kubectl("get", "namespace")).NotTo(ContainSubstring("promise-workflow-namespace"))
 					g.Expect(platform.kubectl("get", "namespace")).NotTo(ContainSubstring("bash-workflow-imperative-namespace"))
 					g.Expect(platform.kubectl("get", "promise")).ShouldNot(ContainSubstring("bash"))
-					g.Expect(platform.kubectl("get", "crd")).ShouldNot(ContainSubstring("bash"))
+					g.Expect(platform.kubectl("get", "crd")).ShouldNot(ContainSubstring("bashes"))
 				}, timeout, interval).Should(Succeed())
 			})
 		})
@@ -180,7 +180,7 @@ var _ = Describe("Kratix", func() {
 
 					Eventually(func(g Gomega) {
 						g.Expect(platform.kubectl("get", "promise")).Should(ContainSubstring("bash"))
-						g.Expect(platform.kubectl("get", "crd")).Should(ContainSubstring("bash"))
+						g.Expect(platform.kubectl("get", "crd")).Should(ContainSubstring("bashes"))
 						g.Expect(platform.kubectl("get", "promiserelease")).Should(ContainSubstring("bash"))
 					}, timeout, interval).Should(Succeed())
 
@@ -212,7 +212,7 @@ var _ = Describe("Kratix", func() {
 		Describe("Resource requests", func() {
 			BeforeEach(func() {
 				platform.kubectl("apply", "-f", promisePath)
-				platform.eventuallyKubectl("get", "crd", "bash.test.kratix.io")
+				platform.eventuallyKubectl("get", "crd", "bashes.test.kratix.io")
 			})
 
 			It("executes the pipelines and schedules the work to the appropriate destinations", func() {
@@ -221,7 +221,7 @@ var _ = Describe("Kratix", func() {
 				platform.kubectl("apply", "-f", exampleBashRequest(rrName))
 
 				By("executing the pipeline pod", func() {
-					platform.kubectl("wait", "--for=condition=PipelineCompleted", "bash", rrName, pipelineTimeout)
+					platform.kubectl("wait", "--for=condition=PipelineCompleted", "bashes", rrName, pipelineTimeout)
 				})
 
 				By("deploying the contents of /kratix/output/platform to the platform destination only", func() {
@@ -245,18 +245,18 @@ var _ = Describe("Kratix", func() {
 
 				By("updating the resource status", func() {
 					Eventually(func() string {
-						return platform.kubectl("get", "bash", rrName)
+						return platform.kubectl("get", "bashes", rrName)
 					}, timeout, interval).Should(ContainSubstring("My awesome status message"))
 					Eventually(func() string {
-						return platform.kubectl("get", "bash", rrName, "-o", "jsonpath='{.status.key}'")
+						return platform.kubectl("get", "bashes", rrName, "-o", "jsonpath='{.status.key}'")
 					}, timeout, interval).Should(ContainSubstring("value"))
 				})
 
 				By("deleting the resource request", func() {
-					platform.kubectl("delete", "bash", rrName)
+					platform.kubectl("delete", "bashes", rrName)
 
 					Eventually(func(g Gomega) {
-						g.Expect(platform.kubectl("get", "bash")).NotTo(ContainSubstring(rrName))
+						g.Expect(platform.kubectl("get", "bashes")).NotTo(ContainSubstring(rrName))
 						g.Expect(platform.kubectl("get", "namespace")).NotTo(ContainSubstring("imperative-rr-test"))
 						g.Expect(worker.kubectl("get", "namespace")).NotTo(ContainSubstring("declarative-rr-test"))
 					}, timeout, interval).Should(Succeed())
@@ -280,7 +280,7 @@ var _ = Describe("Kratix", func() {
 						oldNamespaceName,
 					)
 					platform.kubectl("apply", "-f", requestWithNameAndCommand(requestName, createNamespace))
-					platform.kubectl("wait", "--for=condition=PipelineCompleted", "bash", requestName, pipelineTimeout)
+					platform.kubectl("wait", "--for=condition=PipelineCompleted", "bashes", requestName, pipelineTimeout)
 					worker.eventuallyKubectl("get", "namespace", oldNamespaceName)
 				})
 
@@ -321,7 +321,7 @@ var _ = Describe("Kratix", func() {
 				By("installing and requesting v1alpha1 promise", func() {
 					platform.kubectl("apply", "-f", promisePath)
 
-					platform.eventuallyKubectl("get", "crd", "bash.test.kratix.io")
+					platform.eventuallyKubectl("get", "crd", "bashes.test.kratix.io")
 					Expect(worker.eventuallyKubectl("get", "namespace", "bash-dep-namespace-v1alpha1", "-o=yaml")).To(ContainSubstring("modifydepsinpipeline"))
 				})
 
@@ -398,7 +398,7 @@ var _ = Describe("Kratix", func() {
 		// - security: high
 		BeforeEach(func() {
 			platform.kubectl("apply", "-f", promiseWithSchedulingPath)
-			platform.eventuallyKubectl("get", "crd", "bash.test.kratix.io")
+			platform.eventuallyKubectl("get", "crd", "bashes.test.kratix.io")
 		})
 
 		AfterEach(func() {
@@ -455,7 +455,7 @@ var _ = Describe("Kratix", func() {
 				kubectl create namespace rr-2-namespace --dry-run=client -oyaml > /kratix/output/ns.yaml`
 				platform.kubectl("apply", "-f", requestWithNameAndCommand("rr-2", pipelineCmd))
 
-				platform.kubectl("wait", "--for=condition=PipelineCompleted", "bash", "rr-2", pipelineTimeout)
+				platform.kubectl("wait", "--for=condition=PipelineCompleted", "bashes", "rr-2", pipelineTimeout)
 
 				By("only scheduling the work when a Destination label matches", func() {
 					/*
@@ -536,7 +536,7 @@ var _ = Describe("Kratix", func() {
 			It("installs the Promises specified", func() {
 				platform.eventuallyKubectl("get", "promiserelease", "bash")
 				platform.eventuallyKubectl("get", "promise", "bash")
-				platform.eventuallyKubectl("get", "crd", "bash.test.kratix.io")
+				platform.eventuallyKubectl("get", "crd", "bashes.test.kratix.io")
 			})
 		})
 
@@ -548,7 +548,7 @@ var _ = Describe("Kratix", func() {
 			It("deletes the PromiseRelease and the Promises", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(platform.kubectl("get", "promise")).ShouldNot(ContainSubstring("bash"))
-					g.Expect(platform.kubectl("get", "crd")).ShouldNot(ContainSubstring("bash"))
+					g.Expect(platform.kubectl("get", "crd")).ShouldNot(ContainSubstring("bashes"))
 					g.Expect(platform.kubectl("get", "promiserelease")).ShouldNot(ContainSubstring("bash"))
 				}, timeout, interval).Should(Succeed())
 			})
@@ -583,7 +583,7 @@ var _ = Describe("Kratix", func() {
 			By("writing to the repo on promise install", func() {
 				platform.kubectl("apply", "-f", promisePath)
 
-				platform.eventuallyKubectl("get", "crd", "bash.test.kratix.io")
+				platform.eventuallyKubectl("get", "crd", "bashes.test.kratix.io")
 				platform.eventuallyKubectl("get", "namespace", "promise-workflow-namespace")
 				worker.eventuallyKubectl("get", "namespace", "bash-dep-namespace-v1alpha1")
 				worker.eventuallyKubectl("get", "namespace", "bash-workflow-namespace-v1alpha1")
@@ -593,7 +593,7 @@ var _ = Describe("Kratix", func() {
 				platform.kubectl("apply", "-f", exampleBashRequest(rrName))
 
 				By("executing the pipeline pod", func() {
-					platform.kubectl("wait", "--for=condition=PipelineCompleted", "bash", rrName, pipelineTimeout)
+					platform.kubectl("wait", "--for=condition=PipelineCompleted", "bashes", rrName, pipelineTimeout)
 				})
 
 				By("deploying the contents of /kratix/output to the appropriate destinations", func() {
@@ -603,10 +603,10 @@ var _ = Describe("Kratix", func() {
 			})
 
 			By("removing from the repo on resource delete", func() {
-				platform.kubectl("delete", "bash", rrName)
+				platform.kubectl("delete", "bashes", rrName)
 
 				Eventually(func(g Gomega) {
-					g.Expect(platform.kubectl("get", "bash")).NotTo(ContainSubstring(rrName))
+					g.Expect(platform.kubectl("get", "bashes")).NotTo(ContainSubstring(rrName))
 					g.Expect(platform.kubectl("get", "namespace")).NotTo(ContainSubstring("imperative-rr-test"))
 					g.Expect(platform.kubectl("get", "namespace")).NotTo(ContainSubstring("declarative-platform-only-rr-test"))
 					g.Expect(worker.kubectl("get", "namespace")).NotTo(ContainSubstring("declarative-rr-test"))
@@ -620,7 +620,7 @@ var _ = Describe("Kratix", func() {
 					g.Expect(worker.kubectl("get", "namespace")).NotTo(ContainSubstring("bash-dep-namespace-v1alpha1"))
 					g.Expect(platform.kubectl("get", "namespace")).NotTo(ContainSubstring("promise-workflow-namespace"))
 					g.Expect(platform.kubectl("get", "promise")).ShouldNot(ContainSubstring("bash"))
-					g.Expect(platform.kubectl("get", "crd")).ShouldNot(ContainSubstring("bash"))
+					g.Expect(platform.kubectl("get", "crd")).ShouldNot(ContainSubstring("bashes"))
 				}, timeout, interval).Should(Succeed())
 			})
 		})


### PR DESCRIPTION
#67 introduced a bug which meant that the ServiceAccount used in delete pipelines wasn't configured correctly, which meant deletes failed.

tl;dr - we started to use the `Kind` and not the plural for the Role resource, and didn't catch it in tests because `bash` and `redis` both have identical singular and plural versions 😢

This PR fixes the bug by passing in the plural when creating the delete pipeline, and also makes `bashes` the plural of `bash` so we have some coverage of this case in the system tests.

(There's also a `redis` promise used in the system tests, so we still have some coverage of the identical-singular-plural case.)

See [here](https://syntasso.slack.com/archives/C044T9ZFUMN/p1704970369264829?thread_ts=1704900358.243089&cid=C044T9ZFUMN) in Slack for more detail 🧵 