### PR TITLE
Clearer pipeline visibility

### DIFF
--- a/lib/pipeline/args.go
+++ b/lib/pipeline/args.go
@@ -11,8 +11,8 @@ func NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, pName, name, 
 	}
 
 	names := map[string]string{
-		"configure-pipeline-name": pipelineName(promiseIdentifier, resourceRequestIdentifier, pName),
-		"delete-pipeline-name":    pipelineName(promiseIdentifier, resourceRequestIdentifier, pName),
+		"configure-pipeline-name": pipelineName(promiseIdentifier, resourceRequestIdentifier, name, pName),
+		"delete-pipeline-name":    pipelineName(promiseIdentifier, resourceRequestIdentifier, name, pName),
 		"promise-id":              promiseIdentifier,
 		"service-account":         pipelineID,
 		"role":                    pipelineID,

--- a/lib/pipeline/args.go
+++ b/lib/pipeline/args.go
@@ -11,8 +11,8 @@ func NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, pName, name, 
 	}
 
 	names := map[string]string{
-		"configure-pipeline-name": pipelineName("configure", promiseIdentifier),
-		"delete-pipeline-name":    pipelineName("delete", promiseIdentifier),
+		"configure-pipeline-name": pipelineName(promiseIdentifier, resourceRequestIdentifier, pName),
+		"delete-pipeline-name":    pipelineName(promiseIdentifier, resourceRequestIdentifier, pName),
 		"promise-id":              promiseIdentifier,
 		"service-account":         pipelineID,
 		"role":                    pipelineID,

--- a/lib/pipeline/args.go
+++ b/lib/pipeline/args.go
@@ -4,15 +4,15 @@ type PipelineArgs struct {
 	names map[string]string
 }
 
-func NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, pName, name, namespace string) PipelineArgs {
+func NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, pName, objectName, namespace string) PipelineArgs {
 	pipelineID := promiseIdentifier + "-promise-pipeline"
 	if resourceRequestIdentifier != "" {
 		pipelineID = promiseIdentifier + "-resource-pipeline"
 	}
 
 	names := map[string]string{
-		"configure-pipeline-name": pipelineName(promiseIdentifier, resourceRequestIdentifier, name, pName),
-		"delete-pipeline-name":    pipelineName(promiseIdentifier, resourceRequestIdentifier, name, pName),
+		"configure-pipeline-name": pipelineName(promiseIdentifier, resourceRequestIdentifier, objectName, pName),
+		"delete-pipeline-name":    pipelineName(promiseIdentifier, resourceRequestIdentifier, objectName, pName),
 		"promise-id":              promiseIdentifier,
 		"service-account":         pipelineID,
 		"role":                    pipelineID,
@@ -21,7 +21,7 @@ func NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, pName, name, 
 		"resource-request-id":     resourceRequestIdentifier,
 		"namespace":               namespace,
 		"pipeline-name":           pName,
-		"name":                    name,
+		"name":                    objectName,
 	}
 
 	return PipelineArgs{

--- a/lib/pipeline/configure.go
+++ b/lib/pipeline/configure.go
@@ -28,7 +28,7 @@ func NewConfigureResource(
 	logger logr.Logger,
 ) ([]client.Object, error) {
 
-	pipelineResources := NewPipelineArgs(promiseIdentifier, rr.GetName(), pipeline.Name, rr.GetName(), rr.GetNamespace())
+	pipelineResources := NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, pipeline.Name, rr.GetName(), rr.GetNamespace())
 	destinationSelectorsConfigMap, err := destinationSelectorsConfigMap(pipelineResources, promiseDestinationSelectors, nil)
 	if err != nil {
 		return nil, err

--- a/lib/pipeline/configure.go
+++ b/lib/pipeline/configure.go
@@ -28,7 +28,7 @@ func NewConfigureResource(
 	logger logr.Logger,
 ) ([]client.Object, error) {
 
-	pipelineResources := NewPipelineArgs(promiseIdentifier, resourceRequestIdentifier, pipeline.Name, rr.GetName(), rr.GetNamespace())
+	pipelineResources := NewPipelineArgs(promiseIdentifier, rr.GetName(), pipeline.Name, rr.GetName(), rr.GetNamespace())
 	destinationSelectorsConfigMap, err := destinationSelectorsConfigMap(pipelineResources, promiseDestinationSelectors, nil)
 	if err != nil {
 		return nil, err

--- a/lib/pipeline/configure_test.go
+++ b/lib/pipeline/configure_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+
 	"github.com/syntasso/kratix/api/v1alpha1"
 	"github.com/syntasso/kratix/lib/pipeline"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,6 +23,9 @@ var _ = Describe("Configure Pipeline", func() {
 		p                 v1alpha1.Pipeline
 		pipelineResources pipeline.PipelineArgs
 		logger            logr.Logger
+		job               *batchv1.Job
+		err               error
+		labelsMatcher     types.GomegaMatcher
 	)
 
 	BeforeEach(func() {
@@ -48,17 +55,34 @@ var _ = Describe("Configure Pipeline", func() {
 		}
 		logger = logr.Logger{}
 
-		pipelineResources = pipeline.NewPipelineArgs("test-promise", "test-resource-request", "configure-step", "test-name", "test-namespace")
+		pipelineResources = pipeline.NewPipelineArgs("test-promise", "", "configure-step", "test-name", "test-namespace")
 	})
 
-	Describe("Pipeline Request Hash", func() {
+	Describe("Promise", func() {
 		const expectedHash = "9bb58f26192e4ba00f01e2e7b136bbd8"
-
-		It("is included as a label to the pipeline job", func() {
-			job, err := pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
+		BeforeEach(func() {
+			job, err = pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(job.Labels).To(HaveKeyWithValue("kratix.io/hash", expectedHash))
+			labelsMatcher = MatchAllKeys(Keys{
+				"kratix.io/hash":                  Equal(expectedHash),
+				"kratix-workflow-action":          Equal("configure"),
+				"kratix-workflow-pipeline-name":   Equal("configure-step"),
+				"kratix.io/pipeline-name":         Equal("configure-step"),
+				"kratix-workflow-type":            Equal("promise"),
+				"kratix-workflow-kind":            Equal("pipeline.platform.kratix.io"),
+				"kratix-workflow-promise-version": Equal("v1alpha1"),
+				"kratix.io/work-type":             Equal("promise"),
+				"kratix.io/promise-name":          Equal("test-promise"),
+			})
+		})
+
+		It("creates a job with the expected metadata", func() {
+			Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
+				"Name":      HavePrefix("kratix-test-promise-configure-step-"),
+				"Namespace": Equal("test-namespace"),
+				"Labels":    labelsMatcher,
+			}))
 		})
 	})
 

--- a/lib/pipeline/configure_test.go
+++ b/lib/pipeline/configure_test.go
@@ -107,9 +107,9 @@ var _ = Describe("Configure Pipeline", func() {
 			})
 
 			It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
-				Expect(job.ObjectMeta.Name).To(HaveLen(63))
+				Expect(job.ObjectMeta.Name).To(HaveLen(62))
 				Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
-					"Name":      HavePrefix("kratix-long-long-long-long-promise-also-very-verbose-pipe-"),
+					"Name":      HavePrefix("kratix-long-long-long-long-promise-also-very-verbose-pip-"),
 					"Namespace": Equal("test-namespace"),
 					"Labels":    labelsMatcher,
 				}))
@@ -120,7 +120,7 @@ var _ = Describe("Configure Pipeline", func() {
 	Describe("Resource Configure Pipeline", func() {
 		const expectedHash = "9bb58f26192e4ba00f01e2e7b136bbd8"
 		BeforeEach(func() {
-			pipelineResources = pipeline.NewPipelineArgs("test-promise", "test-resource", "configure-step", "test-rr", "test-namespace")
+			pipelineResources = pipeline.NewPipelineArgs("test-promise", "test-promise-test-rr", "configure-step", "test-rr", "test-namespace")
 			job, err = pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -134,14 +134,14 @@ var _ = Describe("Configure Pipeline", func() {
 				"kratix-workflow-promise-version":    Equal("v1alpha1"),
 				"kratix.io/work-type":                Equal("resource"),
 				"kratix.io/promise-name":             Equal("test-promise"),
-				"kratix-promise-resource-request-id": Equal("test-resource"),
+				"kratix-promise-resource-request-id": Equal("test-promise-test-rr"),
 				"kratix.io/resource-name":            Equal("test-rr"),
 			})
 		})
 
 		It("creates a job with the expected metadata", func() {
 			Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
-				"Name":      HavePrefix("kratix-test-promise-test-resource-configure-step-"),
+				"Name":      HavePrefix("kratix-test-promise-test-rr-configure-step-"),
 				"Namespace": Equal("test-namespace"),
 				"Labels":    labelsMatcher,
 			}))
@@ -150,7 +150,7 @@ var _ = Describe("Configure Pipeline", func() {
 		Context("when the pipeline name would exceed the 63 character limit", func() {
 			BeforeEach(func() {
 				promise_identifier := "long-long-long-long-promise"
-				pipelineResources = pipeline.NewPipelineArgs(promise_identifier, "test-resource", "configure-step", "test-rr", "test-namespace")
+				pipelineResources = pipeline.NewPipelineArgs(promise_identifier, "long-long-long-long-promise-test-resource", "configure-step", "test-resource", "test-namespace")
 
 				job, err = pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
 
@@ -164,15 +164,15 @@ var _ = Describe("Configure Pipeline", func() {
 					"kratix-workflow-promise-version":    Equal("v1alpha1"),
 					"kratix.io/work-type":                Equal("resource"),
 					"kratix.io/promise-name":             Equal(promise_identifier),
-					"kratix-promise-resource-request-id": Equal("test-resource"),
-					"kratix.io/resource-name":            Equal("test-rr"),
+					"kratix-promise-resource-request-id": Equal("long-long-long-long-promise-test-resource"),
+					"kratix.io/resource-name":            Equal("test-resource"),
 				})
 			})
 
 			It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
-				Expect(job.ObjectMeta.Name).To(HaveLen(63))
+				Expect(job.ObjectMeta.Name).To(HaveLen(62))
 				Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
-					"Name":      HavePrefix("kratix-long-long-long-long-promise-test-resource-configur-"),
+					"Name":      HavePrefix("kratix-long-long-long-long-promise-test-resource-configu-"),
 					"Namespace": Equal("test-namespace"),
 					"Labels":    labelsMatcher,
 				}))

--- a/lib/pipeline/configure_test.go
+++ b/lib/pipeline/configure_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Configure Pipeline", func() {
 				})
 			})
 
-			It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+			It("truncates the pipeline name to ensure it fits the 63 character limit", func() {
 				Expect(job.ObjectMeta.Name).To(HaveLen(62))
 				Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
 					"Name":      HavePrefix("kratix-long-long-long-long-promise-also-very-verbose-pip-"),
@@ -169,7 +169,7 @@ var _ = Describe("Configure Pipeline", func() {
 				})
 			})
 
-			It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+			It("truncates the pipeline name to ensure it fits the 63 character limit", func() {
 				Expect(job.ObjectMeta.Name).To(HaveLen(62))
 				Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
 					"Name":      HavePrefix("kratix-long-long-long-long-promise-test-resource-configu-"),

--- a/lib/pipeline/configure_test.go
+++ b/lib/pipeline/configure_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Configure Pipeline", func() {
 		pipelineResources = pipeline.NewPipelineArgs("test-promise", "", "configure-step", "test-name", "test-namespace")
 	})
 
-	Describe("Promise", func() {
+	Describe("Promise Configure Pipeline", func() {
 		const expectedHash = "9bb58f26192e4ba00f01e2e7b136bbd8"
 		BeforeEach(func() {
 			job, err = pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
@@ -83,6 +83,100 @@ var _ = Describe("Configure Pipeline", func() {
 				"Namespace": Equal("test-namespace"),
 				"Labels":    labelsMatcher,
 			}))
+		})
+
+		Context("when the pipeline name would exceed the 63 character limit", func() {
+			BeforeEach(func() {
+				promise_identifier := "long-long-long-long-promise"
+				pipeline_name := "also-very-verbose-pipeline"
+				pipelineResources = pipeline.NewPipelineArgs(promise_identifier, "", pipeline_name, "test-name", "test-namespace")
+
+				job, err = pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
+
+				labelsMatcher = MatchAllKeys(Keys{
+					"kratix.io/hash":                  Equal(expectedHash),
+					"kratix-workflow-action":          Equal("configure"),
+					"kratix-workflow-pipeline-name":   Equal(pipeline_name),
+					"kratix.io/pipeline-name":         Equal(pipeline_name),
+					"kratix-workflow-type":            Equal("promise"),
+					"kratix-workflow-kind":            Equal("pipeline.platform.kratix.io"),
+					"kratix-workflow-promise-version": Equal("v1alpha1"),
+					"kratix.io/work-type":             Equal("promise"),
+					"kratix.io/promise-name":          Equal(promise_identifier),
+				})
+			})
+
+			It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+				Expect(job.ObjectMeta.Name).To(HaveLen(63))
+				Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
+					"Name":      HavePrefix("kratix-long-long-long-long-promise-also-very-verbose-pipe-"),
+					"Namespace": Equal("test-namespace"),
+					"Labels":    labelsMatcher,
+				}))
+			})
+		})
+	})
+
+	Describe("Resource Configure Pipeline", func() {
+		const expectedHash = "9bb58f26192e4ba00f01e2e7b136bbd8"
+		BeforeEach(func() {
+			pipelineResources = pipeline.NewPipelineArgs("test-promise", "test-resource", "configure-step", "test-rr", "test-namespace")
+			job, err = pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			labelsMatcher = MatchAllKeys(Keys{
+				"kratix.io/hash":                     Equal(expectedHash),
+				"kratix-workflow-action":             Equal("configure"),
+				"kratix-workflow-pipeline-name":      Equal("configure-step"),
+				"kratix.io/pipeline-name":            Equal("configure-step"),
+				"kratix-workflow-type":               Equal("resource"),
+				"kratix-workflow-kind":               Equal("pipeline.platform.kratix.io"),
+				"kratix-workflow-promise-version":    Equal("v1alpha1"),
+				"kratix.io/work-type":                Equal("resource"),
+				"kratix.io/promise-name":             Equal("test-promise"),
+				"kratix-promise-resource-request-id": Equal("test-resource"),
+				"kratix.io/resource-name":            Equal("test-rr"),
+			})
+		})
+
+		It("creates a job with the expected metadata", func() {
+			Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
+				"Name":      HavePrefix("kratix-test-promise-test-resource-configure-step-"),
+				"Namespace": Equal("test-namespace"),
+				"Labels":    labelsMatcher,
+			}))
+		})
+
+		Context("when the pipeline name would exceed the 63 character limit", func() {
+			BeforeEach(func() {
+				promise_identifier := "long-long-long-long-promise"
+				pipelineResources = pipeline.NewPipelineArgs(promise_identifier, "test-resource", "configure-step", "test-rr", "test-namespace")
+
+				job, err = pipeline.ConfigurePipeline(rr, expectedHash, p, pipelineResources, "test-promise", false, logger)
+
+				labelsMatcher = MatchAllKeys(Keys{
+					"kratix.io/hash":                     Equal(expectedHash),
+					"kratix-workflow-action":             Equal("configure"),
+					"kratix-workflow-pipeline-name":      Equal("configure-step"),
+					"kratix.io/pipeline-name":            Equal("configure-step"),
+					"kratix-workflow-type":               Equal("resource"),
+					"kratix-workflow-kind":               Equal("pipeline.platform.kratix.io"),
+					"kratix-workflow-promise-version":    Equal("v1alpha1"),
+					"kratix.io/work-type":                Equal("resource"),
+					"kratix.io/promise-name":             Equal(promise_identifier),
+					"kratix-promise-resource-request-id": Equal("test-resource"),
+					"kratix.io/resource-name":            Equal("test-rr"),
+				})
+			})
+
+			It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+				Expect(job.ObjectMeta.Name).To(HaveLen(63))
+				Expect(job.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
+					"Name":      HavePrefix("kratix-long-long-long-long-promise-test-resource-configur-"),
+					"Namespace": Equal("test-namespace"),
+					"Labels":    labelsMatcher,
+				}))
+			})
 		})
 	})
 

--- a/lib/pipeline/delete_test.go
+++ b/lib/pipeline/delete_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Delete Pipeline", func() {
 					)
 				})
 
-				It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+				It("truncates the pipeline name to ensure it fits the 63 character limit", func() {
 					job = *pipelineResources[3].(*batchv1.Job)
 					Expect(job.ObjectMeta.Name).To(HaveLen(62))
 					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-long-long-long-long-promise-promise-del-"))
@@ -466,7 +466,7 @@ var _ = Describe("Delete Pipeline", func() {
 					)
 				})
 
-				It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+				It("truncates the pipeline name to ensure it fits the 63 character limit", func() {
 					job = *pipelineResources[3].(*batchv1.Job)
 					Expect(job.ObjectMeta.Name).To(HaveLen(62))
 					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-promise-long-long-request-instance-dele-"))

--- a/lib/pipeline/delete_test.go
+++ b/lib/pipeline/delete_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Delete Pipeline", func() {
 
 				Expect(job).To(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Name":      HavePrefix("delete-pipeline-custom-namespace-"),
+						"Name":      HavePrefix("kratix-custom-namespace-promise-delete-"),
 						"Namespace": Equal("kratix-platform-system"),
 						"Labels":    labelsMatcher,
 					}),
@@ -334,7 +334,7 @@ var _ = Describe("Delete Pipeline", func() {
 
 				Expect(job).To(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Name":      HavePrefix("delete-pipeline-custom-namespace-"),
+						"Name":      HavePrefix("kratix-custom-namespace-example-custom-namespace-instance-delete-"),
 						"Namespace": Equal("default"),
 						"Labels":    labelsMatcher,
 					}),

--- a/lib/pipeline/delete_test.go
+++ b/lib/pipeline/delete_test.go
@@ -245,8 +245,8 @@ var _ = Describe("Delete Pipeline", func() {
 
 				It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
 					job = *pipelineResources[3].(*batchv1.Job)
-					Expect(job.ObjectMeta.Name).To(HaveLen(63))
-					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-long-long-long-long-promise-promise-dele-"))
+					Expect(job.ObjectMeta.Name).To(HaveLen(62))
+					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-long-long-long-long-promise-promise-del-"))
 				})
 			})
 		})
@@ -357,7 +357,7 @@ var _ = Describe("Delete Pipeline", func() {
 
 				Expect(job).To(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Name":      HavePrefix("kratix-custom-namespace-example-ns-instance-delete-"),
+						"Name":      HavePrefix("kratix-custom-namespace-example-instance-delete-"),
 						"Namespace": Equal("default"),
 						"Labels":    labelsMatcher,
 					}),
@@ -452,6 +452,7 @@ var _ = Describe("Delete Pipeline", func() {
 				BeforeEach(func() {
 					promise := promiseFromFile(promisePath)
 					resourceRequest := resourceRequestFromFile(resourceRequestPath)
+					resourceRequest.SetName("long-long-request")
 
 					pipelines, err := promise.GeneratePipelines(logger)
 					Expect(err).ToNot(HaveOccurred())
@@ -467,8 +468,8 @@ var _ = Describe("Delete Pipeline", func() {
 
 				It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
 					job = *pipelineResources[3].(*batchv1.Job)
-					Expect(job.ObjectMeta.Name).To(HaveLen(63))
-					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-promise-long-long-request-instance-delet-"))
+					Expect(job.ObjectMeta.Name).To(HaveLen(62))
+					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-promise-long-long-request-instance-dele-"))
 				})
 			})
 		})

--- a/lib/pipeline/delete_test.go
+++ b/lib/pipeline/delete_test.go
@@ -226,6 +226,29 @@ var _ = Describe("Delete Pipeline", func() {
 					}),
 				}))
 			})
+
+			Context("the pipeline name would exceed the 63 character limit", func() {
+				BeforeEach(func() {
+					promise := promiseFromFile(promisePath)
+					promise.SetName("long-long-long-long-long-long-promise")
+					unstructuredPromise, err := promise.ToUnstructured()
+					Expect(err).ToNot(HaveOccurred())
+
+					pipelines, err := promise.GeneratePipelines(logger)
+					Expect(err).ToNot(HaveOccurred())
+
+					pipelineResources = pipeline.NewDeletePromise(
+						unstructuredPromise,
+						pipelines.DeletePromise[0],
+					)
+				})
+
+				It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+					job = *pipelineResources[3].(*batchv1.Job)
+					Expect(job.ObjectMeta.Name).To(HaveLen(63))
+					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-long-long-long-long-promise-promise-dele-"))
+				})
+			})
 		})
 	})
 
@@ -251,7 +274,7 @@ var _ = Describe("Delete Pipeline", func() {
 				pipelineResources = pipeline.NewDeleteResource(
 					resourceRequest,
 					pipelines.DeleteResource[0],
-					"example-custom-namespace",
+					"example-ns",
 					"custom-namespace",
 					"custom-namespaces",
 				)
@@ -325,7 +348,7 @@ var _ = Describe("Delete Pipeline", func() {
 					"kratix-workflow-type":               Equal("resource"),
 					"kratix-workflow-action":             Equal("delete"),
 					"kratix.io/promise-name":             Equal("custom-namespace"),
-					"kratix-promise-resource-request-id": Equal("example-custom-namespace"),
+					"kratix-promise-resource-request-id": Equal("example-ns"),
 					"kratix-workflow-pipeline-name":      Equal("instance-delete"),
 					"kratix.io/pipeline-name":            Equal("instance-delete"),
 					"kratix.io/work-type":                Equal("resource"),
@@ -334,7 +357,7 @@ var _ = Describe("Delete Pipeline", func() {
 
 				Expect(job).To(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Name":      HavePrefix("kratix-custom-namespace-example-custom-namespace-instance-delete-"),
+						"Name":      HavePrefix("kratix-custom-namespace-example-ns-instance-delete-"),
 						"Namespace": Equal("default"),
 						"Labels":    labelsMatcher,
 					}),
@@ -423,6 +446,30 @@ var _ = Describe("Delete Pipeline", func() {
 						}),
 					}),
 				}))
+			})
+
+			Context("the pipeline name would exceed the 63 character limit", func() {
+				BeforeEach(func() {
+					promise := promiseFromFile(promisePath)
+					resourceRequest := resourceRequestFromFile(resourceRequestPath)
+
+					pipelines, err := promise.GeneratePipelines(logger)
+					Expect(err).ToNot(HaveOccurred())
+
+					pipelineResources = pipeline.NewDeleteResource(
+						resourceRequest,
+						pipelines.DeleteResource[0],
+						"long-long-request",
+						"long-long-promise",
+						"long-long-promises",
+					)
+				})
+
+				It("concatenates the pipeline name to ensure it fits the 63 character limit", func() {
+					job = *pipelineResources[3].(*batchv1.Job)
+					Expect(job.ObjectMeta.Name).To(HaveLen(63))
+					Expect(job.ObjectMeta.Name).To(HavePrefix("kratix-long-long-promise-long-long-request-instance-delet-"))
+				})
 			})
 		})
 	})

--- a/lib/pipeline/shared.go
+++ b/lib/pipeline/shared.go
@@ -221,9 +221,20 @@ func pipelineName(promiseIdentifier, resourceName, pipelineName string) string {
 	if resourceName != "" {
 		resource_and_separator = resourceName + "-"
 	}
+
+	name := fmt.Sprintf("kratix-%s-%s%s", promiseIdentifier, resource_and_separator, pipelineName)
+
+	if len(name) > 57 {
+		return enforceCharacterLimit(name, 57) + "-" + getShortUuid()
+	}
+
 	return fmt.Sprintf("kratix-%s-%s%s-%s", promiseIdentifier, resource_and_separator, pipelineName, getShortUuid())
 }
 
 func getShortUuid() string {
 	return string(uuid.NewUUID()[0:5])
+}
+
+func enforceCharacterLimit(name string, limit int) string {
+	return name[0:limit]
 }

--- a/lib/pipeline/shared.go
+++ b/lib/pipeline/shared.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -215,8 +216,12 @@ func generateContainersAndVolumes(obj *unstructured.Unstructured, workflowType v
 
 // TODO(breaking) change this to {promiseIdentifier}-{pipelineType}-pipeline-{short-uuid}
 // for consistency with other resource names (e.g. service account)
-func pipelineName(pipelineType, promiseIdentifier string) string {
-	return pipelineType + "-pipeline-" + promiseIdentifier + "-" + getShortUuid()
+func pipelineName(promiseIdentifier, resourceName, pipelineName string) string {
+	var resource_and_separator = ""
+	if resourceName != "" {
+		resource_and_separator = resourceName + "-"
+	}
+	return fmt.Sprintf("kratix-%s-%s%s-%s", promiseIdentifier, resource_and_separator, pipelineName, getShortUuid())
 }
 
 func getShortUuid() string {

--- a/lib/pipeline/shared.go
+++ b/lib/pipeline/shared.go
@@ -214,15 +214,13 @@ func generateContainersAndVolumes(obj *unstructured.Unstructured, workflowType v
 	return containers, volumes
 }
 
-// TODO(breaking) change this to {promiseIdentifier}-{pipelineType}-pipeline-{short-uuid}
-// for consistency with other resource names (e.g. service account)
-func pipelineName(promiseIdentifier, resourceIdentifier, name, pipelineName string) string {
-	var promise_resource = promiseIdentifier
+func pipelineName(promiseIdentifier, resourceIdentifier, objectName, pipelineName string) string {
+	var promiseResource = promiseIdentifier
 	if resourceIdentifier != "" {
-		promise_resource = fmt.Sprintf("%s-%s", promiseIdentifier, name)
+		promiseResource = fmt.Sprintf("%s-%s", promiseIdentifier, objectName)
 	}
 
-	pipelineIdentifier := fmt.Sprintf("kratix-%s-%s", promise_resource, pipelineName)
+	pipelineIdentifier := fmt.Sprintf("kratix-%s-%s", promiseResource, pipelineName)
 
 	return resourceutil.GenerateObjectName(pipelineIdentifier)
 }

--- a/lib/pipeline/shared.go
+++ b/lib/pipeline/shared.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/syntasso/kratix/api/v1alpha1"
+	"github.com/syntasso/kratix/lib/resourceutil"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const (
@@ -216,25 +216,13 @@ func generateContainersAndVolumes(obj *unstructured.Unstructured, workflowType v
 
 // TODO(breaking) change this to {promiseIdentifier}-{pipelineType}-pipeline-{short-uuid}
 // for consistency with other resource names (e.g. service account)
-func pipelineName(promiseIdentifier, resourceName, pipelineName string) string {
-	var resource_and_separator = ""
-	if resourceName != "" {
-		resource_and_separator = resourceName + "-"
+func pipelineName(promiseIdentifier, resourceIdentifier, name, pipelineName string) string {
+	var promise_resource = promiseIdentifier
+	if resourceIdentifier != "" {
+		promise_resource = fmt.Sprintf("%s-%s", promiseIdentifier, name)
 	}
 
-	name := fmt.Sprintf("kratix-%s-%s%s", promiseIdentifier, resource_and_separator, pipelineName)
+	pipelineIdentifier := fmt.Sprintf("kratix-%s-%s", promise_resource, pipelineName)
 
-	if len(name) > 57 {
-		return enforceCharacterLimit(name, 57) + "-" + getShortUuid()
-	}
-
-	return fmt.Sprintf("kratix-%s-%s%s-%s", promiseIdentifier, resource_and_separator, pipelineName, getShortUuid())
-}
-
-func getShortUuid() string {
-	return string(uuid.NewUUID()[0:5])
-}
-
-func enforceCharacterLimit(name string, limit int) string {
-	return name[0:limit]
+	return resourceutil.GenerateObjectName(pipelineIdentifier)
 }


### PR DESCRIPTION
Implements #84

This PR updates the pipeline naming format to ensure they are named in the format, `kratix-<promiseName>-<pipelineName>-UUID` for Promise Configure and Delete pipelines and `kratix-<promiseName>-<resourceName>-<pipelineName>-UUID` for Resource Configure and Delete Pipelines. This makes no changes to the existing labels.

When the name of the pipeline will exceed the 63 character limit, the name is truncated.

## Manual Validation

**Promise Configure**
Promise: Redis Marketplace promise

Install Promise
```
kubectl apply -t promise.yaml
```

Get pods
```
➜  ~ k get pods -A
NAMESPACE                NAME                                                 READY   STATUS      RESTARTS   AGE
kratix-platform-system   kratix-redis-promise-configure-f8ddb-clvws           0/1     Completed   0          35s
```

Describe configure pod
```
➜  ~ k describe pod kratix-redis-promise-configure-f8ddb-clvws -n kratix-platform-system
Name:             kratix-redis-promise-configure-f8ddb-clvws
Namespace:        kratix-platform-system
Priority:         0
Service Account:  redis-promise-pipeline
Node:             platform-control-plane/172.18.0.3
Start Time:       Thu, 13 Jun 2024 16:05:35 +0100
Labels:           batch.kubernetes.io/controller-uid=205b4bf9-6f1e-4298-88e1-22b21186a9a7
                  batch.kubernetes.io/job-name=kratix-redis-promise-configure-f8ddb
                  controller-uid=205b4bf9-6f1e-4298-88e1-22b21186a9a7
                  job-name=kratix-redis-promise-configure-f8ddb
                  kratix-workflow-action=configure
                  kratix-workflow-kind=pipeline.platform.kratix.io
                  kratix-workflow-pipeline-name=promise-configure
                  kratix-workflow-promise-version=v1alpha1
                  kratix-workflow-type=promise
                  kratix.io/hash=03a63c34b73cc8da52e9209b436e5011
                  kratix.io/pipeline-name=promise-configure
                  kratix.io/promise-name=redis
                  kratix.io/work-type=promise
```

**Resource Configure**

Make request (name: example)
```
k apply -f resource-request.yaml
```

Get pods
```
➜  redis git:(main) ✗ k get pods -A
NAMESPACE                NAME                                                              READY   STATUS      RESTARTS   AGE
default                  kratix-redis-example-instance-configure-b1a4e-t7khd   0/1     Init:2/3    0          3s
```

Describe resource configure pod
```
➜  ~ k describe pod kratix-redis-example-instance-configure-b1a4e-t7khd
Name:             kratix-redis-example-instance-configure-b1a4e-t7khd
Namespace:        default
Priority:         0
Service Account:  redis-resource-pipeline
Node:             platform-control-plane/172.18.0.3
Start Time:       Thu, 13 Jun 2024 16:10:15 +0100
Labels:           batch.kubernetes.io/controller-uid=1c70235c-c1fb-4c57-88fb-0b483b180ff8
                  batch.kubernetes.io/job-name=kratix-redis-example-instance-configure-b1a4e
                  controller-uid=1c70235c-c1fb-4c57-88fb-0b483b180ff8
                  job-name=kratix-redis-example-instance-configure-b1a4e
                  kratix-promise-resource-request-id=example
                  kratix-workflow-action=configure
                  kratix-workflow-kind=pipeline.platform.kratix.io
                  kratix-workflow-pipeline-name=instance-configure
                  kratix-workflow-promise-version=v1alpha1
                  kratix-workflow-type=resource
                  kratix.io/hash=c2ef384011e18a3545c23409e3e9bed8
                  kratix.io/pipeline-name=instance-configure
                  kratix.io/promise-name=redis
                  kratix.io/resource-name=example
                  kratix.io/work-type=resource
```

**Resource Delete Pipeline**

Delete request
```
kubectl delete -f resource-request.yaml
```

View pods
```
➜  redis git:(main) ✗ k get pods -A
NAMESPACE                NAME                                                              READY   STATUS      RESTARTS   AGE
default                  kratix-redis-example-instance-delete-27c58-4fcmk   0/1     Terminating       0          47s
```

**Promise Delete Pipeline**

Delete Promise
```
kubectl delete -f promise.yaml
```

```
NAMESPACE                NAME                                                              READY   STATUS      RESTARTS   AGE
kratix-platform-system   kratix-redis-instance-delete-dc79f-xqhr4   0/1     Completed         0          3s
```

### Longer Pipeline Names

**Promise Configure**
Promise: Redis Marketplace promise updated as follows

```
apiVersion: platform.kratix.io/v1alpha1
kind: Promise
metadata:
  creationTimestamp: null
  name: a-very-weirdly-unecessarily-long-redis
  namespace: default
  labels:
    kratix.io/promise-version: v0.1.0
```

Install Promise
```
kubectl apply -t promise.yaml
```

Get pods
```
NAMESPACE                NAME                                                              READY   STATUS      RESTARTS   AGE
kratix-platform-system   kratix-a-very-weirdly-unecessarily-long-redis-promise-co-af2cz7   0/1     Completed         0          7
```

Describe configure pod
```
➜  redis git:(main) ✗ k describe pod kratix-a-very-weirdly-unecessarily-long-redis-promise-co-af2cz7 -n kratix-platform-system
Name:             kratix-a-very-weirdly-unecessarily-long-redis-promise-co-af2cz7
Namespace:        kratix-platform-system
Priority:         0
Service Account:  a-very-weirdly-unecessarily-long-redis-promise-pipeline
Node:             platform-control-plane/172.18.0.3
Start Time:       Thu, 13 Jun 2024 15:40:40 +0100
Labels:           batch.kubernetes.io/controller-uid=e2bceae7-8706-42d5-b92d-7646cce52caf
                  batch.kubernetes.io/job-name=kratix-a-very-weirdly-unecessarily-long-redis-promise-co-a323f
                  controller-uid=e2bceae7-8706-42d5-b92d-7646cce52caf
                  job-name=kratix-a-very-weirdly-unecessarily-long-redis-promise-co-a323f
                  kratix-workflow-action=configure
                  kratix-workflow-kind=pipeline.platform.kratix.io
                  kratix-workflow-pipeline-name=promise-configure
                  kratix-workflow-promise-version=v1alpha1
                  kratix-workflow-type=promise
                  kratix.io/hash=b07f4e335b2969943d0a3469842b77ca
                  kratix.io/pipeline-name=promise-configure
                  kratix.io/promise-name=a-very-weirdly-unecessarily-long-redis
                  kratix.io/work-type=promise
```

**Resource Configure**

Make request (name: example)
```
k apply -f resource-request.yaml
```

Get pods
```
➜  redis git:(main) ✗ k get pods -A
NAMESPACE                NAME                                                              READY   STATUS      RESTARTS   AGE
default                  kratix-a-very-weirdly-unecessarily-long-redis-example-in-bvrcxg   0/1     Completed   0          5s
```

Describe configure pod
```
➜  redis git:(main) ✗ k describe pod kratix-a-very-weirdly-unecessarily-long-redis-example-in-bvrcxg
Name:             kratix-a-very-weirdly-unecessarily-long-redis-example-in-bvrcxg
Namespace:        default
Priority:         0
Service Account:  a-very-weirdly-unecessarily-long-redis-resource-pipeline
Node:             platform-control-plane/172.18.0.3
Start Time:       Thu, 13 Jun 2024 15:45:38 +0100
Labels:           batch.kubernetes.io/controller-uid=f3f14bc9-2cb1-42cb-b13e-ce431ac0e8b2
                  batch.kubernetes.io/job-name=kratix-a-very-weirdly-unecessarily-long-redis-example-in-b9c66
                  controller-uid=f3f14bc9-2cb1-42cb-b13e-ce431ac0e8b2
                  job-name=kratix-a-very-weirdly-unecessarily-long-redis-example-in-b9c66
                  kratix-promise-resource-request-id=example
                  kratix-workflow-action=configure
                  kratix-workflow-kind=pipeline.platform.kratix.io
                  kratix-workflow-pipeline-name=instance-configure
                  kratix-workflow-promise-version=v1alpha1
                  kratix-workflow-type=resource
                  kratix.io/hash=c2ef384011e18a3545c23409e3e9bed8
                  kratix.io/pipeline-name=instance-configure
                  kratix.io/promise-name=a-very-weirdly-unecessarily-long-redis
                  kratix.io/resource-name=example
                  kratix.io/work-type=resource
```

**Resource Delete Pipeline**

Delete request
```
kubectl delete -f resource-request.yaml
```

View pods
```
➜  redis git:(main) ✗ k get pods -A
NAMESPACE                NAME                                                              READY   STATUS      RESTARTS   AGE
default                  kratix-a-very-weirdly-unecessarily-long-redis-example-in-1ngt6j   0/1     Terminating       0          47s
```

**Promise Delete Pipeline**

Delete Promise
```
kubectl delete -f promise.yaml
```

```
NAMESPACE                NAME                                                              READY   STATUS      RESTARTS   AGE
kratix-platform-system   kratix-a-very-weirdly-unecessarily-long-redis-instance-d-3cjjq6   0/1     Completed         0          3s
```
