### PR TITLE
Remove dev branch as gate to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,7 +449,7 @@ workflows:
           cron: "0 0 * * 1"
           filters:
             branches:
-              only: [dev]
+              only: [main]
     jobs:
       - clone-kratix
       - generate-demo-image-list:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,20 +313,20 @@ jobs:
           command: |
             ./scripts/build-images << parameters.image >>
 
-  git-push-to-dev:
+  git-push-to-main:
     executor: machine-medium
     steps:
       - attach_workspace:
           at: .
       - setup_git
       - run:
-          name: Push dev
+          name: Push main
           command: |
             git add -f demo/
             # below command exits 0 when nothing is added
             git diff --cached --quiet && exit 0 || true
             git commit -m"update demo image list"
-            git push origin dev
+            git push origin main
 
   generate-release-distribution:
     executor: machine-medium
@@ -454,7 +454,7 @@ workflows:
       - clone-kratix
       - generate-demo-image-list:
           requires: [clone-kratix]
-      - git-push-to-dev:
+      - git-push-to-main:
           requires: [generate-demo-image-list]
 
   security-scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,23 +276,6 @@ jobs:
           command: |
             ./scripts/install-jenkins.sh
 
-  git-merge-and-push:
-    executor: machine-medium
-    steps:
-      - install_software
-      - setup_git
-      - run:
-          name: Merge dev to main
-          command: |
-            git checkout main
-            git merge --no-ff --no-edit dev
-            git push origin main
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-
   generate-demo-image-list:
     executor: machine-large
     steps:
@@ -427,16 +410,6 @@ workflows:
           requires: [clone-kratix, clone-helm-charts]
       - e2e-demo-test-helm-git:
           requires: [clone-kratix, clone-helm-charts]
-      ### ONLY DEV
-      - git-merge-and-push:
-          requires:
-            - test
-            - e2e-demo-test-helm-git
-            - e2e-demo-test-helm-bucket
-          filters:
-            branches:
-              only: dev
-      ### END ONLY DEV
       ### ONLY MAIN
       - tag-new-version:
           requires:


### PR DESCRIPTION
Originally we used the dev branch as a way to mitigate risk against breaking users with changes. This was before we had introduced the release process which is itself a safety gate for this.

This change removes the dev branch from the CI process, enabling engineers to open PRs directly against main branch. 

Note that this does not change the GitHub settings so main continues to be the "default" branch:
<img width="800" alt="image" src="https://github.com/syntasso/kratix/assets/1557346/8124970e-cd4f-4c28-8e74-0c999115902f">

And we will continue to have branch protection rules on `main` which means only Kratix maintainers can push directly to that branch.