### PR TITLE
Don't reconcile Works that are being deleted; set workplacement finalizers after writing files

### DIFF
--- a/controllers/destination_controller.go
+++ b/controllers/destination_controller.go
@@ -91,12 +91,6 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return defaultRequeue, nil
 	}
 
-	// TODO: Instead of this function call, we could watch for changes to the Destination
-	// CRD and triggering all Works to reconcile on every change.
-	if err := r.Scheduler.ReconcileAllDependencyWorks(); err != nil {
-		logger.Error(err, "unable to schedule destination resources")
-		return defaultRequeue, nil
-	}
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/workplacement_controller.go
+++ b/controllers/workplacement_controller.go
@@ -103,14 +103,14 @@ func (r *WorkPlacementReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.deleteWorkPlacement(ctx, writer, workPlacement, filepathMode, logger)
 	}
 
-	if missingFinalizers := checkWorkPlacementFinalizers(workPlacement, filepathMode); len(missingFinalizers) > 0 {
-		return addFinalizers(opts, workPlacement, missingFinalizers)
-	}
-
 	versionID, err := r.writeWorkloadsToStateStore(writer, *workPlacement, *destination, logger)
 	if err != nil {
 		logger.Error(err, "Error writing to repository, will try again in 5 seconds")
 		return defaultRequeue, err
+	}
+
+	if missingFinalizers := checkWorkPlacementFinalizers(workPlacement, filepathMode); len(missingFinalizers) > 0 {
+		return addFinalizers(opts, workPlacement, missingFinalizers)
 	}
 
 	if versionID == "" && r.VersionCache[workPlacement.GetUniqueID()] != "" {

--- a/controllers/workplacement_controller_test.go
+++ b/controllers/workplacement_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("WorkplacementReconciler", func() {
 				Expect(result).To(Equal(ctrl.Result{}))
 
 				By("calling UpdateFiles()")
-				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 				dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 				Expect(workPlacementName).To(Equal(workPlacement.Name))
 				Expect(dir).To(Equal(""))
@@ -214,17 +214,17 @@ files:
 					Expect(result).To(Equal(ctrl.Result{}))
 
 					kratixStateFile := fmt.Sprintf(".kratix/%s-%s.yaml", workPlacement.Namespace, workPlacement.Name)
-					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(3))
-					Expect(fakeWriter.ReadFileCallCount()).To(Equal(2))
+					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(4))
+					Expect(fakeWriter.ReadFileCallCount()).To(Equal(3))
 					Expect(fakeWriter.ReadFileArgsForCall(1)).To(Equal(kratixStateFile))
 
-					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(1)
+					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(2)
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
 					Expect(workloadsToCreate).To(BeNil())
 					Expect(workloadsToDelete).To(ConsistOf("fruit.yaml"))
 					Expect(dir).To(Equal(""))
 
-					dir, workPlacementName, workloadsToCreate, workloadsToDelete = fakeWriter.UpdateFilesArgsForCall(2)
+					dir, workPlacementName, workloadsToCreate, workloadsToDelete = fakeWriter.UpdateFilesArgsForCall(3)
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
 					Expect(workloadsToCreate).To(BeNil())
 					Expect(workloadsToDelete).To(ConsistOf(kratixStateFile))
@@ -244,10 +244,10 @@ files:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					Expect(fakeWriter.ReadFileCallCount()).To(Equal(1))
+					Expect(fakeWriter.ReadFileCallCount()).To(Equal(2))
 					Expect(fakeWriter.ReadFileArgsForCall(0)).To(Equal(fmt.Sprintf(".kratix/%s-%s.yaml", workPlacement.Namespace, workPlacement.Name)))
 
-					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
 					Expect(workloadsToCreate).To(ConsistOf(append(workloads, v1alpha1.Workload{
@@ -281,7 +281,7 @@ files:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 
-				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 				dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 				Expect(dir).To(Equal("resources/default/test-promise/test-resource/5058f"))
 				Expect(workPlacementName).To(Equal(workPlacement.Name))
@@ -310,7 +310,7 @@ files:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 					Expect(dir).To(Equal("dependencies/test-promise/5058f"))
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
@@ -372,7 +372,6 @@ files:
 				subResourceUpdateError = fmt.Errorf("an-error")
 
 				fakeWriter.UpdateFilesReturnsOnCall(0, "an-amazing-version-id", nil)
-				fakeWriter.UpdateFilesReturnsOnCall(1, "", nil)
 
 				result, err := t.reconcileUntilCompletion(reconciler, &workPlacement)
 				Expect(err).To(HaveOccurred())
@@ -384,6 +383,7 @@ files:
 				result, err = t.reconcileUntilCompletion(reconciler, &workPlacement)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(3))
 
 				latestWP := v1alpha1.WorkPlacement{}
 				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{

--- a/lib/writers/git.go
+++ b/lib/writers/git.go
@@ -219,7 +219,7 @@ func (g *GitWriter) ReadFile(filePath string) ([]byte, error) {
 	defer os.RemoveAll(filepath.Dir(localTmpDir))
 
 	if _, err := worktree.Filesystem.Lstat(fullPath); err != nil {
-		logger.Error(err, "could not stat file")
+		logger.Info("could not stat file", "err", err)
 		return nil, FileNotFound
 	}
 


### PR DESCRIPTION
closes #203 

green runs (the red is a different testing flaking, I'm investigating and will address in a different PR) 
![Screenshot 2024-07-24 at 14 11 39](https://github.com/user-attachments/assets/0225ccbd-fa8b-4253-9bd3-53342f324e90)

this bug was pretty nasty to debug, and highlighted two issues:
- Destination controller triggers the reconciliation of ALL works, even if the work in question is being deleted, which causees it to recreate a workplacement immediately after its been deleted (race conditon)
- A workplacement gets the finalizer added for deleting the files it creates *before* it creates them, which means if a workplacement is created, finalizers added (requeue triggered), workplacement deleted, requeue starts the deletion path despite no files having been created.

## Example failure

Chronological order:

1. An existing healthy work get deleted, triggers deletion of workplacement
![1  Work being deleted](https://github.com/user-attachments/assets/1ba91963-a130-41ee-93bb-d4fe05107f2b)

2. Workplacement gets successfully deleted
![2  successfull deletion of wp](https://github.com/user-attachments/assets/addf3af5-c5bf-489c-a68d-d6478cc996c5)

3. The destination controller then triggers a reconcilation of all works (via the code directly, not via the work controller), the Work placement which is being deleted hasn't been deleted *yet*, because there is a time delay between the workplacement successfully being deleted, and the work resource having its finalzier removed. This reconciliation therefore then creates a new workplacement for the work
![3  destination triggering reconciliation of deleting work resource](https://github.com/user-attachments/assets/5911f994-7d44-4986-83e0-86d73a020b6a)

4. Workplacement gets created with finalizers, and then requeues (no files written yet!)
![4  workplacement recreated, adding finalizers](https://github.com/user-attachments/assets/c58b4efb-8680-47b2-86ec-542a78b6bbc4)
 Work being deleted](https://github.com/user-attachments/assets/bcad7c45-086e-4c10-82db-bb120a8a552f)
 
5. The workplacement gets marked as deleted, even though its not created any files yet
![5  deletion triggered- before workplacement actualy writes files](https://github.com/user-attachments/assets/e0a724ce-af54-4b77-bd57-7c6308374ef3)

6. Workplacement deletion fails because the finalizers exist, but the files do not
![6  workplacement deletion fails because it never wrote the fails, but has the finalizers](https://github.com/user-attachments/assets/c6f53788-6ff7-47df-9cf1-4ccb502513e1)
