### PR TITLE
fix: remove deprecated circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,7 +313,6 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.23
           docker_layer_caching: true
       - docker_login
       - run:


### PR DESCRIPTION
https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176T

This fixes: https://app.circleci.com/pipelines/github/syntasso/kratix/2375/workflows/f6be0c1d-bbc8-49aa-897d-3fdae23bb5d0