### PR TITLE
chore: fix system test clean up

### DIFF
--- a/test/system/system_suite_test.go
+++ b/test/system/system_suite_test.go
@@ -91,6 +91,7 @@ func getEnvOrDefault(envVar, defaultValue string) string {
 }
 
 var _ = AfterSuite(func() {
+	platform.eventuallyKubectlDelete("deployments", "-n", "kratix-platform-system", "kratix-promise-release-test-hoster")
 	os.RemoveAll(testTempDir)
 })
 

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -567,6 +567,7 @@ var _ = Describe("Kratix", func() {
 
 			AfterEach(func() {
 				platform.eventuallyKubectlDelete("namespace", "pipeline-perms-ns-"+bashPromiseName)
+				platform.eventuallyKubectlDelete("ns", rrTwoNamespace)
 			})
 
 			It("creates separate bindings for request namespaces and schedules works to correct destinations", func() {
@@ -631,7 +632,6 @@ var _ = Describe("Kratix", func() {
 				})
 
 				platform.eventuallyKubectlDelete("promise", bashPromiseName)
-				platform.eventuallyKubectlDelete("ns", rrTwoNamespace)
 			})
 		})
 	})
@@ -652,7 +652,6 @@ var _ = Describe("Kratix", func() {
 
 		AfterEach(func() {
 			os.RemoveAll(tmpDir)
-			platform.eventuallyKubectlDelete("deployments", "-n", "kratix-platform-system", "kratix-promise-release-test-hoster")
 		})
 
 		When("a PromiseRelease is installed", func() {


### PR DESCRIPTION
## Context

Some small fixes around system test clean up logic:
- delete 'test' namespace in AfterEach() so this namespace gets cleaned up at failure and won't impact next system test run
- clean up promise release deployment in AfterSuite rather than test AfterEach() because there're two test specs using this deployment