### PR TITLE
Support azure devops repos

### DIFF
--- a/lib/writers/git.go
+++ b/lib/writers/git.go
@@ -279,10 +279,8 @@ func (g *GitWriter) cloneRepo(localRepoFilePath string, logger logr.Logger) (*gi
 		}
 	}
 
-	transport.UnsupportedCapabilities = oldUnsupportedCaps
-
 	logger.Info("cloning repo")
-	return git.PlainClone(localRepoFilePath, false, &git.CloneOptions{
+	repo, err := git.PlainClone(localRepoFilePath, false, &git.CloneOptions{
 		Auth:            g.GitServer.Auth,
 		URL:             g.GitServer.URL,
 		ReferenceName:   plumbing.NewBranchReferenceName(g.GitServer.Branch),
@@ -291,6 +289,9 @@ func (g *GitWriter) cloneRepo(localRepoFilePath string, logger logr.Logger) (*gi
 		NoCheckout:      false,
 		InsecureSkipTLS: true,
 	})
+
+	transport.UnsupportedCapabilities = oldUnsupportedCaps
+	return repo, err
 }
 
 func (g *GitWriter) commitAndPush(repo *git.Repository, worktree *git.Worktree, action, workPlacementName string, logger logr.Logger) (string, error) {


### PR DESCRIPTION
Searching for the error came up with a lot of results for this issue when using `go-git` https://www.google.com/search?q=unexpected+client+error+400+devops+git+clone&oq=unexpected+client+error+400+devops+git+clone&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIHCAEQIRigATIHCAIQIRigATIHCAMQIRigAdIBCDU0MzdqMGo3qAIAsAIA&sourceid=chrome&ie=UTF-8

Found the fix here https://github.com/pulumi/pulumi/pull/12001. Original issue in go-git https://github.com/go-git/go-git/issues/64

before:
```
2024-07-12T16:43:25Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   creating local directory        {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}
2024-07-12T16:43:25Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   cloning repo    {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}
2024-07-12T16:43:27Z    ERROR   controllers.DestinationController.writers.GitStateStoreWriter   could not clone repository      {"destination": {"name":"worker"}, "dir": "worker", "branch": "main", "error": "unexpected client error: unexpected requesting \"https://dev.azure.com/syntasso/jake/_git/jake/git-upload-pack\" status code: 400"}
github.com/syntasso/kratix/lib/writers.(*GitWriter).setupLocalDirectoryWithRepo
        /workspace/lib/writers/git.go:242
github.com/syntasso/kratix/lib/writers.(*GitWriter).update
        /workspace/lib/writers/git.go:122
github.com/syntasso/kratix/lib/writers.(*GitWriter).UpdateFiles
        /workspace/lib/writers/git.go:108
github.com/syntasso/kratix/controllers.(*DestinationReconciler).createDependenciesPathWithExample
        /workspace/controllers/destination_controller.go:135
github.com/syntasso/kratix/controllers.(*DestinationReconciler).Reconcile
        /workspace/controllers/destination_controller.go:84
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:261
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:222

```

after:
```
2024-07-12T16:37:56Z    INFO    controllers.DestinationController       Registering Destination {"destination": {"name":"worker"}, "requestName": "worker"}
2024-07-12T16:37:57Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   creating local directory        {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}
2024-07-12T16:37:57Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   cloning repo    {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}
2024-07-12T16:37:57Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   pushing changes {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}
2024-07-12T16:37:58Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   creating local directory        {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}
2024-07-12T16:37:58Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   cloning repo    {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}
2024-07-12T16:37:58Z    INFO    controllers.DestinationController.writers.GitStateStoreWriter   pushing changes {"destination": {"name":"worker"}, "dir": "worker", "branch": "main"}

```