### PR TITLE
Chore: Upgrade baseline cert-manager to 0.15.0

### DIFF
--- a/.images
+++ b/.images
@@ -1,8 +1,8 @@
 docker.io/minio/mc:RELEASE.2023-06-06T13-48-56Z
 docker.io/minio/minio:RELEASE.2022-06-30T20-58-09Z
-quay.io/jetstack/cert-manager-controller:v1.12.0
-quay.io/jetstack/cert-manager-cainjector:v1.12.0
-quay.io/jetstack/cert-manager-webhook:v1.12.0
+quay.io/jetstack/cert-manager-controller:v1.15.0
+quay.io/jetstack/cert-manager-cainjector:v1.15.0
+quay.io/jetstack/cert-manager-webhook:v1.15.0
 docker.io/bitnami/kubectl:1.28.6
 gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
 ghcr.io/fluxcd/helm-controller:v0.27.0

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ single-cluster: distribution ## Deploys Kratix on a single cluster
 dev-env: quick-start prepare-platform-as-destination ## Quick-start + prepare-platform-as-destination
 
 install-cert-manager: ## Install cert-manager on the platform cluster; used in the helm test
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml
 	kubectl wait --for condition=available -n cert-manager deployment/cert-manager --timeout 120s
 	kubectl wait --for condition=available -n cert-manager deployment/cert-manager-cainjector --timeout 120s
 	kubectl wait --for condition=available -n cert-manager deployment/cert-manager-webhook --timeout 120s

--- a/demo/demo-image-list
+++ b/demo/demo-image-list
@@ -11,9 +11,9 @@ ghcr.io/syntasso/kratix-marketplace/redis-configure-pipeline:v0.1.0
 ghcr.io/syntasso/kratix-marketplace/slack-configure-pipeline:v0.1.0
 ghcr.io/syntasso/promise-postgresql/postgresql-configure-pipeline:v0.1.0
 nginx/nginx-ingress:2.4.2
-quay.io/jetstack/cert-manager-cainjector:v1.12.0
-quay.io/jetstack/cert-manager-controller:v1.12.0
-quay.io/jetstack/cert-manager-webhook:v1.12.0
+quay.io/jetstack/cert-manager-cainjector:v1.15.0
+quay.io/jetstack/cert-manager-controller:v1.15.0
+quay.io/jetstack/cert-manager-webhook:v1.15.0
 quay.io/spotahome/redis-operator:v1.2.4
 redis:6.2.6-alpine
 registry.k8s.io/coredns/coredns:v1.10.1

--- a/lib/writers/git.go
+++ b/lib/writers/git.go
@@ -56,7 +56,7 @@ func NewGitWriter(logger logr.Logger, stateStoreSpec v1alpha1.GitStateStoreSpec,
 
 		knownHostsFile, err := os.CreateTemp("", "knownHosts")
 		if err != nil {
-			return nil, fmt.Errorf("error creating knownhosts file: %w", err)
+			return nil, fmt.Errorf("error creating knownHosts file: %w", err)
 		}
 
 		knownHostsFile.Write(knownHosts)
@@ -68,7 +68,7 @@ func NewGitWriter(logger logr.Logger, stateStoreSpec v1alpha1.GitStateStoreSpec,
 		sshKey.HostKeyCallback = knownHostsCallback
 		err = os.Remove(knownHostsFile.Name())
 		if err != nil {
-			return nil, fmt.Errorf("error removing knownhosts file: %w", err)
+			return nil, fmt.Errorf("error removing knownHosts file: %w", err)
 		}
 
 		authMethod = sshKey
@@ -146,7 +146,7 @@ func (g *GitWriter) update(subDir, workPlacementName string, workloadsToCreate [
 		//returned by `filepath.Join` is still contained with the git repository:
 		// Note: This means `../` can still be used, but only if the end result is still contained within the git repository
 		if !strings.HasPrefix(absoluteFilePath, localTmpDir) {
-			log.Error(nil, "Path of file to write is not located within the git repository", "absolutePath", absoluteFilePath, "tmpDir", localTmpDir)
+			log.Error(nil, "path of file to write is not located within the git repository", "absolutePath", absoluteFilePath, "tmpDir", localTmpDir)
 			return "", nil //We don't want to retry as this isn't a recoverable error. Log error and return nil.
 		}
 

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -21,7 +21,7 @@ WAIT_TIMEOUT="180s"
 KIND_IMAGE="${KIND_IMAGE:-"kindest/node:v1.27.3"}"
 
 WITH_CERT_MANAGER=true
-CERT_MANAGER_DIST=https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+CERT_MANAGER_DIST=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml
 ENABLE_WEBHOOKS=true
 
 LABELS=true


### PR DESCRIPTION
Current stable cert-manager is 3 minors above our default version. Upgrading first in Kratix after testing with quick-start, and will then go to update in docs.