### PR TITLE
fix(#145): delete work for static deps

### DIFF
--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -353,13 +353,21 @@ func (r *PromiseReconciler) generateStatusAndMarkRequirements(ctx context.Contex
 }
 
 func (r *PromiseReconciler) reconcileDependencies(o opts, promise *v1alpha1.Promise, configurePipeline []v1alpha1.Pipeline) (*ctrl.Result, error) {
-	o.logger.Info("Applying static dependencies for Promise", "promise", promise.GetName())
 	if len(promise.Spec.Dependencies) > 0 {
-		if err := r.applyWorkForDependencies(o, promise); err != nil {
+		o.logger.Info("Applying static dependencies for Promise", "promise", promise.GetName())
+		if err := r.applyWorkForStaticDependencies(o, promise); err != nil {
 			o.logger.Error(err, "Error creating Works")
 			return nil, err
 		}
 	}
+
+	if len(promise.Spec.Dependencies) == 0 {
+		err := r.deleteWorkForStaticDependencies(o, promise)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if len(configurePipeline) == 0 {
 		return nil, nil
 	}
@@ -990,7 +998,7 @@ func setStatusFieldsOnCRD(rrCRD *apiextensionsv1.CustomResourceDefinition) {
 	}
 }
 
-func (r *PromiseReconciler) applyWorkForDependencies(o opts, promise *v1alpha1.Promise) error {
+func (r *PromiseReconciler) applyWorkForStaticDependencies(o opts, promise *v1alpha1.Promise) error {
 	name := resourceutil.GenerateObjectName(promise.GetName() + "-static-deps")
 	work, err := v1alpha1.NewPromiseDependenciesWork(promise, name)
 	if err != nil {
@@ -1019,6 +1027,20 @@ func (r *PromiseReconciler) applyWorkForDependencies(o opts, promise *v1alpha1.P
 
 	o.logger.Info("resource reconciled", "operation", op, "namespace", work.GetNamespace(), "name", work.GetName(), "gvk", work.GroupVersionKind())
 	return nil
+}
+
+func (r *PromiseReconciler) deleteWorkForStaticDependencies(o opts, promise *v1alpha1.Promise) error {
+	existingWork, err := resourceutil.GetWorkForStaticDependencies(r.Client, v1alpha1.SystemNamespace, promise.GetName())
+	if err != nil {
+		return err
+	}
+
+	if existingWork == nil {
+		return nil
+	}
+
+	o.logger.Info("deleting work for static dependencies", "namespace", existingWork.GetNamespace(), "name", existingWork.GetName())
+	return r.Client.Delete(o.ctx, existingWork)
 }
 
 func (r *PromiseReconciler) markRequiredPromiseAsRequired(ctx context.Context, version string, promise, requiredPromise *v1alpha1.Promise) {


### PR DESCRIPTION
This PR ensures that we delete the Work for static dependencies when the Promise `spec.dependencies` is removed during an update to the Promise.

fixes #145