### PR TITLE
feat: remove versioning in OS Kratix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
           name: Release
           command: |
             gh config set prompt disabled
-            gh release delete <<pipeline.git.tag>>
+            gh release delete <<pipeline.git.tag>> || true
             gh release create <<pipeline.git.tag>> --title <<pipeline.git.tag>> ./distribution/**/*.yaml ./distribution/*.yaml
 
   helm-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
       - run:
           name: bump minor version and push tag
           command: |
-            ./scripts/tag-new-version
+            ./scripts/tag-latest-version
 
   gh-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,7 @@ jobs:
           name: Release
           command: |
             gh config set prompt disabled
+            gh release delete <<pipeline.git.tag>>
             gh release create <<pipeline.git.tag>> --title <<pipeline.git.tag>> ./distribution/**/*.yaml ./distribution/*.yaml
 
   helm-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,7 @@ jobs:
             git add kratix/
             git diff --cached --quiet && exit 0 || true
 
+            VERSION=v0.0.0-latest ./scripts/bump-version kratix/
             git add kratix/
             git commit -m"update kratix package"
             git push origin main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
 filter-for-tags: &filter-for-tags
   filters:
     tags:
-      only: /^v.*/
+      only: latest
     branches:
       ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ jobs:
     docker:
       - image: cimg/base:current
     environment:
-      VERSION: << pipeline.git.tag >>
+      VERSION: latest
     resource_class: large
     steps:
       - attach_workspace:
@@ -402,7 +402,6 @@ jobs:
             git add kratix/
             git diff --cached --quiet && exit 0 || true
 
-            ./scripts/bump-minor kratix/
             git add kratix/
             git commit -m"update kratix package"
             git push origin main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,8 +389,6 @@ jobs:
   helm-release:
     docker:
       - image: cimg/base:current
-    environment:
-      VERSION: latest
     resource_class: large
     steps:
       - attach_workspace:
@@ -403,8 +401,6 @@ jobs:
             git add kratix/
             git diff --cached --quiet && exit 0 || true
 
-            VERSION=v0.0.0-latest ./scripts/bump-version kratix/
-            git add kratix/
             git commit -m"update kratix package"
             git push origin main
 

--- a/scripts/make-distribution
+++ b/scripts/make-distribution
@@ -8,6 +8,10 @@ cd $ROOT
 source "$ROOT/scripts/utils.sh"
 
 export VERSION="${VERSION:-$(commit_sha)}"
+export PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST=$(docker manifest inspect syntasso/kratix-platform-pipeline-adapter | jq -r '.manifests[] | select(.platform.architecture=="amd64").digest')
+export KRATIX_PLATFORM_MANIFEST_DIGEST=$(docker manifest inspect syntasso/kratix-platform | jq -r '.manifests[] | select(.platform.architecture=="amd64").digest')
+export WC_IMG=docker.io/syntasso/kratix-platform-pipeline-adapter@${PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST}
+export IMG_TAG=docker.io/syntasso/kratix-platform@${KRATIX_PLATFORM_MANIFEST_DIGEST}
 
 make distribution
 

--- a/scripts/tag-latest-version
+++ b/scripts/tag-latest-version
@@ -5,7 +5,7 @@ set -eux
 # ensure we are on the latest main
 git pull origin main
 
-latest_tag=$(git describe --tags --abbrev=0)
+latest_tag="latest"
 current_commit=${CIRCLE_SHA1:-$(git rev-parse HEAD)}
 
 commit_list=$(git rev-list "$latest_tag".."$current_commit")
@@ -13,10 +13,8 @@ commit_list=$(git rev-list "$latest_tag".."$current_commit")
 # Check if the commit list is not empty
 if [ -n "$commit_list" ]; then
     echo "Current commit is ahead of the previous tag; pushing a new tag"
-    minor=$(echo "${latest_tag}" | cut -d '.' -f 2)
-    new_tag="v0.$(($minor+1)).0"
-    git tag -a $new_tag -m"${new_tag}"
-    git push origin $new_tag
+    git tag -a $latest_tag -m "${latest_tag}" --force
+    git push origin $latest_tag --force
 else
     echo "Current commit is not ahead of the previous tag; not pushing a new tag"
 fi


### PR DESCRIPTION
Changes:
- Move to only have a `latest` release (and tag)
- Append the manifest digest to each of the images (Kratix and Work Creator)