### PR TITLE
feat: ensure all delete pipeline params are passed to pods

### DIFF
--- a/lib/pipeline/configure.go
+++ b/lib/pipeline/configure.go
@@ -51,7 +51,7 @@ func NewConfigureResource(
 }
 
 func NewConfigurePromise(
-	unstructedPromise *unstructured.Unstructured,
+	unstructuredPromise *unstructured.Unstructured,
 	pipelines []v1alpha1.Pipeline,
 	promiseIdentifier string,
 	promiseDestinationSelectors []v1alpha1.PromiseScheduling,
@@ -64,7 +64,7 @@ func NewConfigurePromise(
 		return nil, err
 	}
 
-	pipeline, err := ConfigurePipeline(unstructedPromise, pipelines, pipelineResources, promiseIdentifier, true, logger)
+	pipeline, err := ConfigurePipeline(unstructuredPromise, pipelines, pipelineResources, promiseIdentifier, true, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func NewConfigurePromise(
 func ConfigurePipeline(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, pipelineArgs PipelineArgs, promiseName string, promiseWorkflow bool, logger logr.Logger) (*batchv1.Job, error) {
 	volumes := metadataAndSchedulingVolumes(pipelineArgs.ConfigMapName())
 
-	initContainers, pipelineVolumes := configurePipelineInitContainers(obj, pipelines, promiseName, promiseWorkflow, logger)
+	initContainers, pipelineVolumes := generateConfigurePipelineContainersAndVolumes(obj, pipelines, promiseName, promiseWorkflow)
 	volumes = append(volumes, pipelineVolumes...)
 
 	objHash, err := hash.ComputeHashForResource(obj)
@@ -142,12 +142,10 @@ func ConfigurePipeline(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipe
 	return job, nil
 }
 
-func configurePipelineInitContainers(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, promiseName string, promiseWorkflow bool, logger logr.Logger) ([]v1.Container, []v1.Volume) {
-	volumes, volumeMounts := pipelineVolumes()
-
-	kratixWorkflowType := v1alpha1.WorkflowTypeResource
+func generateConfigurePipelineContainersAndVolumes(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, promiseName string, promiseWorkflow bool) ([]v1.Container, []v1.Volume) {
+	workflowType := v1alpha1.WorkflowTypeResource
 	if promiseWorkflow {
-		kratixWorkflowType = v1alpha1.WorkflowTypePromise
+		workflowType = v1alpha1.WorkflowTypePromise
 	}
 
 	kratixEnvVars := []v1.EnvVar{
@@ -157,7 +155,7 @@ func configurePipelineInitContainers(obj *unstructured.Unstructured, pipelines [
 		},
 		{
 			Name:  kratixTypeEnvVar,
-			Value: string(kratixWorkflowType),
+			Value: string(workflowType),
 		},
 		{
 			Name:  kratixPromiseEnvVar,
@@ -165,31 +163,7 @@ func configurePipelineInitContainers(obj *unstructured.Unstructured, pipelines [
 		},
 	}
 
-	readerContainer := readerContainer(obj, kratixWorkflowType, "shared-input")
-	containers := []v1.Container{
-		readerContainer,
-	}
-
-	if len(pipelines) > 0 {
-		if len(pipelines[0].Spec.Volumes) > 0 {
-			volumes = append(volumes, pipelines[0].Spec.Volumes...)
-		}
-		for _, c := range pipelines[0].Spec.Containers {
-			if len(c.VolumeMounts) > 0 {
-				volumeMounts = append(volumeMounts, c.VolumeMounts...)
-			}
-			containers = append(containers, v1.Container{
-				Name:            c.Name,
-				Image:           c.Image,
-				VolumeMounts:    volumeMounts,
-				Args:            c.Args,
-				Command:         c.Command,
-				Env:             append(kratixEnvVars, c.Env...),
-				EnvFrom:         c.EnvFrom,
-				ImagePullPolicy: c.ImagePullPolicy,
-			})
-		}
-	}
+	containers, volumes := generateContainersAndVolumes(obj, workflowType, pipelines, kratixEnvVars)
 
 	workCreatorCommand := fmt.Sprintf("./work-creator -input-directory /work-creator-files -promise-name %s -namespace %q", promiseName, obj.GetNamespace())
 	if promiseWorkflow {

--- a/lib/pipeline/delete.go
+++ b/lib/pipeline/delete.go
@@ -12,14 +12,14 @@ import (
 const kratixActionDelete = "delete"
 
 func NewDeleteResource(rr *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier, crdPlural string) []client.Object {
-	return newDelete(rr, pipelines, resourceRequestIdentifier, promiseIdentifier, crdPlural)
+	return NewDelete(rr, pipelines, resourceRequestIdentifier, promiseIdentifier, crdPlural)
 }
 
 func NewDeletePromise(promise *unstructured.Unstructured, pipelines []v1alpha1.Pipeline) []client.Object {
-	return newDelete(promise, pipelines, "", promise.GetName(), v1alpha1.PromisePlural)
+	return NewDelete(promise, pipelines, "", promise.GetName(), v1alpha1.PromisePlural)
 }
 
-func newDelete(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier, objPlural string) []client.Object {
+func NewDelete(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, resourceRequestIdentifier, promiseIdentifier, objPlural string) []client.Object {
 	isPromise := resourceRequestIdentifier == ""
 	namespace := obj.GetNamespace()
 	if isPromise {
@@ -29,6 +29,11 @@ func newDelete(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, re
 	args := NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, namespace)
 
 	containers, pipelineVolumes := deletePipelineContainers(obj, isPromise, pipelines)
+
+	var imagePullSecrets []v1.LocalObjectReference
+	if len(pipelines) > 0 {
+		imagePullSecrets = pipelines[0].Spec.ImagePullSecrets
+	}
 
 	resources := []client.Object{
 		serviceAccount(args),
@@ -51,6 +56,7 @@ func newDelete(obj *unstructured.Unstructured, pipelines []v1alpha1.Pipeline, re
 						Containers:         []v1.Container{containers[len(containers)-1]},
 						InitContainers:     containers[0 : len(containers)-1],
 						Volumes:            pipelineVolumes,
+						ImagePullSecrets:   imagePullSecrets,
 					},
 				},
 			},
@@ -69,24 +75,35 @@ func deletePipelineContainers(obj *unstructured.Unstructured, isPromise bool, pi
 		workflowType = v1alpha1.WorkflowTypePromise
 	}
 
+	kratixEnvVars := []v1.EnvVar{
+		{
+			Name:  kratixActionEnvVar,
+			Value: kratixActionDelete,
+		},
+	}
+
 	readerContainer := readerContainer(obj, workflowType, "shared-input")
 	containers := []v1.Container{
 		readerContainer,
 	}
 
 	if len(pipelines) > 0 {
-		//TODO: We only support 1 workflow for now
+		if len(pipelines[0].Spec.Volumes) > 0 {
+			volumes = append(volumes, pipelines[0].Spec.Volumes...)
+		}
 		for _, c := range pipelines[0].Spec.Containers {
+			if len(c.VolumeMounts) > 0 {
+				volumeMounts = append(volumeMounts, c.VolumeMounts...)
+			}
 			containers = append(containers, v1.Container{
-				Name:         c.Name,
-				Image:        c.Image,
-				VolumeMounts: volumeMounts,
-				Env: []v1.EnvVar{
-					{
-						Name:  kratixActionEnvVar,
-						Value: kratixActionDelete,
-					},
-				},
+				Name:            c.Name,
+				Image:           c.Image,
+				VolumeMounts:    volumeMounts,
+				Args:            c.Args,
+				Command:         c.Command,
+				Env:             append(kratixEnvVars, c.Env...),
+				EnvFrom:         c.EnvFrom,
+				ImagePullPolicy: c.ImagePullPolicy,
 			})
 		}
 	}

--- a/lib/pipeline/delete_test.go
+++ b/lib/pipeline/delete_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -408,6 +409,134 @@ var _ = Describe("Delete Pipeline", func() {
 					}),
 				}))
 			})
+		})
+	})
+
+	Describe("optional workflow configs", func() {
+		var (
+			rr        *unstructured.Unstructured
+			pipelines []v1alpha1.Pipeline
+		)
+
+		BeforeEach(func() {
+			rr = &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":      "test-pod",
+						"namespace": "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			}
+
+			pipelines = []v1alpha1.Pipeline{
+				{
+					Spec: v1alpha1.PipelineSpec{
+						Containers: []v1alpha1.Container{
+							{Name: "test-container", Image: "test-image"},
+						},
+					},
+				},
+			}
+		})
+
+		It("can include args and commands", func() {
+			pipelines[0].Spec.Containers = append(pipelines[0].Spec.Containers, v1alpha1.Container{
+				Name:    "another-container",
+				Image:   "another-image",
+				Args:    []string{"arg1", "arg2"},
+				Command: []string{"command1", "command2"},
+			})
+			resources := pipeline.NewDelete(rr, pipelines, "", "test-promise", "promises")
+			job := resources[3].(*batchv1.Job)
+
+			Expect(job.Spec.Template.Spec.InitContainers[1].Args).To(BeEmpty())
+			Expect(job.Spec.Template.Spec.InitContainers[1].Command).To(BeEmpty())
+			Expect(job.Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"arg1", "arg2"}))
+			Expect(job.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"command1", "command2"}))
+		})
+
+		It("can include env and envFrom", func() {
+			pipelines[0].Spec.Containers = append(pipelines[0].Spec.Containers, v1alpha1.Container{
+				Name:  "another-container",
+				Image: "another-image",
+				Env: []corev1.EnvVar{
+					{Name: "env1", Value: "value1"},
+				},
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "test-configmap"},
+						},
+					},
+				},
+			})
+			resources := pipeline.NewDelete(rr, pipelines, "", "test-promise", "promises")
+			job := resources[3].(*batchv1.Job)
+
+			Expect(job.Spec.Template.Spec.InitContainers[1].Env).To(ContainElements(
+				corev1.EnvVar{Name: "KRATIX_WORKFLOW_ACTION", Value: "delete"},
+			))
+			Expect(job.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+				corev1.EnvVar{Name: "KRATIX_WORKFLOW_ACTION", Value: "delete"},
+				corev1.EnvVar{Name: "env1", Value: "value1"},
+			))
+
+			Expect(job.Spec.Template.Spec.InitContainers[1].EnvFrom).To(BeNil())
+			Expect(job.Spec.Template.Spec.Containers[0].EnvFrom).To(ContainElements(
+				corev1.EnvFromSource{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-configmap"},
+					},
+				},
+			))
+		})
+
+		It("can include volume and volume mounts", func() {
+			pipelines[0].Spec.Volumes = []corev1.Volume{
+				{Name: "test-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			}
+			pipelines[0].Spec.Containers = append(pipelines[0].Spec.Containers, v1alpha1.Container{
+				Name:  "another-container",
+				Image: "another-image",
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "test-volume-mount", MountPath: "/test-mount-path"},
+				},
+			})
+			resources := pipeline.NewDelete(rr, pipelines, "", "test-promise", "promises")
+			job := resources[3].(*batchv1.Job)
+
+			Expect(job.Spec.Template.Spec.InitContainers[1].VolumeMounts).To(HaveLen(3), "default volume mounts should've been included")
+			Expect(job.Spec.Template.Spec.InitContainers[1].Command).To(BeEmpty())
+			Expect(job.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(
+				corev1.VolumeMount{Name: "test-volume-mount", MountPath: "/test-mount-path"},
+			))
+			Expect(job.Spec.Template.Spec.Volumes).To(ContainElement(
+				corev1.Volume{Name: "test-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			))
+		})
+
+		It("can include imagePullPolicy and imagePullSecrets", func() {
+			pipelines[0].Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "test-secret"}, {Name: "another-secret"}}
+			pipelines[0].Spec.Containers = append(pipelines[0].Spec.Containers, v1alpha1.Container{
+				Name:            "another-container",
+				Image:           "another-image",
+				ImagePullPolicy: corev1.PullAlways,
+			})
+			resources := pipeline.NewDelete(rr, pipelines, "", "test-promise", "promises")
+			job := resources[3].(*batchv1.Job)
+
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(HaveLen(2), "imagePullSecrets should've been included")
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(ContainElements(
+				corev1.LocalObjectReference{Name: "test-secret"},
+				corev1.LocalObjectReference{Name: "another-secret"},
+			), "imagePullSecrets should've been included")
+			Expect(job.Spec.Template.Spec.InitContainers[1].ImagePullPolicy).To(BeEmpty())
+			Expect(job.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullAlways))
 		})
 	})
 })


### PR DESCRIPTION
This commit ensures that we pass through all the fields from the Kratix Pipeline object to the Pods that are created for a delete Job.