### PR TITLE
chore: refactor helpers common code into a pkg

### DIFF
--- a/work-creator/pipeline/cmd/reader/main.go
+++ b/work-creator/pipeline/cmd/reader/main.go
@@ -1,139 +1,14 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-
-	v1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
-
-	"sigs.k8s.io/yaml"
+	"github.com/syntasso/kratix/work-creator/pipeline/lib"
 )
 
 func main() {
-	if err := run(); err != nil {
+	r := lib.Reader{}
+	if err := r.Run(); err != nil {
 		log.Fatalf("Error: %v", err)
 	}
-}
-
-func run() error {
-	// Parse environment variables
-	objectGroup := os.Getenv("OBJECT_GROUP")
-	objectName := os.Getenv("OBJECT_NAME")
-	objectNamespace := os.Getenv("OBJECT_NAMESPACE")
-	objectVersion := os.Getenv("OBJECT_VERSION")
-	crdPlural := os.Getenv("CRD_PLURAL")
-	healthcheck := os.Getenv("HEALTHCHECK")
-	outputDir := os.Getenv("OUTPUT_DIR")
-	clusterScoped := os.Getenv("CLUSTER_SCOPED") == "true"
-	if clusterScoped {
-		objectNamespace = "" // promises are cluster scoped
-	}
-	if outputDir == "" {
-		outputDir = "/kratix/input"
-	}
-
-	dynamicClient, err := getK8sClient()
-	if err != nil {
-		return fmt.Errorf("failed to create Kubernetes client: %v", err)
-	}
-
-	if err := writeObjectToFile(dynamicClient, outputDir, crdPlural, objectGroup, objectVersion, objectName, objectNamespace); err != nil {
-		return err
-	}
-
-	if healthcheck == "true" {
-		promiseName := os.Getenv("PROMISE_NAME")
-		if err := writePromiseToFile(dynamicClient, outputDir, promiseName); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func writeObjectToFile(client dynamic.Interface, outputDir, plural, group, version, name, namespace string) error {
-	// Create GVR for the object
-	gvr := schema.GroupVersionResource{
-		Group:    group,
-		Version:  version,
-		Resource: plural,
-	}
-
-	// Get the object
-	dynamicResource := client.Resource(gvr).Namespace(namespace)
-	obj, err := dynamicResource.Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get object: %v", err)
-	}
-
-	objYAML, err := yaml.Marshal(obj)
-	if err != nil {
-		return fmt.Errorf("failed to marshal object: %v", err)
-	}
-
-	objectFilePath := filepath.Join(outputDir, "object.yaml")
-	if err := os.WriteFile(objectFilePath, objYAML, 0644); err != nil {
-		return fmt.Errorf("failed to write object to file: %v", err)
-	}
-
-	log.Printf("Object written to %s. Head is:\n%s", objectFilePath, string(objYAML[:min(len(objYAML), 500)]))
-	return nil
-}
-
-func writePromiseToFile(client dynamic.Interface, outputDir, promiseName string) error {
-	gvr := schema.GroupVersionResource{
-		Group:    v1alpha1.GroupVersion.Group,
-		Version:  v1alpha1.GroupVersion.Version,
-		Resource: "promises",
-	}
-
-	dynamicResource := client.Resource(gvr)
-	obj, err := dynamicResource.Get(context.TODO(), promiseName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get Promise: %v", err)
-	}
-
-	promiseYAML, err := yaml.Marshal(obj)
-	if err != nil {
-		return fmt.Errorf("failed to marshal Promise: %v", err)
-	}
-
-	promiseFilePath := filepath.Join(outputDir, "promise.yaml")
-	if err := os.WriteFile(promiseFilePath, promiseYAML, 0644); err != nil {
-		return fmt.Errorf("failed to write Promise to file: %v", err)
-	}
-
-	log.Printf("Promise written to %s. Head is:\n%s", promiseFilePath, string(promiseYAML[:min(len(promiseYAML), 500)]))
-	return nil
-}
-
-func getK8sClient() (dynamic.Interface, error) {
-	// Try to load in-cluster config first
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		// Fall back to kubeconfig
-		kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return dynamic.NewForConfig(config)
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/work-creator/pipeline/cmd/reader/main.go
+++ b/work-creator/pipeline/cmd/reader/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"log"
+	"os"
 
 	"github.com/syntasso/kratix/work-creator/pipeline/lib"
 )
 
 func main() {
-	r := lib.Reader{}
-	if err := r.Run(); err != nil {
+	ctx := context.Background()
+	r := lib.Reader{
+		Out: os.Stdout,
+	}
+	if err := r.Run(ctx); err != nil {
 		log.Fatalf("Error: %v", err)
 	}
 }

--- a/work-creator/pipeline/cmd/update-status/main.go
+++ b/work-creator/pipeline/cmd/update-status/main.go
@@ -14,12 +14,13 @@ import (
 )
 
 func main() {
-	if err := run(); err != nil {
+	ctx := context.Background()
+	if err := run(ctx); err != nil {
 		log.Fatalf("Error: %v", err)
 	}
 }
 
-func run() error {
+func run(ctx context.Context) error {
 	workspaceDir := "/work-creator-files"
 	statusFile := filepath.Join(workspaceDir, "metadata", "status.yaml")
 
@@ -32,7 +33,7 @@ func run() error {
 
 	objectClient := client.Resource(helpers.ObjectGVR(params)).Namespace(params.ObjectNamespace)
 
-	existingObj, err := objectClient.Get(context.TODO(), params.ObjectName, metav1.GetOptions{})
+	existingObj, err := objectClient.Get(ctx, params.ObjectName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get existing object: %v", err)
 	}
@@ -57,7 +58,7 @@ func run() error {
 	existingObj.Object["status"] = mergedStatus
 
 	// Update the object's status
-	if _, err = objectClient.UpdateStatus(context.TODO(), existingObj, metav1.UpdateOptions{}); err != nil {
+	if _, err = objectClient.UpdateStatus(ctx, existingObj, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update status: %v", err)
 	}
 

--- a/work-creator/pipeline/lib/helpers/helpers.go
+++ b/work-creator/pipeline/lib/helpers/helpers.go
@@ -1,0 +1,116 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/syntasso/kratix/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
+)
+
+var GetParametersFromEnv = getParametersFromEnv
+var GetK8sClient = getK8sClient
+
+type Parameters struct {
+	ObjectGroup     string
+	ObjectName      string
+	ObjectVersion   string
+	ObjectNamespace string
+	PromiseName     string
+
+	CRDPlural      string
+	ClusterScoped  bool
+	IsLastPipeline bool
+	Healthcheck    bool
+
+	InputDir  string
+	OutputDir string
+}
+
+func getParametersFromEnv() *Parameters {
+	p := &Parameters{
+		ObjectGroup:     os.Getenv("OBJECT_GROUP"),
+		ObjectName:      os.Getenv("OBJECT_NAME"),
+		ObjectVersion:   os.Getenv("OBJECT_VERSION"),
+		ObjectNamespace: os.Getenv("OBJECT_NAMESPACE"),
+		PromiseName:     os.Getenv("PROMISE_NAME"),
+		CRDPlural:       os.Getenv("CRD_PLURAL"),
+		ClusterScoped:   os.Getenv("CLUSTER_SCOPED") == "true",
+		IsLastPipeline:  os.Getenv("IS_LAST_PIPELINE") == "true",
+		Healthcheck:     os.Getenv("HEALTHCHECK") == "true",
+		InputDir:        os.Getenv("INPUT_DIR"),
+		OutputDir:       os.Getenv("OUTPUT_DIR"),
+	}
+
+	if p.InputDir == "" {
+		p.InputDir = "/kratix/input"
+	}
+	if p.OutputDir == "" {
+		p.OutputDir = "/kratix/output"
+	}
+	if p.ObjectNamespace == "" {
+		p.ObjectNamespace = "default"
+	}
+	if p.ClusterScoped {
+		p.ObjectNamespace = ""
+	}
+
+	return p
+}
+
+func (p *Parameters) GetPromisePath() string {
+	return filepath.Join(p.InputDir, "promise.yaml")
+}
+
+func (p *Parameters) GetObjectPath() string {
+	return filepath.Join(p.InputDir, "object.yaml")
+}
+
+// GetK8sClient creates a Kubernetes client with the given scheme
+func getK8sClient() (dynamic.Interface, error) {
+	// Try to load in-cluster config first
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		// Fall back to kubeconfig
+		kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return dynamic.NewForConfig(config)
+}
+
+func WriteToYaml(obj interface{}, objectFilePath string) error {
+	objYAML, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal object: %v", err)
+	}
+
+	if err := os.WriteFile(objectFilePath, objYAML, 0644); err != nil {
+		return fmt.Errorf("failed to write object to file: %v", err)
+	}
+	return nil
+}
+
+func ObjectGVR(params *Parameters) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    params.ObjectGroup,
+		Version:  params.ObjectVersion,
+		Resource: params.CRDPlural,
+	}
+}
+
+func PromiseGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    v1alpha1.GroupVersion.Group,
+		Version:  v1alpha1.GroupVersion.Version,
+		Resource: "promises",
+	}
+}

--- a/work-creator/pipeline/lib/helpers/helpers.go
+++ b/work-creator/pipeline/lib/helpers/helpers.go
@@ -71,7 +71,6 @@ func (p *Parameters) GetObjectPath() string {
 	return filepath.Join(p.InputDir, "object.yaml")
 }
 
-// GetK8sClient creates a Kubernetes client with the given scheme
 func getK8sClient() (dynamic.Interface, error) {
 	// Try to load in-cluster config first
 	config, err := rest.InClusterConfig()
@@ -113,4 +112,16 @@ func PromiseGVR() schema.GroupVersionResource {
 		Version:  v1alpha1.GroupVersion.Version,
 		Resource: "promises",
 	}
+}
+
+// PrintFileHead prints the first n lines of a file
+func PrintFileHead(f *os.File, filename string, n int) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	end := min(len(content), n)
+	fmt.Fprint(f, string(content[:end]))
+	return nil
 }

--- a/work-creator/pipeline/lib/reader.go
+++ b/work-creator/pipeline/lib/reader.go
@@ -1,0 +1,65 @@
+package lib
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/syntasso/kratix/work-creator/pipeline/lib/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+type Reader struct{}
+
+func (r *Reader) Run() error {
+	params := helpers.GetParametersFromEnv()
+
+	client, err := helpers.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %v", err)
+	}
+
+	if err := writeObjectToFile(client, params); err != nil {
+		return err
+	}
+
+	if params.Healthcheck {
+		if err := writePromiseToFile(client, params); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeObjectToFile(client dynamic.Interface, params *helpers.Parameters) error {
+	objectClient := client.Resource(helpers.ObjectGVR(params)).Namespace(params.ObjectNamespace)
+
+	obj, err := objectClient.Get(context.TODO(), params.ObjectName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get object: %v", err)
+	}
+
+	objectFilePath := params.GetObjectPath()
+	if err := helpers.WriteToYaml(obj, objectFilePath); err != nil {
+		return fmt.Errorf("failed to write object to file: %v", err)
+	}
+
+	return nil
+}
+
+func writePromiseToFile(client dynamic.Interface, params *helpers.Parameters) error {
+	promiseClient := client.Resource(helpers.PromiseGVR())
+
+	obj, err := promiseClient.Get(context.TODO(), params.PromiseName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get Promise: %v", err)
+	}
+
+	promiseFilePath := params.GetPromisePath()
+	if err := helpers.WriteToYaml(obj, promiseFilePath); err != nil {
+		return fmt.Errorf("failed to write Promise to file: %v", err)
+	}
+
+	return nil
+}

--- a/work-creator/pipeline/lib/reader_test.go
+++ b/work-creator/pipeline/lib/reader_test.go
@@ -1,0 +1,143 @@
+package lib_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/syntasso/kratix/api/v1alpha1"
+	"github.com/syntasso/kratix/work-creator/pipeline/lib"
+	"github.com/syntasso/kratix/work-creator/pipeline/lib/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("Reader", func() {
+	var (
+		tempDir    string
+		fakeClient dynamic.Interface
+
+		subject lib.Reader
+		params  *helpers.Parameters
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "health-state-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		params = &helpers.Parameters{
+			InputDir:        tempDir,
+			ObjectGroup:     "group",
+			ObjectName:      "name-foo",
+			ObjectVersion:   "version",
+			ObjectNamespace: "ns-foo",
+			CRDPlural:       "thekinds",
+
+			PromiseName:   "test-promise",
+			Healthcheck:   false,
+			ClusterScoped: false,
+		}
+
+		originalGetInputDir := helpers.GetParametersFromEnv
+		originalGetK8sClient := helpers.GetK8sClient
+		helpers.GetParametersFromEnv = func() *helpers.Parameters {
+			return params
+		}
+		helpers.GetK8sClient = func() (dynamic.Interface, error) {
+			return fakeClient, nil
+		}
+		DeferCleanup(func() {
+			helpers.GetParametersFromEnv = originalGetInputDir
+			helpers.GetK8sClient = originalGetK8sClient
+		})
+
+		promise := v1alpha1.Promise{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "platform.kratix.io/v1alpha1",
+				Kind:       "Promise",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-promise",
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		v1alpha1.AddToScheme(scheme)
+
+		fakeClient = fake.NewSimpleDynamicClient(scheme,
+			newUnstructured("group/version", "TheKind", "ns-foo", "name-foo"),
+			&promise,
+		)
+
+		subject = lib.Reader{}
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tempDir)).To(Succeed())
+	})
+
+	It("should write the object to a file", func() {
+		Expect(subject.Run()).To(Succeed())
+
+		_, err := os.Stat(params.GetObjectPath())
+		Expect(err).NotTo(HaveOccurred())
+
+		fileContent, err := os.ReadFile(params.GetObjectPath())
+		Expect(err).NotTo(HaveOccurred())
+
+		var object map[string]interface{}
+		err = yaml.Unmarshal(fileContent, &object)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(object["apiVersion"]).To(Equal("group/version"))
+		Expect(object["kind"]).To(Equal("TheKind"))
+		Expect(object["metadata"].(map[string]interface{})["name"]).To(Equal("name-foo"))
+		Expect(object["metadata"].(map[string]interface{})["namespace"]).To(Equal("ns-foo"))
+		Expect(object["spec"].(map[string]interface{})["test"]).To(Equal("bar"))
+	})
+
+	It("should write the promise to a file if healthcheck is set to true", func() {
+		params.Healthcheck = true
+
+		Expect(subject.Run()).To(Succeed())
+
+		_, err := os.Stat(params.GetObjectPath())
+		Expect(err).NotTo(HaveOccurred(), "object file should exist")
+
+		_, err = os.Stat(params.GetPromisePath())
+		Expect(err).NotTo(HaveOccurred())
+
+		fileContent, err := os.ReadFile(params.GetPromisePath())
+		Expect(err).NotTo(HaveOccurred())
+
+		var object map[string]interface{}
+		err = yaml.Unmarshal(fileContent, &object)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(object["apiVersion"]).To(Equal("platform.kratix.io/v1alpha1"))
+		Expect(object["kind"]).To(Equal("Promise"))
+		Expect(object["metadata"].(map[string]interface{})["name"]).To(Equal("test-promise"))
+		Expect(object["metadata"].(map[string]interface{})["namespace"]).To(BeNil())
+	})
+})
+
+func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+			},
+			"spec": map[string]interface{}{
+				"test": "bar",
+			},
+		},
+	}
+}


### PR DESCRIPTION
Refactors the reader pipeline component into a testable library and adds unit tests

- Extracts reader functionality into a dedicated library package
- Introduces shared helpers for kubernetes client and parameter handling
- Adds unit tests for the reader component

closes #122