### PR TITLE
fix: Pin kratix distribution at generic docker sha, not AMD specific

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,12 @@ commands:
           cache: true
           version: 1.23.5
       - run:
+          name: Install skopeo
+          command: |
+            sudo apt-get -y update
+            sudo apt-get -y install skopeo
+
+      - run:
           name: Install Kind
           command: |
             if [ ! -f ~/bin/kind ]; then

--- a/scripts/make-distribution
+++ b/scripts/make-distribution
@@ -13,10 +13,10 @@ docker pull syntasso/kratix-platform-pipeline-adapter
 
 docker pull syntasso/kratix-platform
 
-PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST=$(docker buildx imagetools inspect syntasso/kratix-platform-pipeline-adapter --raw | yq -r '.manifests[] | select(.platform.architecture=="amd64").digest')
+PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST=$(skopeo --override-os linux inspect docker://docker.io/syntasso/kratix-platform-pipeline-adapter:latest | jq -r .Digest)
 export PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST
 
-KRATIX_PLATFORM_MANIFEST_DIGEST=$(docker buildx imagetools inspect syntasso/kratix-platform --raw | yq -r '.manifests[] | select(.platform.architecture=="amd64").digest')
+KRATIX_PLATFORM_MANIFEST_DIGEST=$(skopeo --override-os linux inspect docker://docker.io/syntasso/kratix-platform:latest | jq -r .Digest)
 export KRATIX_PLATFORM_MANIFEST_DIGEST
 
 export PIPELINE_ADAPTER_IMG=syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter@${PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST}


### PR DESCRIPTION
Today the SHA the kratix manifests pin the kratix docker images at are the AMD specific SHA:
Manifest:
<img width="1518" alt="Screenshot 2025-01-22 at 14 09 52" src="https://github.com/user-attachments/assets/f584e2af-4796-43b3-829c-ffbd72ea9824" />

SHA:
<img width="825" alt="Screenshot 2025-01-22 at 14 10 08" src="https://github.com/user-attachments/assets/72d6620f-74d1-4232-859d-385c1ce198a4" />

The consequence of this is that if you deploy Kratix to an arm-only setup, e.g. running OpenShift locally on MacOS M2 Mac, it fails to start (KinD on MacOS is happy to run AMD image):
<img width="1432" alt="Screenshot 2025-01-22 at 14 21 05" src="https://github.com/user-attachments/assets/926a68ff-250d-46d9-9d18-36864c7d8f0e" />


If you select `arm` in the dropdown in dockerhub, you get a different sha
<img width="832" alt="Screenshot 2025-01-22 at 14 10 12" src="https://github.com/user-attachments/assets/dcb5c19d-d8b2-4ead-8b4b-fd21e0952b01" />


The solution for us to use the index digest, which is platform agnostic
<img width="953" alt="Screenshot 2025-01-22 at 14 22 04" src="https://github.com/user-attachments/assets/ffa6f2a7-76ae-4a1c-b5bc-3ff53a78abe5" />

This index digest isn't fetchable using `docker` cli, but [skopeo](https://github.com/containers/skopeo) is a tool used to interact with remote registries and can retrieve it:

<img width="1260" alt="Screenshot 2025-01-22 at 14 23 59" src="https://github.com/user-attachments/assets/a8a109ba-2f93-4964-834c-3be1e37bc1d9" />

## Impl details

Skopeo doens't host static binaries... so I'm installing using ubuntu package 🤷 opent o alternatives https://github.com/containers/skopeo/blob/main/install.md 
