### PR TITLE
fix: ensure all promise finalizers checked when deleting

### DIFF
--- a/test/system/assets/bash-promise/execute-pipeline
+++ b/test/system/assets/bash-promise/execute-pipeline
@@ -21,7 +21,7 @@ declarative_platform_namespace=${unique_id}-platform-declarative
 
 if [ "${workflow_action}" = "delete" ]; then
   echo "promise/delete: cleaning up"
-  kubectl delete namespace ${imperative_platform_namespace}
+  kubectl delete namespace ${imperative_platform_namespace} --ignore-not-found
   exit 0
 fi
 

--- a/test/system/assets/bash-promise/promise-v1alpha2.yaml
+++ b/test/system/assets/bash-promise/promise-v1alpha2.yaml
@@ -73,7 +73,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: first-configure
           spec:
             rbac:
               permissions:
@@ -110,7 +110,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: second
+            name: second-configure
           spec:
             containers:
               - image: syntassodev/bash-promise:dev1
@@ -125,7 +125,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: delete
           spec:
             containers:
               - image: syntassodev/bash-promise:dev1
@@ -138,7 +138,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: first-configure
           spec:
             rbac:
               serviceAccount: REPLACEBASH-existing-custom-sa
@@ -152,7 +152,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: delete
           spec:
             rbac:
               serviceAccount: REPLACEBASH-new-custom-sa

--- a/test/system/assets/bash-promise/promise.yaml
+++ b/test/system/assets/bash-promise/promise.yaml
@@ -53,7 +53,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: first-configure
           spec:
             rbac:
               permissions:
@@ -91,7 +91,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: second
+            name: second-configure
           spec:
             containers:
               - image: syntassodev/bash-promise:dev1
@@ -106,7 +106,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: delete
           spec:
             containers:
               - image: syntassodev/bash-promise:dev1
@@ -119,7 +119,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: first-configure
           spec:
             rbac:
               serviceAccount: REPLACEBASH-existing-custom-sa
@@ -129,7 +129,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: second
+            name: second-configure
           spec:
             containers:
               - image: syntassodev/bash-promise:dev1
@@ -143,7 +143,7 @@ spec:
         - apiVersion: platform.kratix.io/v1alpha1
           kind: Pipeline
           metadata:
-            name: first
+            name: delete
           spec:
             rbac:
               serviceAccount: REPLACEBASH-new-custom-sa

--- a/test/system/assets/bash-promise/roles-for-promise.yaml
+++ b/test/system/assets/bash-promise/roles-for-promise.yaml
@@ -27,7 +27,7 @@ roleRef:
   name: REPLACEBASH-default-resource-pipeline-credentials
 subjects:
 - kind: ServiceAccount
-  name: REPLACEBASH-resource-configure-first
+  name: REPLACEBASH-resource-configure-first-configure
   namespace: default
 - kind: ServiceAccount
   name: REPLACEBASH-existing-custom-sa
@@ -36,5 +36,5 @@ subjects:
   name: REPLACEBASH-new-custom-sa
   namespace: kratix-platform-system
 - kind: ServiceAccount
-  name: REPLACEBASH-resource-delete-first
+  name: REPLACEBASH-resource-delete-delete
   namespace: default


### PR DESCRIPTION
## Summary

This PR does two things:
1. Adds `delete-workflows` and `workflows-cleanup` to the list of Promise finalizers which are checked when deleting a Promise.
2. Fixes the system tests to ensure that no resources are left over after tests have passed.

(1) was a bug we found while fixing (2), and was tested manually. It presented as failing to delete the Promise, which was found to be due to two combined factors:
- The Promise being deleted before all finalizers had been set (so only `delete-workflows` and `workflows-cleanup` were set).
- The `promiseFinalizers` list being incomplete (missing `delete-workflows` and `workflows-cleanup`), meaning these finalizers were never removed during delete.

## Impact

The bug in (1) would have been hit if the Promise was deleted when only the `delete-workflows` and `workflows-cleanup` finalizers had been set, and would have presented as the Promise never being deleted.

Explicitly, the series of events would be:
1.  user installs a Promise
2. Promise controller adds `delete-workflows` and `workflows-cleanup` finalizers and requeues
3. user deletes the Promise before any more finalizers added by Promise controller
4. Promise fails to delete because the controller thinks all finalizers have already been removed

The window between (2) and (4) for the user to delete the Promise in was very small (hence it only being hit in our tests) but it's now fixed!