### PR TITLE
check go version in circleci matches docker image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - install_software
       - run:
           name: Check circleci go version matches docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   k8s: circleci/kubernetes@1.3.1
   gh: circleci/github-cli@2.3.0
-  golang: circleci/go@1.7.2
+  golang: circleci/go@1.7.3
   retry: kimh/run-with-retry@1.0.0
   queue: eddiewebb/queue@2.2.1
   snyk: snyk/snyk@2.0.2
@@ -192,6 +192,23 @@ jobs:
       - notify-slack:
           only_for_branches: "main"
 
+  ensure-circleci-go-versions-matches-docker:
+    executor: machine-medium
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Check circleci go version matches docker image
+          command: |
+            circleci_go_version=$(go version | awk '{print $3}')
+            go_image_tag=$(grep '^FROM' Dockerfile | head -n 1 | cut -d ' ' -f 3)
+
+            docker pull $go_image_tag
+            docker_go_version=$(docker inspect $go_image_tag | grep 'GOLANG_VERSION=' | sed -n 's/.*GOLANG_VERSION=\([^"]*\).*/\1/p')
+            if [ "$circleci_go_version" != "$docker_go_version" ]; then
+              echo "Go version mismatch: $circleci_go_version != $docker_go_version"
+              exit 1
+            fi
   test:
     executor: machine-xlarge
     steps:
@@ -446,6 +463,8 @@ workflows:
     jobs:
       - clone-kratix
       - clone-helm-charts
+      - ensure-circleci-go-versions-matches-docker:
+          requires: [clone-kratix]
       - test:
           requires: [clone-kratix, clone-helm-charts]
       - e2e-demo-test-helm-bucket:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
       - run:
           name: Check circleci go version matches docker image
           command: |
-            circleci_go_version=$(go version | awk '{print $3}')
+            circleci_go_version=$(go version | awk '{print $3}' | sed 's/^go//')
             go_image_tag=$(grep '^FROM' Dockerfile | head -n 1 | cut -d ' ' -f 3)
 
             docker pull $go_image_tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,18 @@ jobs:
       - checkout
       - install_software
       - run:
+          name: Check circleci go version matches docker image
+          command: |
+            circleci_go_version=$(go version | awk '{print $3}' | sed 's/^go//')
+            go_image_tag=$(grep '^FROM' Dockerfile | head -n 1 | cut -d ' ' -f 3)
+
+            docker pull $go_image_tag
+            docker_go_version=$(docker inspect $go_image_tag | grep 'GOLANG_VERSION=' | sed -n 's/.*GOLANG_VERSION=\([^"]*\).*/\1/p')
+            if [ "$circleci_go_version" != "$docker_go_version" ]; then
+              echo "Go version mismatch: $circleci_go_version != $docker_go_version. Please update the Dockerfile to match the CircleCI go version."
+              exit 1
+            fi
+      - run:
           name: install govulncheck
           command: |
             set -o pipefail
@@ -192,24 +204,6 @@ jobs:
       - notify-slack:
           only_for_branches: "main"
 
-  ensure-circleci-go-versions-matches-docker:
-    executor: machine-medium
-    steps:
-      - attach_workspace:
-          at: .
-      - install_software
-      - run:
-          name: Check circleci go version matches docker image
-          command: |
-            circleci_go_version=$(go version | awk '{print $3}' | sed 's/^go//')
-            go_image_tag=$(grep '^FROM' Dockerfile | head -n 1 | cut -d ' ' -f 3)
-
-            docker pull $go_image_tag
-            docker_go_version=$(docker inspect $go_image_tag | grep 'GOLANG_VERSION=' | sed -n 's/.*GOLANG_VERSION=\([^"]*\).*/\1/p')
-            if [ "$circleci_go_version" != "$docker_go_version" ]; then
-              echo "Go version mismatch: $circleci_go_version != $docker_go_version"
-              exit 1
-            fi
   test:
     executor: machine-xlarge
     steps:
@@ -464,8 +458,6 @@ workflows:
     jobs:
       - clone-kratix
       - clone-helm-charts
-      - ensure-circleci-go-versions-matches-docker:
-          requires: [clone-kratix]
       - test:
           requires: [clone-kratix, clone-helm-charts]
       - e2e-demo-test-helm-bucket:


### PR DESCRIPTION
Tested it working in a separate job before moving into the security scanner:

![Screenshot 2024-07-08 at 17 25 10](https://github.com/syntasso/kratix/assets/19669095/7b68a3f6-a0bb-4081-b0b3-cda15957e966)

sad path:
![Screenshot 2024-07-08 at 17 25 31](https://github.com/syntasso/kratix/assets/19669095/dd07be5f-df50-4c2c-8b30-8d313f9e91f6)

happy path:
![Screenshot 2024-07-08 at 17 25 40](https://github.com/syntasso/kratix/assets/19669095/64272df2-fe38-4595-a97b-8444ec942cff)

