### PR TITLE
fix: read .kratix with correct path at deletion

### DIFF
--- a/test/system/assets/git/destinations.yaml
+++ b/test/system/assets/git/destinations.yaml
@@ -13,12 +13,26 @@ spec:
 apiVersion: platform.kratix.io/v1alpha1
 kind: Destination
 metadata:
-  name: terraform
+  name: filepathmode-none-bucket
   labels:
-    environment: terraform
+    environment: filepathmode-none
+    type: bucket
 spec:
   filepath:
     mode: none
   stateStoreRef:
     name: default
     kind: BucketStateStore
+---
+apiVersion: platform.kratix.io/v1alpha1
+kind: Destination
+metadata:
+  name: filepathmode-none-git
+  labels:
+    environment: filepathmode-none
+spec:
+  filepath:
+    mode: none
+  stateStoreRef:
+    name: default
+    kind: GitStateStore

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -930,9 +931,8 @@ func (c destination) withExitCode(code int) destination {
 }
 
 func listFilesInGitStateStore(subDir string) []string {
-	dir, err := os.MkdirTemp("", "kratix-test-repo")
+	dir, err := os.MkdirTemp(testTempDir, "git-state-store")
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	defer os.RemoveAll(filepath.Dir(dir))
 
 	_, err = git.PlainClone(dir, false, &git.CloneOptions{
 		Auth: &http.BasicAuth{

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -686,7 +689,7 @@ var _ = Describe("Kratix", func() {
 		It("manages output files from multiple resource requests", func() {
 			bashPromise.Spec.DestinationSelectors = []v1alpha1.PromiseScheduling{{
 				MatchLabels: map[string]string{
-					"environment": "terraform",
+					"environment": "filepathmode-none",
 				},
 			}}
 
@@ -698,22 +701,40 @@ var _ = Describe("Kratix", func() {
 			platform.kubectl("apply", "-f", terraformRequest(rrNameTwo))
 
 			By("writing output files to the root of stateStore")
-			destinationName := "terraform"
+			promiseDestName := "filepathmode-none-git"
 			Eventually(func() []string {
-				return listFilesInMinIOStateStore(destinationName)
+				return listFilesInGitStateStore(promiseDestName)
+			}, shortTimeout, interval).Should(ContainElements("configmap.yaml"))
+
+			resourceDestName := "filepathmode-none-bucket"
+			Eventually(func() []string {
+				return listFilesInMinIOStateStore(resourceDestName)
 			}, shortTimeout, interval).Should(ContainElements(
+				"configmap.yaml",
 				fmt.Sprintf("%s.yaml", rrNameOne),
 				fmt.Sprintf("%s.yaml", rrNameTwo)))
 
 			By("removing only files associated with the resource request at deletion")
 			platform.kubectl("delete", crd.Name, rrNameOne)
 			Eventually(func() []string {
-				return listFilesInMinIOStateStore(destinationName)
+				return listFilesInMinIOStateStore(resourceDestName)
 			}, shortTimeout, interval).ShouldNot(ContainElements(
 				fmt.Sprintf("%s.yaml", rrNameOne)))
-			Expect(listFilesInMinIOStateStore(destinationName)).To(ContainElements(fmt.Sprintf("%s.yaml", rrNameTwo)))
+			Expect(listFilesInMinIOStateStore(resourceDestName)).To(ContainElements(fmt.Sprintf("%s.yaml", rrNameTwo)))
 
+			By("cleaning up files from state store at deletion")
 			platform.eventuallyKubectlDelete("promise", bashPromiseName)
+			Eventually(func() []string {
+				return listFilesInGitStateStore(promiseDestName)
+			}, shortTimeout, interval).ShouldNot(ContainElements("configmap.yaml", ".kratix/"))
+
+			Eventually(func() []string {
+				return listFilesInMinIOStateStore(resourceDestName)
+			}, shortTimeout, interval).ShouldNot(ContainElements(
+				"configmap.yaml",
+				".kratix/",
+				fmt.Sprintf("%s.yaml", rrNameOne),
+				fmt.Sprintf("%s.yaml", rrNameTwo)))
 		})
 	})
 })
@@ -729,6 +750,7 @@ func terraformRequest(name string) string {
 			"spec": map[string]interface{}{
 				"container0Cmd": fmt.Sprintf(`
 					touch /kratix/output/%s.yaml
+					echo "[{\"matchLabels\":{\"type\":\"bucket\"}}]" > /kratix/metadata/destination-selectors.yaml
 			`, name),
 				"container1Cmd": "exit 0",
 			},
@@ -905,6 +927,38 @@ func (c destination) withExitCode(code int) destination {
 	newDestination := c.clone()
 	newDestination.exitCode = code
 	return newDestination
+}
+
+func listFilesInGitStateStore(subDir string) []string {
+	dir, err := os.MkdirTemp("", "kratix-test-repo")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	defer os.RemoveAll(filepath.Dir(dir))
+
+	_, err = git.PlainClone(dir, false, &git.CloneOptions{
+		Auth: &http.BasicAuth{
+			Username: "gitea_admin",
+			Password: "r8sA8CPHD9!bt6d",
+		},
+		URL:             "https://localhost:31333/gitea_admin/kratix",
+		ReferenceName:   plumbing.NewBranchReferenceName("main"),
+		SingleBranch:    true,
+		Depth:           1,
+		NoCheckout:      false,
+		InsecureSkipTLS: true,
+	})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	var paths []string
+	absoluteDir := filepath.Join(dir, subDir)
+	err = filepath.Walk(absoluteDir, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			path, err := filepath.Rel(absoluteDir, path)
+			Expect(err).NotTo(HaveOccurred())
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return paths
 }
 
 func listFilesInMinIOStateStore(path string) []string {


### PR DESCRIPTION
Closes #163

- read .kratix state file correctly at deletion and update for git state store
- test `filepath.mode: none` for git state store in system test