### PR TITLE
fix: don't create an empty static-deps work when no static dependencies exist

### DIFF
--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -354,9 +354,11 @@ func (r *PromiseReconciler) generateStatusAndMarkRequirements(ctx context.Contex
 
 func (r *PromiseReconciler) reconcileDependencies(o opts, promise *v1alpha1.Promise, configurePipeline []v1alpha1.Pipeline) (*ctrl.Result, error) {
 	o.logger.Info("Applying static dependencies for Promise", "promise", promise.GetName())
-	if err := r.applyWorkForDependencies(o, promise); err != nil {
-		o.logger.Error(err, "Error creating Works")
-		return nil, err
+	if len(promise.Spec.Dependencies) > 0 {
+		if err := r.applyWorkForDependencies(o, promise); err != nil {
+			o.logger.Error(err, "Error creating Works")
+			return nil, err
+		}
 	}
 	if len(configurePipeline) == 0 {
 		return nil, nil

--- a/controllers/promise_controller_test.go
+++ b/controllers/promise_controller_test.go
@@ -475,6 +475,12 @@ var _ = Describe("PromiseController", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(result).To(Equal(ctrl.Result{}))
 					})
+
+					By("not creating a Work for the empty static dependencies", func() {
+						works := &v1alpha1.WorkList{}
+						Expect(fakeK8sClient.List(ctx, works)).To(Succeed())
+						Expect(works.Items).To(HaveLen(0))
+					})
 				})
 			})
 
@@ -585,7 +591,7 @@ var _ = Describe("PromiseController", func() {
 					Expect(fakeK8sClient.List(ctx, serviceAccounts)).To(Succeed())
 					Expect(clusterRoles.Items).To(HaveLen(1))
 					Expect(clusterRoleBindings.Items).To(HaveLen(1))
-					Expect(works.Items).To(HaveLen(1))
+					Expect(works.Items).To(HaveLen(0))
 					Expect(jobs.Items).To(HaveLen(0))
 					Expect(serviceAccounts.Items).To(HaveLen(0))
 


### PR DESCRIPTION
Before a promise that has no static dependencies would still create an empty work:
```
apiVersion: platform.kratix.io/v1alpha1
kind: Promise
metadata:
  creationTimestamp: null
  name: redis
  namespace: default
  labels:
    kratix.io/promise-version: v0.1.0
spec:
  api:
   ...
  workflows:
    resource:
      configure:
        - apiVersion: platform.kratix.io/v1alpha1
          kind: Pipeline
          metadata:
            name: instance-configure
            namespace: default
          spec:
            containers:
              - image: ghcr.io/syntasso/kratix-marketplace/redis-configure-pipeline:v0.1.0
                name: redis-configure-pipeline
    promise:
      configure:
        - apiVersion: platform.kratix.io/v1alpha1
          kind: Pipeline
          metadata:
            name: promise-configure
            namespace: default
          spec:
            containers:
              - image: ghcr.io/syntasso/kratix-marketplace/redis-configure-pipeline:v0.1.0
                name: redis-configure-pipeline
```

```
kaf ~/workspace/kratix-marketplace/redis/promise.yaml
promise.platform.kratix.io/redis created

k get works -A
NAMESPACE                NAME                      AGE
kratix-platform-system   redis-845c8               4s
kratix-platform-system   redis-static-deps-5dd1e   6s
(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [16:46:14] [~/workspace/kratix] [dev]
-> % k -n kratix-platform-system get work redis-static-deps-5dd1e -o yaml
apiVersion: platform.kratix.io/v1alpha1
kind: Work
metadata:
  creationTimestamp: "2024-05-10T15:46:03Z"
  generation: 1
  labels:
    kratix-promise-id: redis
    kratix.io/promise-name: redis
    kratix.io/work-type: static-dependency
  name: redis-static-deps-5dd1e
  namespace: kratix-platform-system
  resourceVersion: "38616"
  uid: ba0e88b5-0729-41f2-be68-5ee16c481cc8
spec:
  promiseName: redis
  replicas: -1
  workloadGroups:
  - directory: .
    id: 5058f1af8388633f609cadb75a75dc9d
    workloads:
    - filepath: static/dependencies.yaml

```

Now it doesn't:
```
kaf ~/workspace/kratix-marketplace/redis/promise.yaml
promise.platform.kratix.io/redis created

k get works -A
NAMESPACE                NAME          AGE
kratix-platform-system   redis-e7ff1   6s

```