### PR TITLE
chore: update deprecated flux resources

### DIFF
--- a/hack/destination/gitops-tk-resources-git.yaml
+++ b/hack/destination/gitops-tk-resources-git.yaml
@@ -12,7 +12,7 @@ spec:
   secretRef:
     name: gitea-credentials
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-resources
@@ -40,7 +40,7 @@ spec:
   secretRef:
     name: gitea-credentials
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-dependencies

--- a/hack/destination/gitops-tk-resources-single-cluster.yaml
+++ b/hack/destination/gitops-tk-resources-single-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: Bucket
 metadata:
   name: kratix
@@ -23,7 +23,7 @@ data:
   accesskey: bWluaW9hZG1pbg==
   secretkey: bWluaW9hZG1pbg==
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-resources
@@ -37,9 +37,8 @@ spec:
     kind: Bucket
     name: kratix
   path: ./worker-1/resources
-  validation: client
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-dependencies
@@ -50,5 +49,4 @@ spec:
   sourceRef:
     kind: Bucket
     name: kratix
-  validation: client
   path: ./worker-1/dependencies

--- a/hack/destination/gitops-tk-resources.yaml
+++ b/hack/destination/gitops-tk-resources.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: Bucket
 metadata:
   name: kratix-bucket
@@ -23,7 +23,7 @@ data:
   accesskey: bWluaW9hZG1pbg==
   secretkey: bWluaW9hZG1pbg==
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-resources
@@ -37,9 +37,8 @@ spec:
     kind: Bucket
     name: kratix-bucket
   path: ./worker-1/resources
-  validation: client
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-dependencies
@@ -51,4 +50,3 @@ spec:
     kind: Bucket
     name: kratix-bucket
   path: ./worker-1/dependencies
-  validation: client

--- a/hack/templates/gitops-tk-resources-template.yaml
+++ b/hack/templates/gitops-tk-resources-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: Bucket
 metadata:
   name: DESTINATION_NAME-workload-dependencies
@@ -13,7 +13,7 @@ spec:
   secretRef:
     name: minio-credentials
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: Bucket
 metadata:
   name: DESTINATION_NAME-workload-resources
@@ -37,7 +37,7 @@ data:
   accesskey: bWluaW9hZG1pbg==
   secretkey: bWluaW9hZG1pbg==
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: DESTINATION_NAME-workload-resources
@@ -50,10 +50,9 @@ spec:
   sourceRef:
     kind: Bucket
     name: DESTINATION_NAME-workload-resources
-  validation: client
   path: PATH
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: DESTINATION_NAME-workload-dependencies
@@ -64,5 +63,4 @@ spec:
   sourceRef:
     kind: Bucket
     name: DESTINATION_NAME-workload-dependencies
-  validation: client
   path: PATH

--- a/test/system/assets/git/platform_gitops-tk-resources.yaml
+++ b/test/system/assets/git/platform_gitops-tk-resources.yaml
@@ -11,7 +11,7 @@ spec:
   secretRef:
     name: gitea-credentials
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: platform-cluster-resources
@@ -26,7 +26,7 @@ spec:
   path: "platform-cluster/resources/"
   prune: true
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: platform-cluster-dependencies


### PR DESCRIPTION
These warnings come up during the workshop. Nice to get rid of them to reduce noise.