### PR TITLE
Don't reconcile all RRs on promise creation; enforce a 1 second sleep between job creations

### DIFF
--- a/controllers/destination_controller.go
+++ b/controllers/destination_controller.go
@@ -91,12 +91,6 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return defaultRequeue, nil
 	}
 
-	// TODO: Instead of this function call, we could watch for changes to the Destination
-	// CRD and triggering all Works to reconcile on every change.
-	if err := r.Scheduler.ReconcileAllDependencyWorks(); err != nil {
-		logger.Error(err, "unable to schedule destination resources")
-		return defaultRequeue, nil
-	}
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/dynamic_resource_request_controller.go
+++ b/controllers/dynamic_resource_request_controller.go
@@ -149,6 +149,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
 	if requeue {
 		return defaultRequeue, nil
 	}

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -238,8 +238,10 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Info("requirements are fulfilled", "requirementsStatus", promise.Status.RequiredPromises)
 
 		if promise.GetGeneration() != promise.Status.ObservedGeneration {
-			if err := r.reconcileAllRRs(rrGVK); err != nil {
-				return ctrl.Result{}, err
+			if promise.GetGeneration() != 1 {
+				if err := r.reconcileAllRRs(rrGVK); err != nil {
+					return ctrl.Result{}, err
+				}
 			}
 			promise.Status.ObservedGeneration = promise.GetGeneration()
 			return ctrl.Result{}, r.Client.Status().Update(ctx, promise)

--- a/controllers/workplacement_controller.go
+++ b/controllers/workplacement_controller.go
@@ -103,14 +103,14 @@ func (r *WorkPlacementReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.deleteWorkPlacement(ctx, writer, workPlacement, filepathMode, logger)
 	}
 
-	if missingFinalizers := checkWorkPlacementFinalizers(workPlacement, filepathMode); len(missingFinalizers) > 0 {
-		return addFinalizers(opts, workPlacement, missingFinalizers)
-	}
-
 	versionID, err := r.writeWorkloadsToStateStore(writer, *workPlacement, *destination, logger)
 	if err != nil {
 		logger.Error(err, "Error writing to repository, will try again in 5 seconds")
 		return defaultRequeue, err
+	}
+
+	if missingFinalizers := checkWorkPlacementFinalizers(workPlacement, filepathMode); len(missingFinalizers) > 0 {
+		return addFinalizers(opts, workPlacement, missingFinalizers)
 	}
 
 	if versionID == "" && r.VersionCache[workPlacement.GetUniqueID()] != "" {

--- a/controllers/workplacement_controller_test.go
+++ b/controllers/workplacement_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("WorkplacementReconciler", func() {
 				Expect(result).To(Equal(ctrl.Result{}))
 
 				By("calling UpdateFiles()")
-				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 				dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 				Expect(workPlacementName).To(Equal(workPlacement.Name))
 				Expect(dir).To(Equal(""))
@@ -214,17 +214,17 @@ files:
 					Expect(result).To(Equal(ctrl.Result{}))
 
 					kratixStateFile := fmt.Sprintf(".kratix/%s-%s.yaml", workPlacement.Namespace, workPlacement.Name)
-					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(3))
-					Expect(fakeWriter.ReadFileCallCount()).To(Equal(2))
+					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(4))
+					Expect(fakeWriter.ReadFileCallCount()).To(Equal(3))
 					Expect(fakeWriter.ReadFileArgsForCall(1)).To(Equal(kratixStateFile))
 
-					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(1)
+					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(2)
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
 					Expect(workloadsToCreate).To(BeNil())
 					Expect(workloadsToDelete).To(ConsistOf("fruit.yaml"))
 					Expect(dir).To(Equal(""))
 
-					dir, workPlacementName, workloadsToCreate, workloadsToDelete = fakeWriter.UpdateFilesArgsForCall(2)
+					dir, workPlacementName, workloadsToCreate, workloadsToDelete = fakeWriter.UpdateFilesArgsForCall(3)
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
 					Expect(workloadsToCreate).To(BeNil())
 					Expect(workloadsToDelete).To(ConsistOf(kratixStateFile))
@@ -244,10 +244,10 @@ files:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					Expect(fakeWriter.ReadFileCallCount()).To(Equal(1))
+					Expect(fakeWriter.ReadFileCallCount()).To(Equal(2))
 					Expect(fakeWriter.ReadFileArgsForCall(0)).To(Equal(fmt.Sprintf(".kratix/%s-%s.yaml", workPlacement.Namespace, workPlacement.Name)))
 
-					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
 					Expect(workloadsToCreate).To(ConsistOf(append(workloads, v1alpha1.Workload{
@@ -281,7 +281,7 @@ files:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 
-				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 				dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 				Expect(dir).To(Equal("resources/default/test-promise/test-resource/5058f"))
 				Expect(workPlacementName).To(Equal(workPlacement.Name))
@@ -310,7 +310,7 @@ files:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
+					Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 					dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 					Expect(dir).To(Equal("dependencies/test-promise/5058f"))
 					Expect(workPlacementName).To(Equal(workPlacement.Name))
@@ -372,7 +372,6 @@ files:
 				subResourceUpdateError = fmt.Errorf("an-error")
 
 				fakeWriter.UpdateFilesReturnsOnCall(0, "an-amazing-version-id", nil)
-				fakeWriter.UpdateFilesReturnsOnCall(1, "", nil)
 
 				result, err := t.reconcileUntilCompletion(reconciler, &workPlacement)
 				Expect(err).To(HaveOccurred())
@@ -384,6 +383,7 @@ files:
 				result, err = t.reconcileUntilCompletion(reconciler, &workPlacement)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(3))
 
 				latestWP := v1alpha1.WorkPlacement{}
 				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/syntasso/kratix/api/v1alpha1"
@@ -93,6 +95,7 @@ func ReconcileConfigure(opts Opts) (bool, error) {
 	var mostRecentJob *batchv1.Job
 
 	if len(allJobs) != 0 {
+		opts.logger.Info("found existing jobs, checking to see which pipeline the most recent job is for")
 		resourceutil.SortJobsByCreationDateTime(allJobs, false)
 		mostRecentJob = &allJobs[0]
 		pipelineIndex = nextPipelineIndex(opts, mostRecentJob)
@@ -101,6 +104,8 @@ func ReconcileConfigure(opts Opts) (bool, error) {
 	if pipelineIndex >= len(opts.Resources) {
 		pipelineIndex = len(opts.Resources) - 1
 	}
+
+	opts.logger.Info("pipeline index", "index", pipelineIndex)
 
 	if pipelineIndex < 0 {
 		opts.logger.Info("No pipeline to reconcile")
@@ -115,10 +120,11 @@ func ReconcileConfigure(opts Opts) (bool, error) {
 	opts.logger.Info("Reconciling Configure workflow", "pipelineIndex", pipelineIndex, "mostRecentJob", mostRecentJobName)
 
 	pipeline := opts.Resources[pipelineIndex]
-	opts.logger = originalLogger.WithName(pipeline.Name)
-
 	isManualReconciliation := isManualReconciliation(opts.parentObject.GetLabels())
+	opts.logger = originalLogger.WithName(pipeline.Name).WithValues("isManualReconciliation", isManualReconciliation)
+
 	if jobIsForPipeline(pipeline, mostRecentJob) {
+		opts.logger.Info("checking if job is for pipeline", "job", mostRecentJob.Name, "pipeline", pipeline.Name)
 		if isRunning(mostRecentJob) {
 			if isManualReconciliation {
 				err := suspendJob(opts.ctx, opts.client, mostRecentJob)
@@ -134,7 +140,7 @@ func ReconcileConfigure(opts Opts) (bool, error) {
 		}
 
 		if isManualReconciliation {
-			opts.logger.Info("Pipeline running due to manual reconciliation", "pipeline", pipeline.Name)
+			opts.logger.Info("Pipeline running due to manual reconciliation", "pipeline", pipeline.Name, "parentLabels", opts.parentObject.GetLabels())
 			return createConfigurePipeline(opts, pipelineIndex, pipeline)
 		}
 
@@ -225,10 +231,13 @@ func nextPipelineIndex(opts Opts, mostRecentJob *batchv1.Job) int {
 		return 0
 	}
 
+	// in reverse order loop through the pipeline, see if the latest job is for
+	// the pipeline if it is and its finished then we know the pipeline at the
+	// index is done, and we need to start the next one
 	i := len(opts.Resources) - 1
 	for i >= 0 {
 		if jobIsForPipeline(opts.Resources[i], mostRecentJob) {
-			opts.logger.Info("Found job for pipeline", "pipeline", opts.Resources[i].Name, "index", i)
+			opts.logger.Info("Found job for pipeline", "pipeline", opts.Resources[i].Name, "job", mostRecentJob.Name, "status", mostRecentJob.Status, "index", i)
 			if isFailed(mostRecentJob) || isRunning(mostRecentJob) {
 				return i
 			}
@@ -237,7 +246,6 @@ func nextPipelineIndex(opts Opts, mostRecentJob *batchv1.Job) int {
 		i -= 1
 	}
 
-	opts.logger.Info("Next pipeline is", "index", i+1)
 	return i + 1
 }
 
@@ -247,7 +255,7 @@ func isFailed(job *batchv1.Job) bool {
 	}
 
 	for _, condition := range job.Status.Conditions {
-		if condition.Type == batchv1.JobFailed {
+		if condition.Type == batchv1.JobFailed || condition.Type == batchv1.JobSuspended {
 			return true
 		}
 	}
@@ -365,7 +373,11 @@ func createConfigurePipeline(opts Opts, pipelineIndex int, pipeline v1alpha1.Pip
 	}
 
 	opts.logger.Info("Triggering Promise pipeline")
+	isManualRec := isManualReconciliation(opts.parentObject.GetLabels())
 
+	if isManualRec {
+		time.Sleep(time.Millisecond * 1100)
+	}
 	applyResources(opts, append(pipeline.RequiredResources, pipeline.Job)...)
 
 	opts.logger.Info("Parent object:", "parent", opts.parentObject.GetName())
@@ -454,9 +466,9 @@ func applyResources(opts Opts, resources ...client.Object) {
 	opts.logger.Info("Reconciling pipeline resources")
 
 	for _, resource := range resources {
-		logger := opts.logger.WithValues("gvk", resource.GetObjectKind().GroupVersionKind(), "name", resource.GetName(), "namespace", resource.GetNamespace(), "labels", resource.GetLabels())
+		logger := opts.logger.WithValues("type", reflect.TypeOf(resource), "gvk", resource.GetObjectKind().GroupVersionKind(), "name", resource.GetName(), "namespace", resource.GetNamespace(), "labels", resource.GetLabels())
 
-		logger.Info("Reconciling")
+		logger.Info("Reconciling resource")
 		if err := opts.client.Create(opts.ctx, resource); err != nil {
 			if errors.IsAlreadyExists(err) {
 				if resource.GetObjectKind().GroupVersionKind().Kind == "ServiceAccount" {

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -372,14 +372,7 @@ func createConfigurePipeline(opts Opts, pipelineIndex int, pipeline v1alpha1.Pip
 		return updated, err
 	}
 
-	opts.logger.Info("Triggering Promise pipeline")
-	isManualRec := isManualReconciliation(opts.parentObject.GetLabels())
-
-	if isManualRec {
-		time.Sleep(time.Millisecond * 1100)
-	}
 	applyResources(opts, append(pipeline.RequiredResources, pipeline.Job)...)
-
 	opts.logger.Info("Parent object:", "parent", opts.parentObject.GetName())
 	if isManualReconciliation(opts.parentObject.GetLabels()) {
 		if err := removeManualReconciliationLabel(opts); err != nil {
@@ -497,4 +490,6 @@ func applyResources(opts Opts, resources ...client.Object) {
 			logger.Info("Resource created")
 		}
 	}
+
+	time.Sleep(time.Second * 1100)
 }

--- a/lib/writers/git.go
+++ b/lib/writers/git.go
@@ -219,7 +219,7 @@ func (g *GitWriter) ReadFile(filePath string) ([]byte, error) {
 	defer os.RemoveAll(filepath.Dir(localTmpDir))
 
 	if _, err := worktree.Filesystem.Lstat(fullPath); err != nil {
-		logger.Error(err, "could not stat file")
+		logger.Info("could not stat file", "err", err)
 		return nil, FileNotFound
 	}
 

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Kratix", func() {
 			secondPromiseConfigureWorkflowName = fmt.Sprintf("%s-2nd-workflow", bashPromiseName)
 		})
 
-		It("can install, update, and delete a promise", func() {
+		PIt("can install, update, and delete a promise", func() {
 			By("installing the promise", func() {
 				platform.eventuallyKubectl("apply", "-f", cat(bashPromise))
 
@@ -192,7 +192,7 @@ var _ = Describe("Kratix", func() {
 			})
 		})
 
-		When("the promise has requirements that are fulfilled", func() {
+		PWhen("the promise has requirements that are fulfilled", func() {
 			var tmpDir string
 			BeforeEach(func() {
 				var err error
@@ -410,7 +410,7 @@ var _ = Describe("Kratix", func() {
 			})
 		})
 
-		When("A Promise is updated", func() {
+		PWhen("A Promise is updated", func() {
 			It("propagates the changes and re-runs all the pipelines", func() {
 				By("installing and requesting v1alpha1 promise", func() {
 					platform.eventuallyKubectl("apply", "-f", cat(bashPromise))
@@ -492,7 +492,7 @@ var _ = Describe("Kratix", func() {
 		})
 	})
 
-	Describe("PromiseRelease", func() {
+	PDescribe("PromiseRelease", func() {
 		When("a PromiseRelease is installed", func() {
 			BeforeEach(func() {
 				tmpDir, err := os.MkdirTemp(os.TempDir(), "systest")
@@ -524,7 +524,7 @@ var _ = Describe("Kratix", func() {
 		})
 	})
 
-	Describe("Scheduling", Serial, func() {
+	PDescribe("Scheduling", Serial, func() {
 		//The tests start with destinations:
 		// Worker destination (BucketStateStore):
 		// - environment: dev
@@ -688,7 +688,7 @@ var _ = Describe("Kratix", func() {
 		})
 	})
 
-	Describe("filepathMode set to none", func() {
+	PDescribe("filepathMode set to none", func() {
 		It("manages output files from multiple resource requests", func() {
 			if getEnvOrDefault("TEST_SKIP_BUCKET_CHECK", "false") != "true" {
 				bashPromise.Spec.DestinationSelectors = []v1alpha1.PromiseScheduling{{

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Kratix", func() {
 			secondPromiseConfigureWorkflowName = fmt.Sprintf("%s-2nd-workflow", bashPromiseName)
 		})
 
-		PIt("can install, update, and delete a promise", func() {
+		It("can install, update, and delete a promise", func() {
 			By("installing the promise", func() {
 				platform.eventuallyKubectl("apply", "-f", cat(bashPromise))
 
@@ -192,7 +192,7 @@ var _ = Describe("Kratix", func() {
 			})
 		})
 
-		PWhen("the promise has requirements that are fulfilled", func() {
+		When("the promise has requirements that are fulfilled", func() {
 			var tmpDir string
 			BeforeEach(func() {
 				var err error
@@ -410,7 +410,7 @@ var _ = Describe("Kratix", func() {
 			})
 		})
 
-		PWhen("A Promise is updated", func() {
+		When("A Promise is updated", func() {
 			It("propagates the changes and re-runs all the pipelines", func() {
 				By("installing and requesting v1alpha1 promise", func() {
 					platform.eventuallyKubectl("apply", "-f", cat(bashPromise))
@@ -492,7 +492,7 @@ var _ = Describe("Kratix", func() {
 		})
 	})
 
-	PDescribe("PromiseRelease", func() {
+	Describe("PromiseRelease", func() {
 		When("a PromiseRelease is installed", func() {
 			BeforeEach(func() {
 				tmpDir, err := os.MkdirTemp(os.TempDir(), "systest")
@@ -524,7 +524,7 @@ var _ = Describe("Kratix", func() {
 		})
 	})
 
-	PDescribe("Scheduling", Serial, func() {
+	Describe("Scheduling", Serial, func() {
 		//The tests start with destinations:
 		// Worker destination (BucketStateStore):
 		// - environment: dev
@@ -688,7 +688,7 @@ var _ = Describe("Kratix", func() {
 		})
 	})
 
-	PDescribe("filepathMode set to none", func() {
+	Describe("filepathMode set to none", func() {
 		It("manages output files from multiple resource requests", func() {
 			if getEnvOrDefault("TEST_SKIP_BUCKET_CHECK", "false") != "true" {
 				bashPromise.Spec.DestinationSelectors = []v1alpha1.PromiseScheduling{{


### PR DESCRIPTION
We had a series of race conditions causing some test failures:
https://app.circleci.com/pipelines/github/syntasso/kratix/2135/workflows/db157571-5e8d-4062-9d77-cb0a95fbea28/jobs/11979
https://app.circleci.com/pipelines/github/syntasso/kratix/2133/workflows/a53d9571-223d-477e-a791-bb9e673b864c/jobs/11884

the observed behaviour of these failures were always: 
- 2 jobs for the 1st pipeline (1 suspended so no pod created)
-  N (N>1) jobs for the 2nd pipeline
- all these pods/jobs having the same creation timestamp (within 1 second of eachother)
![Screenshot 2024-07-24 at 16 04 10](https://github.com/user-attachments/assets/6e10fe5b-b450-4097-ad9f-596cfb15d094)


Three issues:
- When a Promise Generation changes we trigger the manual reconciliation of all RRs, this was happening on the Creation event (generation=1), which meant it was suspending jobs unnecessarily and if you very quickly created a Promise, then RR, we could accidentally create two jobs (suspending one of them) for the 1st pieline
- We handled a Job being suspended as it being finished, which was incorrect
- We can create multiple jobs within a second of each other, meaning they have the same creationTimestamp, which causes issues in our code as we rely on sorting jobs by time order to determine the latest one. This also led to race conditions as our k8s client uses a cache, meaning that if the reconciler ran repeatedly within a few milliseconds of eachother, we would create a load of jobs because the cache didn't list any jobs as existing, because it doesn't always give the most up to date information.

fixes:
- Gracefully handle the `promise.metadata.generation`==1 scenario
- Introduce a 1 second delay after creating jobs. Our reconcilers run sequentially, and using the requeue isn't sufficient since external things can trigger the reconciler to run again (ignoring the desired requeue time)
- Handle suspended jobs as a failure