### PR TITLE
feat: add CRDs to 'kratix' category

### DIFF
--- a/api/v1alpha1/bucketstatestore_types.go
+++ b/api/v1alpha1/bucketstatestore_types.go
@@ -44,7 +44,7 @@ type BucketStateStoreStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster,path=bucketstatestores
+//+kubebuilder:resource:scope=Cluster,path=bucketstatestores,categories=kratix
 
 // BucketStateStore is the Schema for the bucketstatestores API
 type BucketStateStore struct {

--- a/api/v1alpha1/destination_types.go
+++ b/api/v1alpha1/destination_types.go
@@ -68,7 +68,7 @@ type DestinationStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster,path=destinations
+//+kubebuilder:resource:scope=Cluster,path=destinations,categories=kratix
 
 // Destination is the Schema for the Destinations API
 type Destination struct {

--- a/api/v1alpha1/gitstatestore_types.go
+++ b/api/v1alpha1/gitstatestore_types.go
@@ -50,7 +50,7 @@ type GitStateStoreStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster,path=gitstatestores
+//+kubebuilder:resource:scope=Cluster,path=gitstatestores,categories=kratix
 
 // GitStateStore is the Schema for the gitstatestores API
 type GitStateStore struct {

--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -139,7 +139,7 @@ type RequiredPromiseStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster,path=promises
+//+kubebuilder:resource:scope=Cluster,path=promises,categories=kratix
 //+kubebuilder:printcolumn:JSONPath=".status.status",name="Status",type=string
 //+kubebuilder:printcolumn:JSONPath=".status.kind",name=Kind,type=string
 //+kubebuilder:printcolumn:JSONPath=".status.apiVersion",name="API Version",type=string

--- a/api/v1alpha1/promiserelease_types.go
+++ b/api/v1alpha1/promiserelease_types.go
@@ -43,7 +43,7 @@ type PromiseReleaseStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster,path=promisereleases
+//+kubebuilder:resource:scope=Cluster,path=promisereleases,categories=kratix
 //+kubebuilder:printcolumn:JSONPath=".status.status",name="Status",type=string
 //+kubebuilder:printcolumn:JSONPath=".spec.version",name="Version",type=string
 

--- a/api/v1alpha1/work_types.go
+++ b/api/v1alpha1/work_types.go
@@ -43,6 +43,7 @@ type WorkStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:categories=kratix
 
 // Work is the Schema for the works API
 type Work struct {

--- a/api/v1alpha1/workplacement_types.go
+++ b/api/v1alpha1/workplacement_types.go
@@ -37,6 +37,7 @@ type WorkPlacementStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:categories=kratix
 
 // WorkPlacement is the Schema for the workplacements API
 type WorkPlacement struct {

--- a/config/crd/bases/platform.kratix.io_bucketstatestores.yaml
+++ b/config/crd/bases/platform.kratix.io_bucketstatestores.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: platform.kratix.io
   names:
+    categories:
+    - kratix
     kind: BucketStateStore
     listKind: BucketStateStoreList
     plural: bucketstatestores

--- a/config/crd/bases/platform.kratix.io_destinations.yaml
+++ b/config/crd/bases/platform.kratix.io_destinations.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: platform.kratix.io
   names:
+    categories:
+    - kratix
     kind: Destination
     listKind: DestinationList
     plural: destinations

--- a/config/crd/bases/platform.kratix.io_gitstatestores.yaml
+++ b/config/crd/bases/platform.kratix.io_gitstatestores.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: platform.kratix.io
   names:
+    categories:
+    - kratix
     kind: GitStateStore
     listKind: GitStateStoreList
     plural: gitstatestores

--- a/config/crd/bases/platform.kratix.io_promisereleases.yaml
+++ b/config/crd/bases/platform.kratix.io_promisereleases.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: platform.kratix.io
   names:
+    categories:
+    - kratix
     kind: PromiseRelease
     listKind: PromiseReleaseList
     plural: promisereleases

--- a/config/crd/bases/platform.kratix.io_promises.yaml
+++ b/config/crd/bases/platform.kratix.io_promises.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: platform.kratix.io
   names:
+    categories:
+    - kratix
     kind: Promise
     listKind: PromiseList
     plural: promises

--- a/config/crd/bases/platform.kratix.io_workplacements.yaml
+++ b/config/crd/bases/platform.kratix.io_workplacements.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: platform.kratix.io
   names:
+    categories:
+    - kratix
     kind: WorkPlacement
     listKind: WorkPlacementList
     plural: workplacements

--- a/config/crd/bases/platform.kratix.io_works.yaml
+++ b/config/crd/bases/platform.kratix.io_works.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: platform.kratix.io
   names:
+    categories:
+    - kratix
     kind: Work
     listKind: WorkList
     plural: works


### PR DESCRIPTION
Add CRDs to 'kratix' category, so all resources can be easily fetched with 'kubectl get kratix'. 

It's up to the team if including all CRDs is the desired way. We should discuss as a group before approving and merging this PR.

For example:
```
❯ k get kratix
NAME                                          AGE
bucketstatestore.platform.kratix.io/default   25m

NAME                                              AGE
destination.platform.kratix.io/platform-cluster   23m
destination.platform.kratix.io/worker-1           25m

NAME                                       AGE
gitstatestore.platform.kratix.io/default   25m

NAME                                 STATUS        KIND      API VERSION                      VERSION
promise.platform.kratix.io/easyapp   Unavailable   EasyApp   example.promise.syntasso.io/v1
promise.platform.kratix.io/jenkins   Available     jenkins   marketplace.kratix.io/v1alpha1
```