### PR TITLE
chore: requeue on update conflict

### DIFF
--- a/controllers/work_controller.go
+++ b/controllers/work_controller.go
@@ -81,7 +81,10 @@ func (r *WorkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	logger.Info("Requesting scheduling for Work")
 	unscheduledWorkloadGroupIDs, err := r.Scheduler.ReconcileWork(work)
-	if err != nil {
+	if errors.IsConflict(err) {
+		logger.Info("failed to schedule Work due to update conflict, requeue...")
+		return fastRequeue, nil
+	} else if err != nil {
 		//TODO remove this error checking
 		//temp fix until resolved: https://syntasso.slack.com/archives/C044T9ZFUMN/p1674058648965449
 		logger.Error(err, "Error scheduling Work, will retry...")


### PR DESCRIPTION
## Context

follow up from #253 

Requeue when update fails with a conflict error instead of returning the error to reduce the occurence of update conflict error "the object has been modified"

```
2024-10-11T14:08:10Z	ERROR	Reconciler error	{"controller": "promise", "controllerGroup": "platform.kratix.io", "controllerKind": "Promise", "Promise": {"name":"bashb398b"}, "namespace": "", "name": "bashb398b", "reconcileID": "f067966e-ef3a-4ce8-b42b-939ec8cc6f01", "error": "Operation cannot be fulfilled on promises.platform.kratix.io \"bashb398b\": the object has been modified; please apply your changes to the latest version and try again"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:324
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:261
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:222
```

Before this PR, running system tests will produce about 60 of these errors:

```
k logs -n kratix-platform-system kratix-platform-controller-manager-5c86979644-pw4gt | grep "the object has been modified" | wc
Defaulted container "manager" out of: manager, kube-rbac-proxy
      60    2308   27173
```


With this PR:
```
❯ k -n kratix-platform-system logs kratix-platform-controller-manager-5c86979644-pcmmp| grep "the object has been modified" | wc
Defaulted container "manager" out of: manager, kube-rbac-proxy
      11     444    5246
  ```

