### PR TITLE
feat: Set observed generation in resource requests

### DIFF
--- a/controllers/dynamic_resource_request_controller.go
+++ b/controllers/dynamic_resource_request_controller.go
@@ -193,8 +193,13 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	if requeue {
 		return defaultRequeue, nil
 	}
-	return ctrl.Result{}, nil
 
+	if rr.GetGeneration() != resourceutil.GetObservedGeneration(rr) {
+		resourceutil.SetStatus(rr, logger, "observedGeneration", rr.GetGeneration())
+		return ctrl.Result{}, opts.client.Status().Update(opts.ctx, rr)
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *DynamicResourceRequestController) deleteResources(o opts, resourceRequest *unstructured.Unstructured, resourceRequestIdentifier string) (ctrl.Result, error) {

--- a/controllers/dynamic_resource_request_controller_test.go
+++ b/controllers/dynamic_resource_request_controller_test.go
@@ -188,7 +188,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 
 			By("finishing the creation once the job is finished", func() {
 				setReconcileConfigureWorkflowToReturnFinished()
-				result, err := t.reconcileUntilCompletion(reconciler, promise)
+				result, err := t.reconcileUntilCompletion(reconciler, resReq)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))

--- a/controllers/dynamic_resource_request_controller_test.go
+++ b/controllers/dynamic_resource_request_controller_test.go
@@ -103,6 +103,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 		}
 		Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
 		resReq.SetUID("1234abcd")
+		resReq.SetGeneration(1)
 		Expect(fakeK8sClient.Update(ctx, resReq)).To(Succeed())
 		Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
 
@@ -117,7 +118,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 	})
 
 	When("resource is being created", func() {
-		It("re-reconciles until completetion", func() {
+		It("re-reconciles until completion", func() {
 			_, err := t.reconcileUntilCompletion(reconciler, resReq)
 			Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
 
@@ -209,6 +210,14 @@ var _ = Describe("DynamicResourceRequestController", func() {
 						"non-kratix-label":       "true",
 					},
 				))
+			})
+
+			By("setting the observedGeneration in the resource status", func() {
+				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+				status := resReq.Object["status"]
+				Expect(status).NotTo(BeNil())
+				statusMap := status.(map[string]interface{})
+				Expect(statusMap["observedGeneration"]).To(Equal(int64(1)))
 			})
 		})
 

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -951,6 +951,10 @@ func setStatusFieldsOnCRD(rrCRD *apiextensionsv1.CustomResourceDefinition) {
 				"message": {
 					Type: "string",
 				},
+				"observedGeneration": {
+					Type:   "integer",
+					Format: "int64",
+				},
 				"conditions": {
 					Type: "array",
 					Items: &apiextensionsv1.JSONSchemaPropsOrArray{

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -199,6 +199,20 @@ func GetStatus(rr *unstructured.Unstructured, key string) string {
 	return nestedMap[key].(string)
 }
 
+// GetObservedGeneration returns 0 when either status or status.observedGeneration is nil
+func GetObservedGeneration(rr *unstructured.Unstructured) int64 {
+	if rr.Object["status"] == nil {
+		return 0
+	}
+
+	nestedMap := rr.Object["status"].(map[string]interface{})
+	if nestedMap["observedGeneration"] == nil {
+		return 0
+	}
+
+	return nestedMap["observedGeneration"].(int64)
+}
+
 func GetResourceNames(items []unstructured.Unstructured) []string {
 	var names []string
 	for _, item := range items {

--- a/lib/resourceutil/util_test.go
+++ b/lib/resourceutil/util_test.go
@@ -323,19 +323,64 @@ var _ = Describe("Conditions", func() {
 	})
 
 	Describe("SetStatus", func() {
-		It("sets the status of a resource", func() {
-			rr = &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-			}
-			resourceutil.SetStatus(rr, logger, "test", "val")
+		var rr *unstructured.Unstructured
 
-			Expect(rr.Object).To(HaveKey("status"))
-			Expect(rr.Object["status"]).To(HaveKeyWithValue("foo", "bar"))
-			Expect(rr.Object["status"]).To(HaveKeyWithValue("test", "val"))
+		When("there is an existing status", func() {
+			BeforeEach(func() {
+				rr = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				}
+			})
+
+			It("sets the status of a resource", func() {
+				resourceutil.SetStatus(rr, logger, "test", "val", "key1", int64(1))
+				Expect(rr.Object).To(HaveKey("status"))
+				Expect(rr.Object["status"]).To(HaveKeyWithValue("foo", "bar"))
+				Expect(rr.Object["status"]).To(HaveKeyWithValue("test", "val"))
+				Expect(rr.Object["status"]).To(HaveKeyWithValue("key1", int64(1)))
+			})
+
+			When("a non-string key is provided", func() {
+				It("does not set that key/value pair", func() {
+					resourceutil.SetStatus(rr, logger, 1, "val")
+					Expect(rr.Object).To(HaveKey("status"))
+					Expect(rr.Object["status"]).To(Equal(map[string]interface{}{"foo": "bar"}))
+				})
+			})
+
+			When("an odd number of arguments is provided", func() {
+				It("does not set any new key/value pairs", func() {
+					resourceutil.SetStatus(rr, logger, "key1", "value1", "key2")
+					Expect(rr.Object).To(HaveKey("status"))
+					Expect(rr.Object["status"]).To(Equal(map[string]interface{}{"foo": "bar"}))
+				})
+			})
+		})
+
+		When("there is no existing status", func() {
+			BeforeEach(func() {
+				rr = &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				}
+			})
+
+			It("sets the status of a resource", func() {
+				resourceutil.SetStatus(rr, logger, "test", "val", "key1", int64(1))
+				Expect(rr.Object).To(HaveKey("status"))
+				Expect(rr.Object["status"]).To(HaveKeyWithValue("test", "val"))
+				Expect(rr.Object["status"]).To(HaveKeyWithValue("key1", int64(1)))
+			})
+
+			When("there are no valid status key/value pairs", func() {
+				It("does not set status", func() {
+					resourceutil.SetStatus(rr, logger, 1, "val")
+					Expect(rr.Object).NotTo(HaveKey("status"))
+				})
+			})
 		})
 	})
 })

--- a/lib/resourceutil/util_test.go
+++ b/lib/resourceutil/util_test.go
@@ -383,4 +383,50 @@ var _ = Describe("Conditions", func() {
 			})
 		})
 	})
+
+	Describe("GetObservedGeneration", func() {
+		var rr *unstructured.Unstructured
+
+		When("status is nil", func() {
+			BeforeEach(func() {
+				rr = &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				}
+			})
+
+			It("returns 0", func() {
+				Expect(resourceutil.GetObservedGeneration(rr)).To(Equal(int64(0)))
+			})
+		})
+
+		When("status.observedGeneration is nil", func() {
+			BeforeEach(func() {
+				rr = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{},
+					},
+				}
+			})
+
+			It("returns 0", func() {
+				Expect(resourceutil.GetObservedGeneration(rr)).To(Equal(int64(0)))
+			})
+		})
+
+		When("status.observedGeneration is set", func() {
+			BeforeEach(func() {
+				rr = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"observedGeneration": int64(1),
+						},
+					},
+				}
+			})
+
+			It("returns the observedGeneration", func() {
+				Expect(resourceutil.GetObservedGeneration(rr)).To(Equal(int64(1)))
+			})
+		})
+	})
 })

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -336,6 +336,10 @@ var _ = Describe("Kratix", func() {
 					Eventually(func() string {
 						return platform.kubectl("get", bashPromiseName, rrName, "-o", "jsonpath='{.status.key}'")
 					}, timeout, interval).Should(ContainSubstring("value"))
+					generation := platform.kubectl("get", bashPromiseName, rrName, "-o", "jsonpath='{.metadata.generation}'")
+					Eventually(func() string {
+						return platform.kubectl("get", bashPromiseName, rrName, "-o", "jsonpath='{.status.observedGeneration}'")
+					}, timeout, interval).Should(Equal(generation))
 				})
 
 				newRRDeclarativePlatformNamespace := "declarative-platform-only-" + rrName + "-new"

--- a/work-creator/scripts/reader
+++ b/work-creator/scripts/reader
@@ -5,10 +5,3 @@ set -euxo pipefail
 kubectl get $OBJECT_KIND.$OBJECT_GROUP/$OBJECT_NAME --namespace $OBJECT_NAMESPACE  -oyaml > /kratix/input/object.yaml
 echo "Object have been written to /kratix/input/object.yaml. Head is:"
 head -n 50 /kratix/input/object.yaml
-
-# if [ $KRATIX_WORKFLOW_TYPE == "promise" ] && [ "$(yq '.spec | has("dependencies")' /kratix/input/object.yaml)" == "true" ]; then
-	#   mkdir -p /kratix/output/static/
-	# 	yq '.spec.dependencies[] | split_doc' /kratix/input/object.yaml > /kratix/output/static/dependencies.yaml
-	# 	echo "Dependencies have been written to /kratix/output/static/dependencies.yaml. Head is:"
-	# 	head -n 50 /kratix/output/static/dependencies.yaml
-# fi


### PR DESCRIPTION
We now show `Observed Generation` in the resource status.

closes #109

### Example

```
  > k get data.marketplace.kratix.io my-resource -o yaml
apiVersion: marketplace.kratix.io/v1alpha1
kind: data
metadata:
  ...
  generation: 1
  name: my-resource
  namespace: default
spec:
  value: abc
status:
  conditions:
  - lastTransitionTime: "2024-05-03T14:04:27Z"
    message: Pipeline completed
    reason: PipelineExecutedSuccessfully
    status: "True"
    type: PipelineCompleted
  message: Resource requested
  observedGeneration: 1
```