### PR TITLE
feat(#273): reconcile all resources from promise label

### DIFF
--- a/controllers/dynamic_resource_request_controller_test.go
+++ b/controllers/dynamic_resource_request_controller_test.go
@@ -60,10 +60,9 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			CRD:                         rrCRD,
 			PromiseIdentifier:           promise.GetName(),
 			PromiseDestinationSelectors: promise.Spec.DestinationSelectors,
-			// promiseWorkflowSelectors:    work.GetDefaultScheduling("promise-workflow"),
-			Log:     l,
-			UID:     "1234abcd",
-			Enabled: &enabled,
+			Log:                         l,
+			UID:                         "1234abcd",
+			Enabled:                     &enabled,
 		}
 
 		yamlFile, err := os.ReadFile(resourceRequestPath)
@@ -221,7 +220,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			))
 		})
 
-		It("re-reconciles until completetion", func() {
+		It("re-reconciles until completion", func() {
 			Expect(fakeK8sClient.Delete(ctx, resReq)).To(Succeed())
 			_, err := t.reconcileUntilCompletion(reconciler, resReq)
 

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -18,6 +18,7 @@ import (
 const (
 	ConfigureWorkflowCompletedCondition = clusterv1.ConditionType("ConfigureWorkflowCompleted")
 	ManualReconciliationLabel           = "kratix.io/manual-reconciliation"
+	ReconcileResourcesLabel             = "kratix.io/reconcile-resources"
 	promiseAvailableCondition           = clusterv1.ConditionType("PromiseAvailable")
 	promiseRequirementsNotMetReason     = "PromiseRequirementsNotInstalled"
 	promiseRequirementsNotMetMessage    = "Promise Requirements are not installed"

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -16,14 +16,15 @@ import (
 )
 
 const (
-	ConfigureWorkflowCompletedCondition = clusterv1.ConditionType("ConfigureWorkflowCompleted")
-	ManualReconciliationLabel           = "kratix.io/manual-reconciliation"
-	ReconcileResourcesLabel             = "kratix.io/reconcile-resources"
-	promiseAvailableCondition           = clusterv1.ConditionType("PromiseAvailable")
-	promiseRequirementsNotMetReason     = "PromiseRequirementsNotInstalled"
-	promiseRequirementsNotMetMessage    = "Promise Requirements are not installed"
-	promiseRequirementsMetReason        = "PromiseAvailable"
-	promiseRequirementsMetMessage       = "Promise Requirements are met"
+	ConfigureWorkflowCompletedCondition    = clusterv1.ConditionType("ConfigureWorkflowCompleted")
+	ConfigureWorkflowCompletedFailedReason = "ConfigureWorkflowFailed"
+	ManualReconciliationLabel              = "kratix.io/manual-reconciliation"
+	ReconcileResourcesLabel                = "kratix.io/reconcile-resources"
+	promiseAvailableCondition              = clusterv1.ConditionType("PromiseAvailable")
+	promiseRequirementsNotMetReason        = "PromiseRequirementsNotInstalled"
+	promiseRequirementsNotMetMessage       = "Promise Requirements are not installed"
+	promiseRequirementsMetReason           = "PromiseAvailable"
+	promiseRequirementsMetMessage          = "Promise Requirements are met"
 )
 
 func GetConfigureWorkflowCompletedConditionStatus(obj *unstructured.Unstructured) v1.ConditionStatus {
@@ -50,10 +51,10 @@ func MarkWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstructured, fa
 		Type:               ConfigureWorkflowCompletedCondition,
 		Status:             v1.ConditionFalse,
 		Message:            fmt.Sprintf("A Pipeline has failed: %s", failedPipeline),
-		Reason:             "ConfigureWorkflowFailed",
+		Reason:             ConfigureWorkflowCompletedFailedReason,
 		LastTransitionTime: metav1.NewTime(time.Now()),
 	})
-	logger.Info("set conditions", "condition", ConfigureWorkflowCompletedCondition, "value", v1.ConditionFalse, "reason", "ConfigureWorkflowFailed")
+	logger.Info("set conditions", "condition", ConfigureWorkflowCompletedCondition, "value", v1.ConditionFalse, "reason", ConfigureWorkflowCompletedFailedReason)
 }
 
 func SortJobsByCreationDateTime(jobs []batchv1.Job, desc bool) []batchv1.Job {


### PR DESCRIPTION
## Context

Closes #273 

Introduce label `kratix.io/reconcile-resources`. When set to true on a promise, kratix will re reconcile all its resources label This label will be automatically removed after kratix has set manual reconciliation label on resources.