### PR TITLE
feat: cross-namespace pipeline permissions

### DIFF
--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -704,7 +704,7 @@ var _ = Describe("Pipeline", func() {
 			})
 		})
 
-		DescribeTable("User provided permissions",
+		DescribeTable("User provided permissions within the Pipeline namespace",
 			func(resource bool, numRoles int) {
 				if resource {
 					factory.ResourceWorkflow = true
@@ -725,22 +725,20 @@ var _ = Describe("Pipeline", func() {
 				Expect(resources.Name).To(Equal(pipeline.GetName()))
 
 				Expect(resources.Shared.Roles).To(HaveLen(numRoles))
-				expectedName := fmt.Sprintf("%s-up", factory.ID)
-				Expect(resources.Shared.Roles[numRoles-1].GetName()).To(Equal(expectedName))
+				Expect(resources.Shared.Roles[numRoles-1].GetName()).To(ContainSubstring(factory.ID))
 				Expect(resources.Shared.Roles[numRoles-1].GetNamespace()).To(Equal("factoryNamespace"))
-				Expect(resources.Shared.Roles[numRoles-1].GetLabels()).To(HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()))
 				Expect(resources.Shared.Roles[numRoles-1].Rules).To(ConsistOf(rbacv1.PolicyRule{
 					Verbs:         []string{"watch", "create"},
 					APIGroups:     []string{"", "apps"},
 					Resources:     []string{"deployments", "deployments/status"},
 					ResourceNames: []string{"a-deployment", "b-deployment"},
 				}))
+				matchUserPermissionsLabels(&resources, resources.Shared.Roles[numRoles-1].GetLabels())
 
 				Expect(resources.Shared.RoleBindings).To(HaveLen(numRoles))
-				Expect(resources.Shared.RoleBindings[numRoles-1].GetName()).To(Equal(expectedName))
+				Expect(resources.Shared.RoleBindings[numRoles-1].GetName()).To(ContainSubstring(factory.ID))
 				Expect(resources.Shared.RoleBindings[numRoles-1].GetNamespace()).To(Equal("factoryNamespace"))
-				Expect(resources.Shared.RoleBindings[numRoles-1].GetLabels()).To(HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()))
-				Expect(resources.Shared.RoleBindings[numRoles-1].RoleRef.Name).To(Equal(expectedName))
+				Expect(resources.Shared.RoleBindings[numRoles-1].RoleRef.Name).To(ContainSubstring(factory.ID))
 				Expect(resources.Shared.RoleBindings[numRoles-1].RoleRef.Kind).To(Equal("Role"))
 				Expect(resources.Shared.RoleBindings[numRoles-1].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
 				Expect(resources.Shared.RoleBindings[numRoles-1].Subjects).To(ConsistOf(rbacv1.Subject{
@@ -748,12 +746,207 @@ var _ = Describe("Pipeline", func() {
 					Namespace: resources.Shared.ServiceAccount.GetNamespace(),
 					Name:      resources.Shared.ServiceAccount.GetName(),
 				}))
+				matchUserPermissionsLabels(&resources, resources.Shared.RoleBindings[numRoles-1].GetLabels())
 			},
 			Entry("promise pipeline", false, 1),
 			Entry("resource pipeline", true, 2),
 		)
+
+		Describe("User provided permissions with specific resource namespaces", func() {
+			When("resource namespace is a specific namespace", func() {
+				It("should create a cluster role and role binding for the specific namespace", func() {
+					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
+						{
+							ResourceNamespace: "specific-namespace",
+							PolicyRule: rbacv1.PolicyRule{
+								Verbs:         []string{"watch", "create"},
+								APIGroups:     []string{"", "apps"},
+								Resources:     []string{"deployments", "deployments/status"},
+								ResourceNames: []string{"a-deployment", "b-deployment"},
+							},
+						},
+					}
+
+					resources, err := factory.Resources(nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resources.Name).To(Equal(pipeline.GetName()))
+
+					Expect(resources.Shared.Roles).To(HaveLen(0))
+					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(1))
+
+					Expect(resources.Shared.ClusterRoles).To(HaveLen(2))
+					Expect(resources.Shared.ClusterRoles[1].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"a-deployment", "b-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[1].GetLabels())
+
+					Expect(resources.Shared.RoleBindings).To(HaveLen(1))
+					matchUserPermissionsLabels(&resources, resources.Shared.RoleBindings[0].GetLabels())
+					Expect(resources.Shared.RoleBindings[0].GetNamespace()).To(Equal("specific-namespace"))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.Name).To(Equal(resources.Shared.ClusterRoles[1].GetName()))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.Kind).To(Equal("ClusterRole"))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+					Expect(resources.Shared.RoleBindings[0].Subjects).To(ConsistOf(rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+						Name:      resources.Shared.ServiceAccount.GetName(),
+					}))
+				})
+			})
+
+			When("resource namespace is all namespaces", func() {
+				It("should create a cluster role and cluster role binding", func() {
+					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
+						{
+							ResourceNamespace: "*",
+							PolicyRule: rbacv1.PolicyRule{
+								Verbs:         []string{"watch", "create"},
+								APIGroups:     []string{"", "apps"},
+								Resources:     []string{"deployments", "deployments/status"},
+								ResourceNames: []string{"a-deployment", "b-deployment"},
+							},
+						},
+					}
+
+					resources, err := factory.Resources(nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resources.Name).To(Equal(pipeline.GetName()))
+
+					Expect(resources.Shared.Roles).To(HaveLen(0))
+					Expect(resources.Shared.RoleBindings).To(HaveLen(0))
+
+					Expect(resources.Shared.ClusterRoles).To(HaveLen(2))
+					Expect(resources.Shared.ClusterRoles[1].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"a-deployment", "b-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[1].GetLabels())
+
+					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(2))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoleBindings[1].GetLabels())
+					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.Name).To(Equal(resources.Shared.ClusterRoles[1].GetName()))
+					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.Kind).To(Equal("ClusterRole"))
+					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+					Expect(resources.Shared.ClusterRoleBindings[1].Subjects).To(ConsistOf(rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+						Name:      resources.Shared.ServiceAccount.GetName(),
+					}))
+				})
+			})
+
+			When("resource namespace is a specific namespace and all namespaces", func() {
+				It("should create a cluster role and role binding for the specific namespace and a cluster role and cluster role binding for all namespaces", func() {
+					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
+						{
+							PolicyRule: rbacv1.PolicyRule{
+								Verbs:         []string{"watch", "create"},
+								APIGroups:     []string{"", "apps"},
+								Resources:     []string{"deployments", "deployments/status"},
+								ResourceNames: []string{"a-deployment", "b-deployment"},
+							},
+						},
+						{
+							ResourceNamespace: "specific-namespace",
+							PolicyRule: rbacv1.PolicyRule{
+								Verbs:         []string{"watch", "create"},
+								APIGroups:     []string{"", "apps"},
+								Resources:     []string{"deployments", "deployments/status"},
+								ResourceNames: []string{"c-deployment", "d-deployment"},
+							},
+						},
+						{
+							ResourceNamespace: "*",
+							PolicyRule: rbacv1.PolicyRule{
+								Verbs:         []string{"watch", "create"},
+								APIGroups:     []string{"", "apps"},
+								Resources:     []string{"deployments", "deployments/status"},
+								ResourceNames: []string{"e-deployment", "f-deployment"},
+							},
+						},
+					}
+
+					resources, err := factory.Resources(nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resources.Name).To(Equal(pipeline.GetName()))
+
+					Expect(resources.Shared.Roles).To(HaveLen(1))
+					Expect(resources.Shared.RoleBindings).To(HaveLen(2))
+					Expect(resources.Shared.ClusterRoles).To(HaveLen(3))
+					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(2))
+
+					By("creating the role and role binding in the pipeline namespace")
+					Expect(resources.Shared.Roles[0].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"a-deployment", "b-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.Roles[0].GetLabels())
+					Expect(resources.Shared.RoleBindings[0].RoleRef.Name).To(Equal(resources.Shared.Roles[0].GetName()))
+					Expect(resources.Shared.RoleBindings[0].Namespace).To(Equal("factoryNamespace"))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.Kind).To(Equal("Role"))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+					Expect(resources.Shared.RoleBindings[0].Subjects).To(ConsistOf(rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+						Name:      resources.Shared.ServiceAccount.GetName(),
+					}))
+
+					By("creating the cluster role and role binding for the specific namespace")
+					Expect(resources.Shared.ClusterRoles[1].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"c-deployment", "d-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[1].GetLabels())
+					Expect(resources.Shared.RoleBindings[1].RoleRef.Name).To(Equal(resources.Shared.ClusterRoles[1].GetName()))
+					Expect(resources.Shared.RoleBindings[1].Namespace).To(Equal("specific-namespace"))
+					Expect(resources.Shared.RoleBindings[1].RoleRef.Kind).To(Equal("ClusterRole"))
+					Expect(resources.Shared.RoleBindings[1].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+					Expect(resources.Shared.RoleBindings[1].Subjects).To(ConsistOf(rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+						Name:      resources.Shared.ServiceAccount.GetName(),
+					}))
+
+					By("creating the cluster role and cluster role binding for all namespaces")
+					Expect(resources.Shared.ClusterRoles[2].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"e-deployment", "f-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[2].GetLabels())
+					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.Name).To(Equal(resources.Shared.ClusterRoles[2].GetName()))
+					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.Kind).To(Equal("ClusterRole"))
+					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+					Expect(resources.Shared.ClusterRoleBindings[1].Subjects).To(ConsistOf(rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+						Name:      resources.Shared.ServiceAccount.GetName(),
+					}))
+				})
+			})
+		})
 	})
 })
+
+func matchUserPermissionsLabels(pipelineJobResources *v1alpha1.PipelineJobResources, labels map[string]string) {
+	jobLabels := pipelineJobResources.Job.GetLabels()
+	Expect(labels).To(SatisfyAll(
+		HaveKeyWithValue(v1alpha1.PromiseNameLabel, jobLabels[v1alpha1.PromiseNameLabel]),
+		HaveKeyWithValue(v1alpha1.PipelineNameLabel, pipelineJobResources.Name),
+		HaveKeyWithValue(v1alpha1.WorkTypeLabel, jobLabels[v1alpha1.WorkTypeLabel]),
+		HaveKeyWithValue(v1alpha1.WorkActionLabel, jobLabels[v1alpha1.WorkActionLabel]),
+	))
+}
 
 func matchPromiseClusterRolesAndBindings(clusterRoles []rbacv1.ClusterRole, clusterRoleBindings []rbacv1.ClusterRoleBinding, factory *v1alpha1.PipelineFactory, sa *corev1.ServiceAccount) {
 	ExpectWithOffset(1, clusterRoles).To(HaveLen(1))

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -704,84 +704,137 @@ var _ = Describe("Pipeline", func() {
 			})
 		})
 
-		DescribeTable("User provided permissions within the Pipeline namespace",
-			func(resource bool, numRoles int) {
-				if resource {
+		When("user provided permissions within the Pipeline namespace", func() {
+			When("promise workflow", func() {
+				It("should create the user-provided permission role and role binding", func() {
+					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{{PolicyRule: createWatchDeployment()}}
+
+					resources, err := factory.Resources(nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resources.Name).To(Equal(pipeline.GetName()))
+
+					Expect(resources.Shared.Roles).To(HaveLen(1))
+					Expect(resources.Shared.Roles[0].GetName()).To(ContainSubstring(factory.ID))
+					Expect(resources.Shared.Roles[0].GetNamespace()).To(Equal("factoryNamespace"))
+					Expect(resources.Shared.Roles[0].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"a-deployment", "b-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.Roles[0].GetLabels())
+
+					Expect(resources.Shared.RoleBindings).To(HaveLen(1))
+					Expect(resources.Shared.RoleBindings[0].GetName()).To(ContainSubstring(factory.ID))
+					Expect(resources.Shared.RoleBindings[0].GetNamespace()).To(Equal("factoryNamespace"))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.Name).To(ContainSubstring(factory.ID))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.Kind).To(Equal("Role"))
+					Expect(resources.Shared.RoleBindings[0].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+					Expect(resources.Shared.RoleBindings[0].Subjects).To(ConsistOf(rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+						Name:      resources.Shared.ServiceAccount.GetName(),
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.RoleBindings[0].GetLabels())
+				})
+			})
+
+			When("resource workflow", func() {
+				It("should create the user-provided permission role/binding and the default role/binding", func() {
 					factory.ResourceWorkflow = true
-				}
-				factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
-					{
-						PolicyRule: rbacv1.PolicyRule{
-							Verbs:         []string{"watch", "create"},
-							APIGroups:     []string{"", "apps"},
-							Resources:     []string{"deployments", "deployments/status"},
-							ResourceNames: []string{"a-deployment", "b-deployment"},
-						},
-					},
-				}
-
-				resources, err := factory.Resources(nil)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(resources.Name).To(Equal(pipeline.GetName()))
-
-				Expect(resources.Shared.Roles).To(HaveLen(numRoles))
-				Expect(resources.Shared.Roles[numRoles-1].GetName()).To(ContainSubstring(factory.ID))
-				Expect(resources.Shared.Roles[numRoles-1].GetNamespace()).To(Equal("factoryNamespace"))
-				Expect(resources.Shared.Roles[numRoles-1].Rules).To(ConsistOf(rbacv1.PolicyRule{
-					Verbs:         []string{"watch", "create"},
-					APIGroups:     []string{"", "apps"},
-					Resources:     []string{"deployments", "deployments/status"},
-					ResourceNames: []string{"a-deployment", "b-deployment"},
-				}))
-				matchUserPermissionsLabels(&resources, resources.Shared.Roles[numRoles-1].GetLabels())
-
-				Expect(resources.Shared.RoleBindings).To(HaveLen(numRoles))
-				Expect(resources.Shared.RoleBindings[numRoles-1].GetName()).To(ContainSubstring(factory.ID))
-				Expect(resources.Shared.RoleBindings[numRoles-1].GetNamespace()).To(Equal("factoryNamespace"))
-				Expect(resources.Shared.RoleBindings[numRoles-1].RoleRef.Name).To(ContainSubstring(factory.ID))
-				Expect(resources.Shared.RoleBindings[numRoles-1].RoleRef.Kind).To(Equal("Role"))
-				Expect(resources.Shared.RoleBindings[numRoles-1].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
-				Expect(resources.Shared.RoleBindings[numRoles-1].Subjects).To(ConsistOf(rbacv1.Subject{
-					Kind:      rbacv1.ServiceAccountKind,
-					Namespace: resources.Shared.ServiceAccount.GetNamespace(),
-					Name:      resources.Shared.ServiceAccount.GetName(),
-				}))
-				matchUserPermissionsLabels(&resources, resources.Shared.RoleBindings[numRoles-1].GetLabels())
-			},
-			Entry("promise pipeline", false, 1),
-			Entry("resource pipeline", true, 2),
-		)
-
-		Describe("User provided permissions with specific resource namespaces", func() {
-			When("resource namespace is a specific namespace", func() {
-				It("should create a cluster role and role binding for the specific namespace", func() {
 					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
 						{
-							ResourceNamespace: "specific-namespace",
-							PolicyRule: rbacv1.PolicyRule{
+							PolicyRule: createWatchDeployment(),
+						},
+					}
+
+					resources, err := factory.Resources(nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resources.Shared.ClusterRoles).To(HaveLen(0))
+					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(0))
+					Expect(resources.Shared.Roles).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name":      Equal(factory.ID),
+								"Namespace": Equal(factory.Namespace),
+							}),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name":      MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
+								"Namespace": Equal(factory.Namespace),
+							}),
+							"Rules": ConsistOf(rbacv1.PolicyRule{
 								Verbs:         []string{"watch", "create"},
 								APIGroups:     []string{"", "apps"},
 								Resources:     []string{"deployments", "deployments/status"},
 								ResourceNames: []string{"a-deployment", "b-deployment"},
-							},
+							}),
+						}),
+					))
+
+					Expect(resources.Shared.RoleBindings).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name":      Equal(factory.ID),
+								"Namespace": Equal(factory.Namespace),
+							}),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name":      MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
+								"Namespace": Equal(factory.Namespace),
+							}),
+							"RoleRef": MatchFields(IgnoreExtras, Fields{
+								"Name":     MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
+								"Kind":     Equal("Role"),
+								"APIGroup": Equal("rbac.authorization.k8s.io"),
+							}),
+							"Subjects": ConsistOf(rbacv1.Subject{
+								Kind:      rbacv1.ServiceAccountKind,
+								Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+								Name:      resources.Shared.ServiceAccount.GetName(),
+							}),
+						}),
+					))
+				})
+			})
+		})
+
+		When("user provided permissions with a specific resource namespace", func() {
+			When("promise workflow", func() {
+				It("should create a cluster role and role binding for the specific namespace", func() {
+					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
+						{
+							ResourceNamespace: "specific-namespace",
+							PolicyRule:        createWatchDeployment(),
 						},
 					}
 
 					resources, err := factory.Resources(nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(resources.Name).To(Equal(pipeline.GetName()))
-
 					Expect(resources.Shared.Roles).To(HaveLen(0))
 					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(1))
 
-					Expect(resources.Shared.ClusterRoles).To(HaveLen(2))
-					Expect(resources.Shared.ClusterRoles[1].Rules).To(ConsistOf(rbacv1.PolicyRule{
-						Verbs:         []string{"watch", "create"},
-						APIGroups:     []string{"", "apps"},
-						Resources:     []string{"deployments", "deployments/status"},
-						ResourceNames: []string{"a-deployment", "b-deployment"},
-					}))
-					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[1].GetLabels())
+					Expect(resources.Shared.ClusterRoles).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name": Equal(factory.ID),
+							}),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
+							}),
+							"Rules": ConsistOf(rbacv1.PolicyRule{
+								Verbs:         []string{"watch", "create"},
+								APIGroups:     []string{"", "apps"},
+								Resources:     []string{"deployments", "deployments/status"},
+								ResourceNames: []string{"a-deployment", "b-deployment"},
+							}),
+						}),
+					))
 
 					Expect(resources.Shared.RoleBindings).To(HaveLen(1))
 					matchUserPermissionsLabels(&resources, resources.Shared.RoleBindings[0].GetLabels())
@@ -797,17 +850,68 @@ var _ = Describe("Pipeline", func() {
 				})
 			})
 
-			When("resource namespace is all namespaces", func() {
-				It("should create a cluster role and cluster role binding", func() {
+			When("resource workflow", func() {
+				It("should create a cluster role and role binding for the specific namespace", func() {
+					factory.ResourceWorkflow = true
+					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
+						{
+							ResourceNamespace: "specific-namespace",
+							PolicyRule:        createWatchDeployment(),
+						},
+					}
+
+					resources, err := factory.Resources(nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resources.Name).To(Equal(pipeline.GetName()))
+
+					Expect(resources.Shared.Roles).To(HaveLen(1))
+					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(0))
+
+					Expect(resources.Shared.ClusterRoles).To(HaveLen(1))
+					Expect(resources.Shared.ClusterRoles[0].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"a-deployment", "b-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[0].GetLabels())
+					matchUserPermissionsLabels(&resources, resources.Shared.RoleBindings[1].GetLabels())
+
+					Expect(resources.Shared.RoleBindings).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name":      Equal(factory.ID),
+								"Namespace": Equal(factory.Namespace),
+							}),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+								"Name":      MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
+								"Namespace": Equal("specific-namespace"),
+							}),
+							"RoleRef": MatchFields(IgnoreExtras, Fields{
+								"Name":     Equal(resources.Shared.ClusterRoles[0].GetName()),
+								"Kind":     Equal("ClusterRole"),
+								"APIGroup": Equal("rbac.authorization.k8s.io"),
+							}),
+							"Subjects": ConsistOf(rbacv1.Subject{
+								Kind:      rbacv1.ServiceAccountKind,
+								Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+								Name:      resources.Shared.ServiceAccount.GetName(),
+							}),
+						}),
+					))
+				})
+			})
+		})
+
+		When("user provided permissions resource namespace is set to all namespaces", func() {
+			When("promise workflow", func() {
+				It("should create cluster role and cluster role binding", func() {
 					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
 						{
 							ResourceNamespace: "*",
-							PolicyRule: rbacv1.PolicyRule{
-								Verbs:         []string{"watch", "create"},
-								APIGroups:     []string{"", "apps"},
-								Resources:     []string{"deployments", "deployments/status"},
-								ResourceNames: []string{"a-deployment", "b-deployment"},
-							},
+							PolicyRule:        createWatchDeployment(),
 						},
 					}
 
@@ -825,181 +929,30 @@ var _ = Describe("Pipeline", func() {
 						Resources:     []string{"deployments", "deployments/status"},
 						ResourceNames: []string{"a-deployment", "b-deployment"},
 					}))
-					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[1].GetLabels())
 
-					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(2))
-					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoleBindings[1].GetLabels())
-					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.Name).To(Equal(resources.Shared.ClusterRoles[1].GetName()))
-					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.Kind).To(Equal("ClusterRole"))
-					Expect(resources.Shared.ClusterRoleBindings[1].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
-					Expect(resources.Shared.ClusterRoleBindings[1].Subjects).To(ConsistOf(rbacv1.Subject{
-						Kind:      rbacv1.ServiceAccountKind,
-						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
-						Name:      resources.Shared.ServiceAccount.GetName(),
-					}))
-				})
-			})
-
-			When("there are both specific- and all-namespace resource namespaces", func() {
-				It("should create a cluster role and role binding for the specific namespace and a cluster role and cluster role binding for all namespaces", func() {
-					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
-						{
-							PolicyRule: rbacv1.PolicyRule{
-								Verbs:         []string{"watch", "create"},
-								APIGroups:     []string{"", "apps"},
-								Resources:     []string{"deployments", "deployments/status"},
-								ResourceNames: []string{"a-deployment", "b-deployment"},
-							},
-						},
-						{
-							ResourceNamespace: "specific-namespace",
-							PolicyRule: rbacv1.PolicyRule{
-								Verbs:         []string{"watch", "create"},
-								APIGroups:     []string{"", "apps"},
-								Resources:     []string{"deployments", "deployments/status"},
-								ResourceNames: []string{"c-deployment", "d-deployment"},
-							},
-						},
-						{
-							ResourceNamespace: "*",
-							PolicyRule: rbacv1.PolicyRule{
-								Verbs:         []string{"watch", "create"},
-								APIGroups:     []string{"", "apps"},
-								Resources:     []string{"deployments", "deployments/status"},
-								ResourceNames: []string{"e-deployment", "f-deployment"},
-							},
-						},
-					}
-
-					resources, err := factory.Resources(nil)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(resources.Name).To(Equal(pipeline.GetName()))
-
-					Expect(resources.Shared.RoleBindings).To(HaveLen(2))
-					Expect(resources.Shared.ClusterRoles).To(HaveLen(3))
-					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(2))
-
-					By("creating the role in the pipeline namespace")
-					Expect(resources.Shared.Roles).To(ConsistOf(
-						MatchFields(IgnoreExtras, Fields{
-							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-								"Name":      MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
-								"Namespace": Equal(factory.Namespace),
-							}),
-							"Rules": ConsistOf(rbacv1.PolicyRule{
-								Verbs:         []string{"watch", "create"},
-								APIGroups:     []string{"", "apps"},
-								Resources:     []string{"deployments", "deployments/status"},
-								ResourceNames: []string{"a-deployment", "b-deployment"},
-							}),
-						}),
-					))
-					matchUserPermissionsLabels(&resources, resources.Shared.Roles[0].GetLabels())
-
-					By("creating the role bindings for the pipeline and specific namespace")
-					Expect(resources.Shared.RoleBindings).To(ConsistOf(
-						MatchFields(IgnoreExtras, Fields{
-							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-								"Name":      MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
-								"Namespace": Equal(factory.Namespace),
-							}),
-							"RoleRef": MatchFields(IgnoreExtras, Fields{
-								"Name":     MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
-								"Kind":     Equal("Role"),
-								"APIGroup": Equal("rbac.authorization.k8s.io"),
-							}),
-							"Subjects": ConsistOf(rbacv1.Subject{
-								Kind:      rbacv1.ServiceAccountKind,
-								Namespace: resources.Shared.ServiceAccount.GetNamespace(),
-								Name:      resources.Shared.ServiceAccount.GetName(),
-							}),
-						}),
-						MatchFields(IgnoreExtras, Fields{
-							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-								"Name":      MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
-								"Namespace": Equal("specific-namespace"),
-							}),
-							"RoleRef": MatchFields(IgnoreExtras, Fields{
-								"Name":     MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
-								"Kind":     Equal("ClusterRole"),
-								"APIGroup": Equal("rbac.authorization.k8s.io"),
-							}),
-							"Subjects": ConsistOf(rbacv1.Subject{
-								Kind:      rbacv1.ServiceAccountKind,
-								Namespace: resources.Shared.ServiceAccount.GetNamespace(),
-								Name:      resources.Shared.ServiceAccount.GetName(),
-							}),
-						}),
-					))
-
-					By("creating a cluster role for the specific- and all-namespace permissions, and the promise permissions")
 					Expect(resources.Shared.ClusterRoles).To(ConsistOf(
 						MatchFields(IgnoreExtras, Fields{
 							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 								"Name": Equal(factory.ID),
-								"Labels": SatisfyAll(
-									HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-									HaveLen(1),
-								),
-							}),
-							"Rules": ConsistOf(rbacv1.PolicyRule{
-								Verbs:     []string{"get", "list", "update", "create", "patch"},
-								APIGroups: []string{v1alpha1.GroupVersion.Group},
-								Resources: []string{v1alpha1.PromisePlural, v1alpha1.PromisePlural + "/status", "works"},
-							}),
-						}),
-						MatchFields(IgnoreExtras, Fields{
-							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-								"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
-								"Labels": SatisfyAll(
-									HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-									HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
-									HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
-									HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
-									HaveKeyWithValue(v1alpha1.UserPermissionResourceNamespaceLabel, "specific-namespace"),
-									HaveLen(5),
-								),
-							}),
-							"Rules": ConsistOf(rbacv1.PolicyRule{
-								Verbs:         []string{"watch", "create"},
-								APIGroups:     []string{"", "apps"},
-								Resources:     []string{"deployments", "deployments/status"},
-								ResourceNames: []string{"c-deployment", "d-deployment"},
 							}),
 						}),
 						MatchFields(IgnoreExtras, Fields{
 							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 								"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "kratix-all-namespaces")),
-								"Labels": SatisfyAll(
-									HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-									HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
-									HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
-									HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
-									HaveKeyWithValue(v1alpha1.UserPermissionResourceNamespaceLabel, "kratix_all_namespaces"),
-									HaveLen(5),
-								),
 							}),
 							"Rules": ConsistOf(rbacv1.PolicyRule{
 								Verbs:         []string{"watch", "create"},
 								APIGroups:     []string{"", "apps"},
 								Resources:     []string{"deployments", "deployments/status"},
-								ResourceNames: []string{"e-deployment", "f-deployment"},
+								ResourceNames: []string{"a-deployment", "b-deployment"},
 							}),
 						}),
 					))
 
-					By("creating the cluster role binding for all namespaces, and the promise permissions")
 					Expect(resources.Shared.ClusterRoleBindings).To(ConsistOf(
 						MatchFields(IgnoreExtras, Fields{
 							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 								"Name": MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
-								"Labels": SatisfyAll(
-									HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-									HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
-									HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
-									HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
-									HaveLen(4),
-								),
 							}),
 							"RoleRef": MatchFields(IgnoreExtras, Fields{
 								"Name":     MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "kratix-all-namespaces")),
@@ -1015,55 +968,236 @@ var _ = Describe("Pipeline", func() {
 						MatchFields(IgnoreExtras, Fields{
 							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 								"Name": Equal(factory.ID),
-								"Labels": SatisfyAll(
-									HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-									HaveLen(1),
-								),
-							}),
-							"RoleRef": MatchFields(IgnoreExtras, Fields{
-								"Name":     Equal(factory.ID),
-								"Kind":     Equal("ClusterRole"),
-								"APIGroup": Equal("rbac.authorization.k8s.io"),
-							}),
-							"Subjects": ConsistOf(rbacv1.Subject{
-								Kind:      rbacv1.ServiceAccountKind,
-								Namespace: resources.Shared.ServiceAccount.GetNamespace(),
-								Name:      resources.Shared.ServiceAccount.GetName(),
 							}),
 						}),
 					))
 				})
 			})
+
+			When("resource workflow", func() {
+				It("should create cluster role and cluster role binding", func() {
+					factory.ResourceWorkflow = true
+					factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
+						{
+							ResourceNamespace: "*",
+							PolicyRule:        createWatchDeployment(),
+						},
+					}
+
+					resources, err := factory.Resources(nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resources.Name).To(Equal(pipeline.GetName()))
+
+					Expect(resources.Shared.Roles).To(HaveLen(1))
+					Expect(resources.Shared.RoleBindings).To(HaveLen(1))
+
+					Expect(resources.Shared.ClusterRoles).To(HaveLen(1))
+					Expect(resources.Shared.ClusterRoles[0].Rules).To(ConsistOf(rbacv1.PolicyRule{
+						Verbs:         []string{"watch", "create"},
+						APIGroups:     []string{"", "apps"},
+						Resources:     []string{"deployments", "deployments/status"},
+						ResourceNames: []string{"a-deployment", "b-deployment"},
+					}))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoles[0].GetLabels())
+
+					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(1))
+					matchUserPermissionsLabels(&resources, resources.Shared.ClusterRoleBindings[0].GetLabels())
+					Expect(resources.Shared.ClusterRoleBindings[0].RoleRef.Name).To(Equal(resources.Shared.ClusterRoles[0].GetName()))
+					Expect(resources.Shared.ClusterRoleBindings[0].RoleRef.Kind).To(Equal("ClusterRole"))
+					Expect(resources.Shared.ClusterRoleBindings[0].RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+					Expect(resources.Shared.ClusterRoleBindings[0].Subjects).To(ConsistOf(rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+						Name:      resources.Shared.ServiceAccount.GetName(),
+					}))
+				})
+			})
 		})
 
-		Describe("User provided permissions with a resource workflow", func() {
-			It("should create the user-provided permission role and the default role", func() {
-				factory.ResourceWorkflow = true
+		When("there are both specific- and all-namespace resource namespaces", func() {
+			It("should create a cluster role and role binding for the specific namespace and a cluster role and cluster role binding for all namespaces", func() {
 				factory.Pipeline.Spec.RBAC.Permissions = []v1alpha1.Permission{
 					{
+						PolicyRule: createWatchDeployment(),
+					},
+					{
+						ResourceNamespace: "specific-namespace",
 						PolicyRule: rbacv1.PolicyRule{
 							Verbs:         []string{"watch", "create"},
 							APIGroups:     []string{"", "apps"},
 							Resources:     []string{"deployments", "deployments/status"},
-							ResourceNames: []string{"a-deployment", "b-deployment"},
+							ResourceNames: []string{"c-deployment", "d-deployment"},
+						},
+					},
+					{
+						ResourceNamespace: "*",
+						PolicyRule: rbacv1.PolicyRule{
+							Verbs:         []string{"watch", "create"},
+							APIGroups:     []string{"", "apps"},
+							Resources:     []string{"deployments", "deployments/status"},
+							ResourceNames: []string{"e-deployment", "f-deployment"},
 						},
 					},
 				}
 
 				resources, err := factory.Resources(nil)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(resources.Name).To(Equal(pipeline.GetName()))
 
+				Expect(resources.Shared.RoleBindings).To(HaveLen(2))
+				Expect(resources.Shared.ClusterRoles).To(HaveLen(3))
+				Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(2))
+
+				By("creating the role in the pipeline namespace")
 				Expect(resources.Shared.Roles).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-							"Name":      Equal(factory.ID),
-							"Namespace": Equal(factory.Namespace),
-						}),
-					}),
 					MatchFields(IgnoreExtras, Fields{
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 							"Name":      MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
 							"Namespace": Equal(factory.Namespace),
+						}),
+						"Rules": ConsistOf(rbacv1.PolicyRule{
+							Verbs:         []string{"watch", "create"},
+							APIGroups:     []string{"", "apps"},
+							Resources:     []string{"deployments", "deployments/status"},
+							ResourceNames: []string{"a-deployment", "b-deployment"},
+						}),
+					}),
+				))
+				matchUserPermissionsLabels(&resources, resources.Shared.Roles[0].GetLabels())
+
+				By("creating the role bindings for the pipeline and specific namespace")
+				Expect(resources.Shared.RoleBindings).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name":      MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
+							"Namespace": Equal(factory.Namespace),
+						}),
+						"RoleRef": MatchFields(IgnoreExtras, Fields{
+							"Name":     MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
+							"Kind":     Equal("Role"),
+							"APIGroup": Equal("rbac.authorization.k8s.io"),
+						}),
+						"Subjects": ConsistOf(rbacv1.Subject{
+							Kind:      rbacv1.ServiceAccountKind,
+							Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+							Name:      resources.Shared.ServiceAccount.GetName(),
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name":      MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
+							"Namespace": Equal("specific-namespace"),
+						}),
+						"RoleRef": MatchFields(IgnoreExtras, Fields{
+							"Name":     MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
+							"Kind":     Equal("ClusterRole"),
+							"APIGroup": Equal("rbac.authorization.k8s.io"),
+						}),
+						"Subjects": ConsistOf(rbacv1.Subject{
+							Kind:      rbacv1.ServiceAccountKind,
+							Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+							Name:      resources.Shared.ServiceAccount.GetName(),
+						}),
+					}),
+				))
+
+				By("creating a cluster role for the specific- and all-namespace permissions, and the promise permissions")
+				Expect(resources.Shared.ClusterRoles).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal(factory.ID),
+							"Labels": SatisfyAll(
+								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
+								HaveLen(1),
+							),
+						}),
+						"Rules": ConsistOf(rbacv1.PolicyRule{
+							Verbs:     []string{"get", "list", "update", "create", "patch"},
+							APIGroups: []string{v1alpha1.GroupVersion.Group},
+							Resources: []string{v1alpha1.PromisePlural, v1alpha1.PromisePlural + "/status", "works"},
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
+							"Labels": SatisfyAll(
+								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
+								HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
+								HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
+								HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
+								HaveKeyWithValue(v1alpha1.UserPermissionResourceNamespaceLabel, "specific-namespace"),
+								HaveLen(5),
+							),
+						}),
+						"Rules": ConsistOf(rbacv1.PolicyRule{
+							Verbs:         []string{"watch", "create"},
+							APIGroups:     []string{"", "apps"},
+							Resources:     []string{"deployments", "deployments/status"},
+							ResourceNames: []string{"c-deployment", "d-deployment"},
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "kratix-all-namespaces")),
+							"Labels": SatisfyAll(
+								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
+								HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
+								HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
+								HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
+								HaveKeyWithValue(v1alpha1.UserPermissionResourceNamespaceLabel, "kratix_all_namespaces"),
+								HaveLen(5),
+							),
+						}),
+						"Rules": ConsistOf(rbacv1.PolicyRule{
+							Verbs:         []string{"watch", "create"},
+							APIGroups:     []string{"", "apps"},
+							Resources:     []string{"deployments", "deployments/status"},
+							ResourceNames: []string{"e-deployment", "f-deployment"},
+						}),
+					}),
+				))
+
+				By("creating the cluster role binding for all namespaces, and the promise permissions")
+				Expect(resources.Shared.ClusterRoleBindings).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": MatchRegexp(fmt.Sprintf(`^%s-\b\w{5}\b$`, factory.ID)),
+							"Labels": SatisfyAll(
+								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
+								HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
+								HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
+								HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
+								HaveLen(4),
+							),
+						}),
+						"RoleRef": MatchFields(IgnoreExtras, Fields{
+							"Name":     MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "kratix-all-namespaces")),
+							"Kind":     Equal("ClusterRole"),
+							"APIGroup": Equal("rbac.authorization.k8s.io"),
+						}),
+						"Subjects": ConsistOf(rbacv1.Subject{
+							Kind:      rbacv1.ServiceAccountKind,
+							Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+							Name:      resources.Shared.ServiceAccount.GetName(),
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal(factory.ID),
+							"Labels": SatisfyAll(
+								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
+								HaveLen(1),
+							),
+						}),
+						"RoleRef": MatchFields(IgnoreExtras, Fields{
+							"Name":     Equal(factory.ID),
+							"Kind":     Equal("ClusterRole"),
+							"APIGroup": Equal("rbac.authorization.k8s.io"),
+						}),
+						"Subjects": ConsistOf(rbacv1.Subject{
+							Kind:      rbacv1.ServiceAccountKind,
+							Namespace: resources.Shared.ServiceAccount.GetNamespace(),
+							Name:      resources.Shared.ServiceAccount.GetName(),
 						}),
 					}),
 				))
@@ -1165,4 +1299,13 @@ func resourceHash(resource *unstructured.Unstructured) string {
 
 func combinedHash(hashes ...string) string {
 	return hash.ComputeHash(strings.Join(hashes, "-"))
+}
+
+func createWatchDeployment() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		Verbs:         []string{"watch", "create"},
+		APIGroups:     []string{"", "apps"},
+		Resources:     []string{"deployments", "deployments/status"},
+		ResourceNames: []string{"a-deployment", "b-deployment"},
+	}
 }

--- a/api/v1alpha1/work_types.go
+++ b/api/v1alpha1/work_types.go
@@ -26,11 +26,12 @@ import (
 const (
 	DefaultWorkloadGroupDirectory = "."
 
-	PromiseNameLabel  = KratixPrefix + "promise-name"
-	ResourceNameLabel = KratixPrefix + "resource-name"
-	PipelineNameLabel = KratixPrefix + "pipeline-name"
-	WorkTypeLabel     = KratixPrefix + "work-type"
-	WorkActionLabel   = KratixPrefix + "work-action"
+	PromiseNameLabel                     = KratixPrefix + "promise-name"
+	ResourceNameLabel                    = KratixPrefix + "resource-name"
+	PipelineNameLabel                    = KratixPrefix + "pipeline-name"
+	WorkTypeLabel                        = KratixPrefix + "work-type"
+	WorkActionLabel                      = KratixPrefix + "work-action"
+	UserPermissionResourceNamespaceLabel = KratixPrefix + "resource-namespace"
 
 	WorkTypePromise          = "promise"
 	WorkTypeResource         = "resource"

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -981,7 +981,7 @@ func (r *PromiseReconciler) applyWorkForStaticDependencies(o opts, promise *v1al
 		return err
 	}
 
-	o.logger.Info("resource reconciled", "operation", op, "namespace", work.GetNamespace(), "name", work.GetName(), "gvk", work.GroupVersionKind())
+	o.logger.Info("resource reconciled", "operation", op, "namespace", work.GetNamespace(), "name", work.GetName(), "gvk", work.GroupVersionKind().String())
 	return nil
 }
 

--- a/controllers/shared.go
+++ b/controllers/shared.go
@@ -59,7 +59,7 @@ func deleteAllResourcesWithKindMatchingLabel(o opts, gvk schema.GroupVersionKind
 
 	for _, resource := range resourceList.Items {
 		err = o.client.Delete(o.ctx, &resource, client.PropagationPolicy(metav1.DeletePropagationBackground))
-		o.logger.Info("deleting resource", "res", resource.GetName(), "gvk", resource.GroupVersionKind())
+		o.logger.Info("deleting resource", "res", resource.GetName(), "gvk", resource.GroupVersionKind().String())
 		if err != nil && !errors.IsNotFound(err) {
 			o.logger.Error(err, "Error deleting resource, will try again in 5 seconds", "name", resource.GetName(), "kind", resource.GetKind())
 			return true, err

--- a/lib/objectutil/name.go
+++ b/lib/objectutil/name.go
@@ -3,12 +3,33 @@ package objectutil
 import (
 	"regexp"
 
+	"github.com/syntasso/kratix/lib/hash"
 	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const maxNameLength = 63 - 1 - 5 //five char sha, plus the separator
 
 func GenerateObjectName(name string) string {
+	name = processName(name)
+
+	id := uuid.NewUUID()
+
+	return name + "-" + string(id[0:5])
+}
+
+func GenerateDeterministicObjectName(name string) string {
+	name = processName(name)
+
+	id := hash.ComputeHash(name)
+
+	return name + "-" + string(id[0:5])
+}
+
+func isAlphanumeric(s byte) bool {
+	return regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(string(s))
+}
+
+func processName(name string) string {
 	if len(name) > maxNameLength {
 		name = name[0 : maxNameLength-1]
 	}
@@ -17,11 +38,5 @@ func GenerateObjectName(name string) string {
 		name = name[0 : len(name)-1]
 	}
 
-	id := uuid.NewUUID()
-
-	return name + "-" + string(id[0:5])
-}
-
-func isAlphanumeric(s byte) bool {
-	return regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(string(s))
+	return name
 }

--- a/lib/objectutil/name.go
+++ b/lib/objectutil/name.go
@@ -18,9 +18,9 @@ func GenerateObjectName(name string) string {
 }
 
 func GenerateDeterministicObjectName(name string) string {
-	name = processName(name)
-
 	id := hash.ComputeHash(name)
+
+	name = processName(name)
 
 	return name + "-" + string(id[0:5])
 }

--- a/lib/objectutil/name_test.go
+++ b/lib/objectutil/name_test.go
@@ -3,36 +3,77 @@ package objectutil_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/syntasso/kratix/lib/hash"
 	"github.com/syntasso/kratix/lib/objectutil"
 )
 
 var _ = Describe("Name Utils", func() {
-	When("the given name does not reach the maximum character length", func() {
-		It("is appended with the sha", func() {
-			name := objectutil.GenerateObjectName("a-short-name")
-			Expect(name).To(MatchRegexp(`^a-short-name-\b\w{5}\b$`))
+	Describe("GenerateObjectName", func() {
+		When("the given name does not reach the maximum character length", func() {
+			It("is appended with the sha", func() {
+				name := objectutil.GenerateObjectName("a-short-name")
+				Expect(name).To(MatchRegexp(`^a-short-name-\b\w{5}\b$`))
+			})
+		})
+
+		When("the given name does exceeds maximum character length", func() {
+			It("is shortened and appended with the sha", func() {
+				name := objectutil.GenerateObjectName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaatrimmed")
+				Expect(name).To(MatchRegexp(`^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\b\w{5}\b$`))
+			})
+		})
+
+		When("the given name is the character limit", func() {
+			It("is shortened and appended with the sha", func() {
+				name := objectutil.GenerateObjectName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab")
+				Expect(name).To(MatchRegexp(`^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-\b\w{5}\b$`))
+			})
+		})
+
+		When("truncating the name would result in an invalid name", func() {
+			It("truncates it properly", func() {
+				longName := "kratix-promise-1.-@$#%&*()_+{}|:<>?/\\`~[]"
+				name := objectutil.GenerateObjectName(longName)
+				Expect(name).To(MatchRegexp(`^kratix-promise-1-\b\w{5}\b$`))
+			})
 		})
 	})
 
-	When("the given name does exceeds maximum character length", func() {
-		It("is shortened and appended with the sha", func() {
-			name := objectutil.GenerateObjectName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaatrimmed")
-			Expect(name).To(MatchRegexp(`^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-\b\w{5}\b$`))
+	Describe("GenerateDeterministicObjectName", func() {
+		When("the given name does not reach the maximum character length", func() {
+			It("is appended with the hash", func() {
+				resource_name := "a-short-name"
+				hashed_name := hash.ComputeHash(resource_name)
+				name := objectutil.GenerateDeterministicObjectName(resource_name)
+				Expect(name).To(Equal(resource_name + "-" + string(hashed_name[0:5])))
+			})
 		})
-	})
 
-	When("the given name is the character limit", func() {
-		It("is shortened and appended with the sha", func() {
-			name := objectutil.GenerateObjectName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab")
-			Expect(name).To(MatchRegexp(`^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-\b\w{5}\b$`))
+		When("the given name does exceeds maximum character length", func() {
+			It("is shortened and appended with the hash", func() {
+				resource_name := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaatrimmed"
+				hashed_name := hash.ComputeHash(resource_name)
+				name := objectutil.GenerateDeterministicObjectName(resource_name)
+				Expect(name).To(Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-" + string(hashed_name[0:5])))
+			})
 		})
-	})
 
-	When("truncating the name would result in an invalid name", func() {
-		It("truncates it properly", func() {
-			longName := "kratix-promise-1.-@$#%&*()_+{}|:<>?/\\`~[]"
-			name := objectutil.GenerateObjectName(longName)
-			Expect(name).To(MatchRegexp(`^kratix-promise-1-\b\w{5}\b$`))
+		When("the given name is the character limit", func() {
+			It("is shortened and appended with the hash", func() {
+				resource_name := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"
+				hashed_name := hash.ComputeHash(resource_name)
+				name := objectutil.GenerateDeterministicObjectName(resource_name)
+				Expect(name).To(Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab-" + string(hashed_name[0:5])))
+			})
+		})
+
+		When("truncating the name would result in an invalid name", func() {
+			It("truncates it properly", func() {
+				longName := "kratix-promise-1.-@$#%&*()_+{}|:<>?/\\`~[]"
+				hashed_name := hash.ComputeHash(longName)
+				name := objectutil.GenerateDeterministicObjectName(longName)
+				Expect(name).To(Equal("kratix-promise-1-" + string(hashed_name[0:5])))
+			})
 		})
 	})
 })

--- a/lib/workflow/rbac.go
+++ b/lib/workflow/rbac.go
@@ -1,0 +1,269 @@
+package workflow
+
+import (
+	"github.com/syntasso/kratix/api/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getObjectsToCreate(opts Opts, resourcesObjects []client.Object, objectsToSkip []client.Object) []client.Object {
+	var objectsToCreate []client.Object
+	for _, resource := range resourcesObjects {
+		found := false
+		for _, skip := range objectsToSkip {
+			if resourcesMatchNamespacedNameAndGVK(resource, skip) {
+				opts.logger.Info("Skipping resource because it already exists", "name", resource.GetName(), "namespace", resource.GetNamespace(), "gvk", resource.GetObjectKind().GroupVersionKind())
+				found = true
+				break
+			}
+		}
+		if !found {
+			objectsToCreate = append(objectsToCreate, resource)
+		}
+	}
+
+	return objectsToCreate
+}
+
+func getObjectsToDeleteOrSkip(opts Opts, pipeline v1alpha1.PipelineJobResources) ([]client.Object, []client.Object, error) {
+	var toDelete []client.Object
+	var toSkip []client.Object
+	var err error
+
+	labelSelector := labels.SelectorFromSet(getPipelineResourcesLabels(pipeline))
+	listOptions := client.ListOptions{LabelSelector: labelSelector}
+
+	var rolesToDelete []client.Object
+	var rolesToSkip []client.Object
+	if rolesToDelete, rolesToSkip, err = getRolesToDeleteOrSkip(opts, pipeline.Shared.Roles, listOptions); err != nil {
+		return nil, nil, err
+	}
+
+	toDelete = append(toDelete, rolesToDelete...)
+	toSkip = append(toSkip, rolesToSkip...)
+
+	var roleBindingsToDelete []client.Object
+	var roleBindingsToSkip []client.Object
+	if roleBindingsToDelete, roleBindingsToSkip, err = getRoleBindingsToDeleteOrSkip(opts, pipeline.Shared.RoleBindings, listOptions); err != nil {
+		return nil, nil, err
+	}
+
+	toDelete = append(toDelete, roleBindingsToDelete...)
+	toSkip = append(toSkip, roleBindingsToSkip...)
+
+	var clusterRolesToDelete []client.Object
+	var clusterRolesToSkip []client.Object
+	if clusterRolesToDelete, clusterRolesToSkip, err = getClusterRolesToDeleteOrSkip(opts, pipeline.Shared.ClusterRoles, listOptions); err != nil {
+		return nil, nil, err
+	}
+
+	toDelete = append(toDelete, clusterRolesToDelete...)
+	toSkip = append(toSkip, clusterRolesToSkip...)
+
+	var clusterRoleBindingsToDelete []client.Object
+	var clusterRoleBindingsToSkip []client.Object
+	if clusterRoleBindingsToDelete, clusterRoleBindingsToSkip, err = getClusterRoleBindingsToDeleteOrSkip(opts, pipeline.Shared.ClusterRoleBindings, listOptions); err != nil {
+		return nil, nil, err
+	}
+
+	toDelete = append(toDelete, clusterRoleBindingsToDelete...)
+	toSkip = append(toSkip, clusterRoleBindingsToSkip...)
+
+	return toDelete, toSkip, nil
+}
+
+func resourcesMatchNamespacedNameAndGVK(a, b client.Object) bool {
+	return a.GetName() == b.GetName() &&
+		a.GetNamespace() == b.GetNamespace() &&
+		a.GetObjectKind().GroupVersionKind() == b.GetObjectKind().GroupVersionKind()
+}
+
+func getRolesToDeleteOrSkip(opts Opts, desiredRoles []rbacv1.Role, listOptions client.ListOptions) ([]client.Object, []client.Object, error) {
+	rolesToDelete := []client.Object{}
+	rolesToSkip := []client.Object{}
+	existingRoles := rbacv1.RoleList{}
+
+	err := opts.client.List(opts.ctx, &existingRoles, &listOptions)
+
+	if err == nil {
+		for _, existingRole := range existingRoles.Items {
+			delete := true
+			for _, desiredRole := range desiredRoles {
+				if rolesMatch(existingRole, desiredRole) {
+					rolesToSkip = append(rolesToSkip, &desiredRole)
+					delete = false
+					break
+				}
+			}
+
+			if delete {
+				rolesToDelete = append(rolesToDelete, &existingRole)
+			}
+		}
+	} else if !errors.IsNotFound(err) {
+		opts.logger.Error(err, "failed to list user provided permission roles")
+		return nil, nil, err
+	}
+
+	return rolesToDelete, rolesToSkip, nil
+}
+
+func rolesMatch(existingRole rbacv1.Role, desiredRole rbacv1.Role) bool {
+	if len(existingRole.Rules) != len(desiredRole.Rules) {
+		return false
+	}
+
+	for i, existingRule := range existingRole.Rules {
+		if existingRule.String() != desiredRole.Rules[i].String() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func getRoleBindingsToDeleteOrSkip(opts Opts, desiredRoleBindings []rbacv1.RoleBinding, listOptions client.ListOptions) ([]client.Object, []client.Object, error) {
+	roleBindingsToDelete := []client.Object{}
+	roleBindingsToSkip := []client.Object{}
+	existingRoleBindings := rbacv1.RoleBindingList{}
+
+	err := opts.client.List(opts.ctx, &existingRoleBindings, &listOptions)
+
+	if err == nil {
+		for _, existingRoleBinding := range existingRoleBindings.Items {
+			delete := true
+			for _, desiredRoleBinding := range desiredRoleBindings {
+				if roleBindingsMatch(existingRoleBinding, desiredRoleBinding) {
+					roleBindingsToSkip = append(roleBindingsToSkip, &desiredRoleBinding)
+					delete = false
+					break
+				}
+			}
+
+			if delete {
+				roleBindingsToDelete = append(roleBindingsToDelete, &existingRoleBinding)
+			}
+		}
+	} else if !errors.IsNotFound(err) {
+		opts.logger.Error(err, "failed to list user provided permission role bindings")
+		return nil, nil, err
+	}
+
+	return roleBindingsToDelete, roleBindingsToSkip, nil
+}
+
+func roleBindingsMatch(existingRoleBinding rbacv1.RoleBinding, desiredRoleBinding rbacv1.RoleBinding) bool {
+	if len(existingRoleBinding.Subjects) != len(desiredRoleBinding.Subjects) {
+		return false
+	}
+
+	for i, existingSubject := range existingRoleBinding.Subjects {
+		if existingSubject.String() != desiredRoleBinding.Subjects[i].String() {
+			return false
+		}
+	}
+
+	return existingRoleBinding.RoleRef.String() == desiredRoleBinding.RoleRef.String()
+}
+
+func getClusterRolesToDeleteOrSkip(opts Opts, desiredClusterRoles []rbacv1.ClusterRole, listOptions client.ListOptions) ([]client.Object, []client.Object, error) {
+	clusterRolesToDelete := []client.Object{}
+	clusterRolesToSkip := []client.Object{}
+	existingClusterRoles := rbacv1.ClusterRoleList{}
+
+	err := opts.client.List(opts.ctx, &existingClusterRoles, &listOptions)
+
+	if err == nil {
+		for _, existingClusterRole := range existingClusterRoles.Items {
+			delete := true
+			for _, desiredClusterRole := range desiredClusterRoles {
+				opts.logger.Info("Checking if cluster roles match", "existing", existingClusterRole.Name, "desired", desiredClusterRole.Name)
+				if clusterRolesMatch(existingClusterRole, desiredClusterRole) {
+					opts.logger.Info("Cluster roles match")
+					clusterRolesToSkip = append(clusterRolesToSkip, &desiredClusterRole)
+					delete = false
+					break
+				}
+			}
+
+			if delete {
+				opts.logger.Info("No matching cluster role found, deleting", "clusterRole", existingClusterRole.Name)
+				clusterRolesToDelete = append(clusterRolesToDelete, &existingClusterRole)
+			}
+		}
+	} else if !errors.IsNotFound(err) {
+		opts.logger.Error(err, "failed to list user provided permission cluster roles")
+		return nil, nil, err
+	}
+
+	return clusterRolesToDelete, clusterRolesToSkip, nil
+}
+
+func clusterRolesMatch(existingClusterRole rbacv1.ClusterRole, desiredClusterRole rbacv1.ClusterRole) bool {
+	if len(existingClusterRole.Rules) != len(desiredClusterRole.Rules) {
+		return false
+	}
+
+	for i, existingRule := range existingClusterRole.Rules {
+		if existingRule.String() != desiredClusterRole.Rules[i].String() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func getClusterRoleBindingsToDeleteOrSkip(opts Opts, desiredClusterRoleBindings []rbacv1.ClusterRoleBinding, listOptions client.ListOptions) ([]client.Object, []client.Object, error) {
+	clusterRoleBindingsToDelete := []client.Object{}
+	clusterRoleBindingsToSkip := []client.Object{}
+	existingClusterRoleBindings := rbacv1.ClusterRoleBindingList{}
+
+	err := opts.client.List(opts.ctx, &existingClusterRoleBindings, &listOptions)
+
+	if err == nil {
+		for _, existingClusterRoleBinding := range existingClusterRoleBindings.Items {
+			delete := true
+			for _, desiredClusterRoleBinding := range desiredClusterRoleBindings {
+				if clusterRoleBindingsMatch(existingClusterRoleBinding, desiredClusterRoleBinding) {
+					clusterRoleBindingsToSkip = append(clusterRoleBindingsToSkip, &desiredClusterRoleBinding)
+					delete = false
+					break
+				}
+			}
+
+			if delete {
+				clusterRoleBindingsToDelete = append(clusterRoleBindingsToDelete, &existingClusterRoleBinding)
+			}
+		}
+	} else if !errors.IsNotFound(err) {
+		opts.logger.Error(err, "failed to list user provided permission cluster role bindings")
+		return nil, nil, err
+	}
+
+	return clusterRoleBindingsToDelete, clusterRoleBindingsToSkip, nil
+}
+
+func clusterRoleBindingsMatch(existingClusterRoleBinding rbacv1.ClusterRoleBinding, desiredClusterRoleBinding rbacv1.ClusterRoleBinding) bool {
+	if len(existingClusterRoleBinding.Subjects) != len(desiredClusterRoleBinding.Subjects) {
+		return false
+	}
+
+	for i, existingSubject := range existingClusterRoleBinding.Subjects {
+		if existingSubject.String() != desiredClusterRoleBinding.Subjects[i].String() {
+			return false
+		}
+	}
+
+	return existingClusterRoleBinding.RoleRef.String() == desiredClusterRoleBinding.RoleRef.String()
+}
+
+func getPipelineResourcesLabels(pipeline v1alpha1.PipelineJobResources) map[string]string {
+	return map[string]string{
+		v1alpha1.PipelineNameLabel: pipeline.Name,
+		v1alpha1.PromiseNameLabel:  pipeline.Job.GetLabels()[v1alpha1.PromiseNameLabel],
+		v1alpha1.WorkTypeLabel:     pipeline.Job.GetLabels()[v1alpha1.WorkTypeLabel],
+		v1alpha1.WorkActionLabel:   pipeline.Job.GetLabels()[v1alpha1.WorkActionLabel],
+	}
+}

--- a/lib/workflow/rbac.go
+++ b/lib/workflow/rbac.go
@@ -15,7 +15,7 @@ func filterObjectsToCreate(opts Opts, resourcesObjects []client.Object, objectsT
 	for _, resource := range resourcesObjects {
 		found := false
 		for _, skip := range objectsToSkip {
-			if resourcesMatchNamespacedNameAndType(resource, skip) {
+			if resourcesMatchNamespacedNameAndGVK(resource, skip) {
 				opts.logger.Info("Skipping resource because it already exists", "type", reflect.TypeOf(resource), "name", resource.GetName(), "namespace", resource.GetNamespace(), "gvk", resource.GetObjectKind().GroupVersionKind().String())
 				found = true
 				break
@@ -79,11 +79,10 @@ func getObjectsToDeleteOrSkip(opts Opts, pipeline v1alpha1.PipelineJobResources)
 	return toDelete, toSkip, nil
 }
 
-func resourcesMatchNamespacedNameAndType(a, b client.Object) bool {
-	// NOTE: GVK not present on the objects, therefore using type as a workaround for comparison
+func resourcesMatchNamespacedNameAndGVK(a, b client.Object) bool {
 	return a.GetName() == b.GetName() &&
 		a.GetNamespace() == b.GetNamespace() &&
-		reflect.TypeOf(a) == reflect.TypeOf(b)
+		a.GetObjectKind().GroupVersionKind().String() == b.GetObjectKind().GroupVersionKind().String()
 }
 
 func getRolesToDeleteOrSkip(opts Opts, desiredRoles []rbacv1.Role, listOptions client.ListOptions) ([]client.Object, []client.Object, error) {

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -378,15 +378,12 @@ func createConfigurePipeline(opts Opts, pipelineIndex int, resources v1alpha1.Pi
 	opts.logger.Info("Triggering Configure pipeline")
 
 	var objectToDelete []client.Object
-	var objectsToSkip []client.Object
-	if objectToDelete, objectsToSkip, err = getObjectsToDeleteOrSkip(opts, resources); err != nil {
+	if objectToDelete, err = getObjectsToDelete(opts, resources); err != nil {
 		return false, err
 	}
 
-	objectsToCreate := filterObjectsToCreate(opts, resources.GetObjects(), objectsToSkip)
-
 	deleteResources(opts, objectToDelete...)
-	applyResources(opts, append(objectsToCreate, resources.Job)...)
+	applyResources(opts, append(resources.GetObjects(), resources.Job)...)
 
 	opts.logger.Info("Parent object:", "parent", opts.parentObject.GetName())
 	if isManualReconciliation(opts.parentObject.GetLabels()) {

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -383,7 +383,7 @@ func createConfigurePipeline(opts Opts, pipelineIndex int, resources v1alpha1.Pi
 		return false, err
 	}
 
-	objectsToCreate := getObjectsToCreate(opts, resources.GetObjects(), objectsToSkip)
+	objectsToCreate := filterObjectsToCreate(opts, resources.GetObjects(), objectsToSkip)
 
 	deleteResources(opts, objectToDelete...)
 	applyResources(opts, append(objectsToCreate, resources.Job)...)
@@ -474,7 +474,7 @@ func applyResources(opts Opts, resources ...client.Object) {
 	opts.logger.Info("Reconciling pipeline resources")
 
 	for _, resource := range resources {
-		logger := opts.logger.WithValues("type", reflect.TypeOf(resource), "gvk", resource.GetObjectKind().GroupVersionKind(), "name", resource.GetName(), "namespace", resource.GetNamespace(), "labels", resource.GetLabels())
+		logger := opts.logger.WithValues("type", reflect.TypeOf(resource), "gvk", resource.GetObjectKind().GroupVersionKind().String(), "name", resource.GetName(), "namespace", resource.GetNamespace(), "labels", resource.GetLabels())
 
 		logger.Info("Reconciling resource")
 		if err := opts.client.Create(opts.ctx, resource); err != nil {
@@ -511,8 +511,8 @@ func applyResources(opts Opts, resources ...client.Object) {
 
 func deleteResources(opts Opts, resources ...client.Object) {
 	for _, resource := range resources {
-		logger := opts.logger.WithValues("gvk", resource.GetObjectKind().GroupVersionKind(), "name", resource.GetName(), "namespace", resource.GetNamespace(), "labels", resource.GetLabels())
-		logger.Info("Reconciling")
+		logger := opts.logger.WithValues("type", reflect.TypeOf(resource), "gvk", resource.GetObjectKind().GroupVersionKind().String(), "name", resource.GetName(), "namespace", resource.GetNamespace(), "labels", resource.GetLabels())
+		logger.Info("Deleting resource")
 		if err := opts.client.Delete(opts.ctx, resource); err != nil {
 			if errors.IsNotFound(err) {
 				logger.Info("Resource already deleted")

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -738,7 +738,7 @@ var _ = Describe("Workflow Reconciler", func() {
 					specificNamespaceClusterRole = &cr
 					specificNamespaceClusterRole.SetGeneration(originalResourceGeneration)
 					Expect(fakeK8sClient.Update(ctx, specificNamespaceClusterRole)).To(Succeed())
-				} else if ns == "kratix-all-namespaces" {
+				} else if ns == "kratix_all_namespaces" {
 					allNamespaceClusterRole = &cr
 					allNamespaceClusterRole.SetGeneration(originalResourceGeneration)
 					Expect(fakeK8sClient.Update(ctx, allNamespaceClusterRole)).To(Succeed())
@@ -780,7 +780,7 @@ var _ = Describe("Workflow Reconciler", func() {
 					},
 				))
 				Expect(initialRole.GetNamespace()).To(Equal(namespace))
-				Expect(initialRole.GetName()).To(Equal("redis-promise-configure-pipeline-1"))
+				Expect(initialRole.GetName()).To(MatchRegexp(`^redis-promise-configure-pipeline-1-\b\w{5}\b$`))
 
 				By("creating a cluster role for each set of specific- and all-namespace permissions")
 				Expect(initialClusterRoles.Items).To(HaveLen(2))
@@ -795,7 +795,7 @@ var _ = Describe("Workflow Reconciler", func() {
 							}),
 						),
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-							"Name": ContainSubstring("redis-promise-configure-pipeline-1-"),
+							"Name": MatchRegexp(`^redis-promise-configure-pipeline-1-specific-namespace-\b\w{5}\b$`),
 						}),
 					}),
 					MatchFields(IgnoreExtras, Fields{
@@ -807,7 +807,7 @@ var _ = Describe("Workflow Reconciler", func() {
 							}),
 						),
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-							"Name": ContainSubstring("redis-promise-configure-pipeline-1-"),
+							"Name": MatchRegexp(`^redis-promise-configure-pipeline-1-kratix-all-namespaces-\b\w{5}\b$`),
 						}),
 					}),
 				))
@@ -822,7 +822,7 @@ var _ = Describe("Workflow Reconciler", func() {
 							"Kind": Equal("ClusterRole"),
 						}),
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-							"Name":      ContainSubstring("redis-promise-configure-pipeline-1-"),
+							"Name":      MatchRegexp(`^redis-promise-configure-pipeline-1-specific-namespace-\b\w{5}\b$`),
 							"Namespace": Equal("specific-namespace"),
 						}),
 					}),
@@ -832,7 +832,7 @@ var _ = Describe("Workflow Reconciler", func() {
 							"Kind": Equal("Role"),
 						}),
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-							"Name":      Equal("redis-promise-configure-pipeline-1"),
+							"Name":      Equal(initialRole.GetName()),
 							"Namespace": Equal(namespace),
 						}),
 					}),
@@ -842,7 +842,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				Expect(initialClusterRoleBindings.Items).To(HaveLen(1))
 				clusterRoleBinding := &initialClusterRoleBindings.Items[0]
 
-				Expect(clusterRoleBinding.GetName()).To(ContainSubstring("redis-promise-configure-pipeline-1-"))
+				Expect(clusterRoleBinding.GetName()).To(MatchRegexp(`^redis-promise-configure-pipeline-1-\b\w{5}\b$`))
 				Expect(clusterRoleBinding.RoleRef.Name).To(Equal(allNamespaceClusterRole.GetName()))
 				Expect(clusterRoleBinding.RoleRef.Kind).To(Equal("ClusterRole"))
 				Expect(clusterRoleBinding.Subjects).To(HaveLen(1))
@@ -964,7 +964,7 @@ var _ = Describe("Workflow Reconciler", func() {
 							"Kind": Equal("ClusterRole"),
 						}),
 						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-							"Name":       ContainSubstring("redis-promise-configure-pipeline-1-"),
+							"Name":       MatchRegexp(`^redis-promise-configure-pipeline-1-specific-namespace-\b\w{5}\b$`),
 							"Generation": Equal(originalResourceGeneration),
 						}),
 					}),

--- a/test/system/assets/bash-promise/promise-v1alpha2.yaml
+++ b/test/system/assets/bash-promise/promise-v1alpha2.yaml
@@ -78,6 +78,14 @@ spec:
             rbac:
               permissions:
                 - apiGroups: [ "" ]
+                  resources: [ "configmaps" ]
+                  verbs: [ "list" ]
+                  resourceNamespace: "*"
+                - apiGroups: [ "apps" ]
+                  resources: [ "deployments" ]
+                  verbs: [ "list" ]
+                  resourceNamespace: "pipeline-perms-ns"
+                - apiGroups: [ "" ]
                   resources: [ "secrets", "services" ]
                   verbs: [ "list" ]
                 - apiGroups: [ "rbac.authorization.k8s.io" ]

--- a/test/system/assets/bash-promise/promise.yaml
+++ b/test/system/assets/bash-promise/promise.yaml
@@ -58,6 +58,14 @@ spec:
             rbac:
               permissions:
                 - apiGroups: [ "" ]
+                  resources: [ "configmaps" ]
+                  verbs: [ "list" ]
+                  resourceNamespace: "*"
+                - apiGroups: [ "apps" ]
+                  resources: [ "deployments" ]
+                  verbs: [ "list" ]
+                  resourceNamespace: "pipeline-perms-ns"
+                - apiGroups: [ "" ]
                   resources: [ "secrets", "services" ]
                   verbs: [ "list" ]
                 - apiGroups: ["rbac.authorization.k8s.io"]

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/onsi/ginkgo/v2/types"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +19,6 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/syntasso/kratix/api/v1alpha1"
@@ -453,6 +453,26 @@ var _ = Describe("Kratix", func() {
 					worker.eventuallyKubectl("get", "configmap", rrDeclarativeConfigMap)
 				})
 
+				roleName := strings.Trim(platform.kubectl("get", "role", "-l",
+					userPermissionRoleLabels(bashPromiseName, "resource", "configure", "first"),
+					"-o=jsonpath='{.items[0].metadata.name}'"), "'")
+				roleCreationTimestamp := platform.kubectl("get", "role", roleName, "-o=jsonpath='{.metadata.creationTimestamp}'")
+
+				bindingName := strings.Trim(platform.kubectl("get", "rolebinding", "-l",
+					userPermissionRoleLabels(bashPromiseName, "resource", "configure", "first"),
+					"-o=jsonpath='{.items[0].metadata.name}'"), "'")
+				bindingCreationTimestamp := platform.kubectl("get", "rolebinding", bindingName, "-o=jsonpath='{.metadata.creationTimestamp}'")
+
+				specificNamespaceClusterRoleName := strings.Trim(platform.kubectl("get", "ClusterRole", "-l",
+					userPermissionClusterRoleLabels(bashPromiseName, "resource", "configure", "first", "pipeline-perms-ns"),
+					"-o=jsonpath='{.items[0].metadata.name}'"), "'")
+				specificNamespaceClusterRoleCreationTimestamp := platform.kubectl("get", "ClusterRole", specificNamespaceClusterRoleName, "-o=jsonpath='{.metadata.creationTimestamp}'")
+
+				allNamespaceClusterRoleName := strings.Trim(platform.kubectl("get", "ClusterRole", "-l",
+					userPermissionClusterRoleLabels(bashPromiseName, "resource", "configure", "first", "kratix_all_namespaces"),
+					"-o=jsonpath='{.items[0].metadata.name}'"), "'")
+				allNamespaceClusterRoleCreationTimestamp := platform.kubectl("get", "ClusterRole", allNamespaceClusterRoleName, "-o=jsonpath='{.metadata.creationTimestamp}'")
+
 				By("updating the promise", func() {
 					//Promise has:
 					// API:
@@ -462,7 +482,7 @@ var _ = Describe("Kratix", func() {
 					// Pipeline:
 					//    resource
 					//      Extra container to run the 3rd command field
-					//      rename configmap from from bashrr-test-default to bashrr-test-default-v2
+					//      rename configmap from bashrr-test-default to bashrr-test-default-v2
 					//    promise
 					//      rename namespace from bash-dep-namespace-v1alpha1 to
 					//      bash-dep-namespace-v1alpha2
@@ -489,6 +509,13 @@ var _ = Describe("Kratix", func() {
 					}, timeout, interval).Should(Succeed())
 
 					worker.withExitCode(1).eventuallyKubectl("get", "configmap", rrDeclarativeConfigMap)
+				})
+
+				By("not recreating permission objects", func() {
+					Expect(platform.kubectl("get", "role", roleName, "-o=jsonpath='{.metadata.creationTimestamp}'")).To(Equal(roleCreationTimestamp))
+					Expect(platform.kubectl("get", "rolebinding", bindingName, "-o=jsonpath='{.metadata.creationTimestamp}'")).To(Equal(bindingCreationTimestamp))
+					Expect(platform.kubectl("get", "clusterrole", specificNamespaceClusterRoleName, "-o=jsonpath='{.metadata.creationTimestamp}'")).To(Equal(specificNamespaceClusterRoleCreationTimestamp))
+					Expect(platform.kubectl("get", "clusterrole", allNamespaceClusterRoleName, "-o=jsonpath='{.metadata.creationTimestamp}'")).To(Equal(allNamespaceClusterRoleCreationTimestamp))
 				})
 
 				platform.eventuallyKubectlDelete("promise", bashPromiseName)
@@ -1045,4 +1072,18 @@ func readPromiseAndReplaceWithUniqueBashName(promisePath, bashPromiseName string
 	err = yaml.NewYAMLOrJSONDecoder(strings.NewReader(promiseContents), 100).Decode(promise)
 	Expect(err).NotTo(HaveOccurred())
 	return promise
+}
+
+func userPermissionRoleLabels(promiseName, workflowType, action, pipelineName string) string {
+	return fmt.Sprintf("%s=%s,%s=%s,%s=%s,%s=%s",
+		v1alpha1.PromiseNameLabel, promiseName,
+		v1alpha1.WorkTypeLabel, workflowType,
+		v1alpha1.WorkActionLabel, action,
+		v1alpha1.PipelineNameLabel, pipelineName)
+}
+
+func userPermissionClusterRoleLabels(promiseName, workflowType, action, pipelineName, namespace string) string {
+	return fmt.Sprintf("%s,%s=%s",
+		userPermissionRoleLabels(promiseName, workflowType, action, pipelineName),
+		v1alpha1.UserPermissionResourceNamespaceLabel, namespace)
 }

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -273,6 +273,9 @@ var _ = Describe("Kratix", func() {
 				platform.eventuallyKubectl("get", "crd", crd.Name)
 				worker.eventuallyKubectl("get", "namespace", declarativeWorkerNamespace)
 
+				platform.eventuallyKubectl("delete", "namespace", "pipeline-perms-ns")
+				platform.eventuallyKubectl("create", "namespace", "pipeline-perms-ns")
+
 				rrName := bashPromiseName + "rr-test"
 				platform.kubectl("apply", "-f", exampleBashRequest(rrName, "old"))
 
@@ -789,6 +792,8 @@ func exampleBashRequest(name, namespaceSuffix string) string {
 						mkdir -p /kratix/output/foo/
 						echo "{}" > /kratix/output/foo/example.json
 						kubectl get secret,role,service
+						kubectl get configmaps -n kratix-platform-system
+						kubectl get deployments -n pipeline-perms-ns
 						kubectl get namespace imperative-$(yq '.metadata.name' /kratix/input/object.yaml)-%[1]s || kubectl create namespace imperative-$(yq '.metadata.name' /kratix/input/object.yaml)-%[1]s
 						exit 0
 					fi


### PR DESCRIPTION
This PR introduces support for cross-namespace permissions in Kratix Pipelines via the Pipeline's `spec.rbac.permissions`.

It's now possible to access resources outside of the Pipeline namespace by setting the permissions in the Promise, removing the need to set up cross-namespace RBAC manually.

## New Features

### All-namespace permissions

```yaml
- apiVersion: platform.kratix.io/v1alpha1
  kind: Pipeline
  metadata:
    name: foo
  spec:
    rbac:
      permissions:
        - apiGroups: [ "" ]
          resources: [ "configmaps" ]
          verbs: [ "list" ]
          resourceNamespace: "*"
```

This gives the Pipeline's ServiceAccount permission to `list configmaps` across all namespaces.

### Specific namespace permissions

```yaml
- apiVersion: platform.kratix.io/v1alpha1
  kind: Pipeline
  metadata:
    name: foo
  spec:
    rbac:
      permissions:
        - apiGroups: [ "" ]
          resources: [ "configmaps" ]
          verbs: [ "list" ]
          resourceNamespace: "other-namespace"
```

This gives the Pipeline's ServiceAccount permission to `list configmaps` in the `other-namespace` namespace only.

## Engineering Notes

- RBAC objects relating to a given Pipeline are all labelled with the following: `kratix.io/promise-name`, `kratix.io/pipeline-name`, `kratix.io/work-type`, and `kratix.io/work-action`. This allows us to fetch all the RBAC objects for a given Pipeline.

- All RBAC objects matching the `kratix.io/promise-name` label continue to be cleaned up on Promise deletion.

- Pipeline Jobs for Resource workflows still use the same ServiceAccount, and  share instances of the RBAC objects (i.e. a single set of RBAC objects will be created once, the first time the workflow runs).

- The desired RBAC objects are calculated up-front (in `pipeline-types.go`). These are used to 'diff' with the existing RBAC objects in the cluster relating to this Pipeline, and delete the objects which are not in the desired set.

- The [name](https://github.com/syntasso/kratix/pull/210/files#diff-2276e9ad22ad86ed2fab0bac69ec0f838fe5562e5f7544395c1994b779189a43R20) of each object is **deterministic** (even for cluster-wide resources). This means that any references between RBAC objects (e.g. `roleRef`) won't differ between reconciliations, meaning that if the `roleRef` of a {Cluster}RoleBinding has changed, it's because it's actually referencing a **new** {Cluster}Role.

- We create the minimal set of RBAC resources necessary to achieve the right permissions, i.e. if there are two `spec.rbac.permissions` entries with `resourceNamespace: "other-namespace"`, we will create a **single** ClusterRole with both sets of rules.

- We accept `"*"` as the all-namespace value for `resourceNamespace`. However, this needs to be set as a label on the ClusterRole so that we can determine whether to create a RoleBinding or a ClusterRoleBinding for it. `"*"` is not a valid label value, so this is translated internally to `"kratix_all_namespaces"`. (NB: The `_` make this an invalid namespace, so it will never clash with a real namespace.)

- `rbac.go` could (and ideally should) be unit-tested individually. However, this was mainly extracted from `reconciler.go` for readability, and its logic is [exercised thoroughly](https://github.com/syntasso/kratix/pull/210/files#diff-5d92e5eef5813767c2b40d34ef4918c710d1f40db8a690ea0d4396226c3843dbR682) in `reconciler_test.go` so this is not urgent.

- We added `TypeMeta` to every resource generated in `pipeline_types.go` which means that the GVK is now non-empty in our logs.

fixes #198 