### PR TITLE
Git and minio configuration with quick-start

### DIFF
--- a/hack/platform/gitea-install.yaml
+++ b/hack/platform/gitea-install.yaml
@@ -921,19 +921,7 @@ spec:
           args:
             - init
             - --separate-git-dir=/repo/.git
-          volumeMounts:
-            - mountPath: /repo
-              name: repo
-        - name: branch
-          env:
-            - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
-              value: "true"
-          image: docker.io/alpine/git:2.36.3
-          args:
-            - --git-dir=/repo/.git
-            - branch
-            - -m
-            - main
+            - --initial-branch=main
           volumeMounts:
             - mountPath: /repo
               name: repo
@@ -951,23 +939,46 @@ spec:
             - commit
             - --allow-empty
             - -m
-            - "Kratix creating demo repo"
+            - "Kratix verify demo repo exists"
+          volumeMounts:
+            - mountPath: /repo
+              name: repo
+        - name: pull-rebase
+          # Note: this makes us more resilient if the repo already exists.
+          image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+          env:
+            - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
+              value: "true"
+          command:
+            - "sh"
+            - "-c"
+            - |
+              exit_code=$(git -c http.sslVerify=false ls-remote https://gitea_admin:r8sA8CPHD9!bt6d@gitea-http.gitea.svc.cluster.local/gitea_admin/kratix.git > /dev/null 2>&1 && echo $?)
+              if [ $exit_code -eq 0 ]; then
+                touch /repo/.already-exists
+              else
+                echo "remote repo does not yet exist, continuing with push"
+              fi
           volumeMounts:
             - mountPath: /repo
               name: repo
       containers:
         - name: push
-          image: docker.io/alpine/git:2.36.3
-          args:
-            - --git-dir=/repo/.git
-            - -c
-            - http.sslVerify=false
-            - push
-            - https://gitea_admin:r8sA8CPHD9!bt6d@gitea-http.gitea.svc.cluster.local/gitea_admin/kratix.git
-            - --all
+          # Note: this makes us more resilient if the repo already exists.
+          image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
           env:
             - name: GIT_DISCOVERY_ACROSS_FILESYSTEM
               value: "true"
+          command:
+            - "sh"
+            - "-c"
+            - |
+              if [ -f /repo/.already-exists ]; then
+                echo "remote repo already exists, skipping push"
+                exit 0
+              fi
+              git --git-dir=/repo/.git -c http.sslVerify=false \
+                push https://gitea_admin:r8sA8CPHD9!bt6d@gitea-http.gitea.svc.cluster.local/gitea_admin/kratix.git --all
           volumeMounts:
             - mountPath: /repo
               name: repo

--- a/scripts/install-gitops
+++ b/scripts/install-gitops
@@ -53,11 +53,12 @@ load_options() {
 }
 
 patch_kind_networking() {
+    local file_name=$1
     if [[ "${CONTEXT}" =~ ^kind-.* ]]; then
         PLATFORM_DESTINATION_IP=`docker inspect platform-control-plane | grep '"IPAddress": "172' | awk -F '"' '{print $4}'`
-        sed "s/172.18.0.2/${PLATFORM_DESTINATION_IP}/g" ${resource_file}
+        sed "s/172.18.0.2/${PLATFORM_DESTINATION_IP}/g" ${file_name}
     else
-        cat "${resource_file}"
+        cat "${file_name}"
     fi
 }
 
@@ -80,7 +81,7 @@ install_gitops() {
     # install flux crds
     kubectl --context "${CONTEXT}" apply --filename ${ROOT}/hack/destination/gitops-tk-install.yaml
 
-    patch_kind_networking | patch_flux_resources | kubectl --context "${CONTEXT}" apply --filename -
+    patch_kind_networking $resource_file | patch_flux_resources | kubectl --context "${CONTEXT}" apply --filename -
 }
 
 main() {

--- a/scripts/install-gitops
+++ b/scripts/install-gitops
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
+source "${ROOT}/scripts/utils.sh"
 
 set -euo pipefail
 cd $ROOT
@@ -71,7 +72,10 @@ install_gitops() {
     CONTEXT="${CONTEXT:-$1}"
     BUCKET_PATH="${BUCKET_PATH:-$2}"
     resource_file=${ROOT}/hack/destination/gitops-tk-resources.yaml
-    if [ ${WORKER_STATESTORE_TYPE} = "GitStateStore" ]; then resource_file=${ROOT}/hack/destination/gitops-tk-resources-git.yaml; fi
+    if [ ${WORKER_STATESTORE_TYPE} = "GitStateStore" ]; then
+        resource_file=${ROOT}/hack/destination/gitops-tk-resources-git.yaml;
+        copy_gitea_credentials kind-platform ${CONTEXT} flux-system
+    fi
 
     # install flux crds
     kubectl --context "${CONTEXT}" apply --filename ${ROOT}/hack/destination/gitops-tk-install.yaml

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -220,7 +220,7 @@ setup_platform_destination() {
 
 setup_worker_destination() {
     if ${INSTALL_AND_CREATE_GITEA_REPO}; then
-       cat "${ROOT}/config/samples/platform_v1alpha1_gitstatestore.yaml" | sed "s/172.18.0.2/$(platform_destination_ip)/g" | kubectl --context kind-platform apply -f -
+        cat "${ROOT}/config/samples/platform_v1alpha1_gitstatestore.yaml" | sed "s/172.18.0.2/$(platform_destination_ip)/g" | kubectl --context kind-platform apply -f -
     fi
 
     if ${INSTALL_AND_CREATE_MINIO_BUCKET}; then
@@ -273,10 +273,12 @@ wait_for_local_repository() {
     fi
 
     if ${INSTALL_AND_CREATE_GITEA_REPO}; then
+        log "\nwaiting for gitea..."
         wait_for_gitea ${wait_opts}
     fi
 
     if ${INSTALL_AND_CREATE_MINIO_BUCKET}; then
+        log "\nwaiting for minio..."
         wait_for_minio ${wait_opts}
     fi
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -108,7 +108,7 @@ run() {
     wait $pid
     exit_code="$?"
 
-    if [ "$exit_code" -eq "0" ]; then
+    if [ "$exit_code" -eq "0" ] && ! ${SUPRESS_OUTPUT}; then
         success_mark
     else
         if ! ${SUPRESS_OUTPUT}; then

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -49,7 +49,8 @@ generate_gitea_credentials() {
         --from-file=privateKey=${ROOT}/key.pem \
         --from-literal=username="gitea_admin" \
         --from-literal=password="r8sA8CPHD9!bt6d" \
-        --namespace=gitea
+        --namespace=gitea \
+        --dry-run=client -o yaml | kubectl apply --context ${context} -f -
 
     kubectl create secret generic gitea-credentials \
         --context "${context}" \
@@ -57,7 +58,8 @@ generate_gitea_credentials() {
         --from-file=privateKey=${ROOT}/key.pem \
         --from-literal=username="gitea_admin" \
         --from-literal=password="r8sA8CPHD9!bt6d" \
-        --namespace=default
+        --namespace=default \
+        --dry-run=client -o yaml | kubectl apply --context ${context} -f -
 
     kubectl create namespace flux-system --context ${context} || true
     kubectl create secret generic gitea-credentials \
@@ -66,7 +68,8 @@ generate_gitea_credentials() {
         --from-file=privateKey=${ROOT}/key.pem \
         --from-literal=username="gitea_admin" \
         --from-literal=password="r8sA8CPHD9!bt6d" \
-        --namespace=flux-system
+        --namespace=flux-system \
+        --dry-run=client -o yaml | kubectl apply --context ${context} -f -
 
     rm ${ROOT}/cert.pem ${ROOT}/key.pem
 }


### PR DESCRIPTION
There are a few commits here, but the fix is that the secrets were not properly created for git. That is fixed in the `install-gitops` script.

Note that this work uncovered that the quick-start must be run with --git-and-minio to work with backstage config. That is out of scope for this work, but is something we may want to untangle in the future.

closes #112 