### PR TITLE
feat: Delete old jobs, only keep the last five

### DIFF
--- a/controllers/shared.go
+++ b/controllers/shared.go
@@ -109,7 +109,7 @@ func ensureConfigurePipelineIsReconciled(j jobOpts) (*ctrl.Result, error) {
 	}
 
 	//delete 5 old jobs
-	err = deleteAllButLastFiveJobs(j)
+	err = deleteAllButLastFiveJobs(j, pipelineJobs)
 	if err != nil {
 		j.logger.Error(err, "failed to delete old jobs")
 	}
@@ -119,18 +119,7 @@ func ensureConfigurePipelineIsReconciled(j jobOpts) (*ctrl.Result, error) {
 
 const numberOfJobsToKeep = 5
 
-func deleteAllButLastFiveJobs(j jobOpts) error {
-	namespace := j.obj.GetNamespace()
-	if namespace == "" {
-		namespace = v1alpha1.KratixSystemNamespace
-	}
-
-	pipelineJobs, err := getJobsWithLabels(j.opts, j.pipelineLabels, namespace)
-	if err != nil {
-		j.logger.Info("Failed getting Promise pipeline jobs", "error", err)
-		return nil
-	}
-
+func deleteAllButLastFiveJobs(j jobOpts, pipelineJobs []batchv1.Job) error {
 	if len(pipelineJobs) <= numberOfJobsToKeep {
 		return nil
 	}

--- a/controllers/shared_test.go
+++ b/controllers/shared_test.go
@@ -89,6 +89,7 @@ type testReconciler struct {
 // TODO: We watch for various other resources to trigger reconciliaton loop,
 // e.g. changes to jobs owned by a promise trigger the promise. Need to improve
 // this to handle that
+
 func (t *testReconciler) reconcileUntilCompletion(r kubebuilder.Reconciler, obj client.Object, opts ...*opts) (ctrl.Result, error) {
 	t.reconcileCount++
 	k8sObj := &unstructured.Unstructured{}


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/186934123)

Currently we never delete old jobs/pods. If a resource is updated 100 times, we will have a 100 pods. This PR changes it so we only ever keep the last five jobs/pods for a promise/resource. In the future it will be configurable.

## Acceptance

Below is the output from having a promise and resource request updated 5 times:
```
k get pods
default                  configure-pipeline-redis-3ee9c-dxwjn                 0/1     Completed   0          2m6s
default                  configure-pipeline-redis-7b634-ds2hs                 0/1     Completed   0          6s
default                  configure-pipeline-redis-831ed-kd2tb                 0/1     Completed   0          52s
default                  configure-pipeline-redis-bbd43-ftskx                 0/1     Completed   0          39s
default                  configure-pipeline-redis-d6975-fwk85                 0/1     Completed   0          3m5s
kratix-platform-system   configure-pipeline-redis-1d3ea-jxr9t                 0/1     Completed   0          2m12s
kratix-platform-system   configure-pipeline-redis-49dd1-npzlm                 0/1     Completed   0          3m21s
kratix-platform-system   configure-pipeline-redis-68b4d-qc5rj                 0/1     Completed   0          16s
kratix-platform-system   configure-pipeline-redis-adfe1-n4thn                 0/1     Completed   0          59s
kratix-platform-system   configure-pipeline-redis-f6156-5wvft                 0/1     Completed   0          46s
```

If I update the promise again (which triggers a re-run of the resource requests pod as well) you can see the oldest pods (`configure-pipeline-redis-d6975-fwk85` and ` configure-pipeline-redis-49dd1-npzlm`) get deleted:

```
k edit promise redis
promise.platform.kratix.io/redis edited

k get pods
default                  configure-pipeline-redis-3ee9c-dxwjn                 0/1     Completed   0          3m11s
default                  configure-pipeline-redis-7b634-ds2hs                 0/1     Completed   0          71s
default                  configure-pipeline-redis-831ed-kd2tb                 0/1     Completed   0          117s
default                  configure-pipeline-redis-a5d49-v2z9p                 0/1     Completed   0          11s
default                  configure-pipeline-redis-bbd43-ftskx                 0/1     Completed   0          104s
kratix-platform-system   configure-pipeline-redis-1d3ea-jxr9t                 0/1     Completed   0          3m17s
kratix-platform-system   configure-pipeline-redis-68b4d-qc5rj                 0/1     Completed   0          81s
kratix-platform-system   configure-pipeline-redis-adfe1-n4thn                 0/1     Completed   0          2m4s
kratix-platform-system   configure-pipeline-redis-c9ec5-cm4l6                 0/1     Completed   0          32s
kratix-platform-system   configure-pipeline-redis-f6156-5wvft                 0/1     Completed   0          111s
```