### PR TITLE
chore: use k8s 1.31 in quick-start and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ commands:
           name: Install Kind
           command: |
             if [ ! -f ~/bin/kind ]; then
-              curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.20.0/kind-linux-amd64 -o ~/bin/kind
+              curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.25.0/kind-linux-amd64 -o ~/bin/kind
               chmod +x ~/bin/kind
             fi
       - run:

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -18,7 +18,7 @@ VERSION=${VERSION:-"$(cd $ROOT; git branch --show-current)"}
 DOCKER_BUILDKIT="${DOCKER_BUILDKIT:-1}"
 
 WAIT_TIMEOUT="180s"
-KIND_IMAGE="${KIND_IMAGE:-"kindest/node:v1.27.3"}"
+KIND_IMAGE="${KIND_IMAGE:-"kindest/node:v1.31.2"}"
 
 WITH_CERT_MANAGER=true
 CERT_MANAGER_DIST=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml


### PR DESCRIPTION
## Context

- use k8s 1.31 in quick-start
- bump `kind` cli version in circle CI. Default node image is v1.31.2 in kind 0.25.0: https://github.com/kubernetes-sigs/kind/releases/tag/v0.25.0