### PR TITLE
chore: clone helm chart after unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,13 +459,14 @@ workflows:
   run-ci:
     jobs:
       - clone-kratix
-      - clone-helm-charts
       - test:
-          requires: [clone-kratix, clone-helm-charts]
+          requires: [clone-kratix]
+      - clone-helm-charts:
+          requires: [test]
       - e2e-demo-test-helm-bucket:
-          requires: [clone-kratix, clone-helm-charts]
+          requires: [clone-helm-charts]
       - e2e-demo-test-helm-git:
-          requires: [clone-kratix, clone-helm-charts]
+          requires: [clone-helm-charts]
       ### ONLY MAIN
       - tag-new-version:
           requires:


### PR DESCRIPTION
## Context
- helm chart repo now has test suite. Cloning it into repo/charts makes ginkgo run its test suite with -r flag
- this commit makes clone helm chart happen after running kratix unit and sys test to avoid running chart tests as part of kratix ci test