### PR TITLE
fix: check for inotify limits on linux for quickstart

### DIFF
--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -124,6 +124,21 @@ verify_prerequisites() {
         success_mark
     fi
 
+    if [ "$(uname)" = "Linux" ]; then
+        log -n "Confirming Linux inotify limits are sufficient..."
+
+        watches=$(sysctl -n fs.inotify.max_user_watches)
+        instances=$(sysctl -n fs.inotify.max_user_instances)
+
+        if [ "$watches" -lt 246299 ] || [ "$instances" -lt 128 ]; then
+            error "Kind requires higher limits, please see: https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files"
+            exit_code=1
+        else
+            success_mark
+        fi
+    fi
+
+
     if [[ exit_code -gt 0 ]]; then
         log "\nPlease confirm you have the above prerequisites before re-running this script"
         exit $((exit_code))


### PR DESCRIPTION
This was raised as a blocker by a new user. I have decided not to actively set the limits for them, but to instead alert them if there is an issue and give them the tools to solve it. This is because I assume people wouldn't like these kinds of limits to be set automatically.

So far I have:
* tested individual commands on linux docker containers locally
* verified mac installation continues to work locally
* bodged together a test in docker locally to see the command ran correctly
* verified on linux in CI (including lowering minimum limits to match what we run with on CI)

Before merging I want to:
- [ ] verify decision to alert rather than fix the issue with the original user
- [ ]  verify a working solution with the original user
- [ ]  see if @hatofmonkeys can give this a whirl as he runs Linux