### PR TITLE
feat: serve pprof

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,10 +50,13 @@ func init() {
 
 func main() {
 	var metricsAddr string
-	var enableLeaderElection bool
 	var probeAddr string
+	var pprofAddr string
+	var enableLeaderElection bool
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", ":8082", "The address the pprof endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -84,6 +87,7 @@ func main() {
 			Metrics:                metricsServerOptions,
 			WebhookServer:          webhookServer,
 			HealthProbeBindAddress: probeAddr,
+			PprofBindAddress:       pprofAddr,
 			LeaderElection:         enableLeaderElection,
 			LeaderElectionID:       "2743c979.kratix.io",
 		})


### PR DESCRIPTION
## Context

Setting `PprofBindAddress` in manager options to serve `pprof`.

To use: 
1. port forward the controller pod
2. collect a profile
4. visualize:
```
❯ k -n kratix-platform-system port-forward pod/kratix-platform-controller-manager-5c4df4bc77-wtp6z 8082:8082

❯ curl -s "http://127.0.0.1:8082/debug/pprof/heap" > ./heap.out

❯ go tool pprof -http=:8080 ./heap.out
Serving web UI on http://localhost:8080
``` 

Then you can get CPU time, heap, flamegraph...etc
<img width="1125" alt="Screenshot 2024-06-14 at 16 39 06" src="https://github.com/syntasso/kratix/assets/6786193/813885c0-d4c6-4794-ba71-582989565473">
