### PR TITLE
Introduce linting with golangci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,11 @@ jobs:
     steps:
       - install_software
       - run:
+          name: Lint
+          command: |
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4
+            ./bin/golangci-lint run --config=.golangci-required.yml
+      - run:
           name: Unit Tests
           command: |
             make test

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -50,6 +50,7 @@ linters:
   - nestif # reports deeply nested if statements
   - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
   - nolintlint # reports ill-formed or insufficient nolint directives
+  - predeclared # finds code that shadows one of Go's predeclared identifiers
   - protogetter # reports direct reads from proto message fields when getters should be used
   - recvcheck # checks for receiver type consistency
   - staticcheck # is a go vet on steroids, applying a ton of static analysis checks

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -1,0 +1,84 @@
+# .golangci-required.yml
+#
+# Configuration for golangci-lint with required settings.
+#
+# This is a must-have set of rules to be used in precommit hooks and in CI/CD pipelines.
+#
+# This configuration is intended to be used as a green starting point for a set of rules
+# that can be gradually tightened as the codebase matures.
+
+run:
+  timeout: 5m
+
+output:
+  print-issued-lines: true
+
+linters-settings:
+  cyclop:
+    max-complexity: 38  # Starting point for cyclomatic complexity
+  funlen:
+    lines: 175  # Starting point for function length
+    statements: 94  # Starting point for statement count
+  gocognit:
+    min-complexity: 57  # Starting point for cognitive complexity
+  ineffassign:
+    report-ineffassign: true
+  nakedret:
+    max-func-lines: 0
+  nestif:
+    min-complexity: 13  # Starting point for nested if complexity
+  nolintlint:
+    require-specific: true
+
+linters:
+  enable:
+  - bodyclose # checks whether HTTP response body is closed successfully
+  - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+  - cyclop # checks function and package cyclomatic complexity
+  - durationcheck # checks for two durations multiplied together
+  - funlen # tool for detection of long functions
+  - gocognit # computes and checks the cognitive complexity of functions
+  - gosec # inspects source code for security problems
+  - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+  - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
+  - ineffassign # detects when assignments to existing variables are not used
+  - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+  - nakedret # finds naked returns in functions greater than a specified function length
+  - nestif # reports deeply nested if statements
+  - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
+  - nolintlint # reports ill-formed or insufficient nolint directives
+  - protogetter # reports direct reads from proto message fields when getters should be used
+  - recvcheck # checks for receiver type consistency
+  - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+  - testpackage # makes you use a separate _test package
+  - usetesting # reports uses of functions with replacement inside the testing package
+  - wastedassign # finds wasted assignment statements
+
+issues:
+  exclude-use-default: false
+  include:
+    - ".*"  # Include all issues for now
+  exclude:
+    - "comment on exported .* should be of the form .*"  # Commonly ignored style rule
+    - "context.Context should be the first parameter of a function"
+    # GoSec exclusions:
+    - 'G401: Use of weak cryptographic primitive'
+    - 'G501: Blocklisted import crypto/md5: weak cryptographic primitive'
+    - 'G306: Expect WriteFile permissions to be 0600 or less'
+    - 'G403: RSA keys should be at least 2048 bits'
+    - 'G115: integer overflow conversion int64 -> uint64'
+    - "G404: Use of weak random number generator \\(math/rand or math/rand/v2 instead of crypto/rand\\)"
+    - "G304: Potential file inclusion via variable"
+  exclude-rules:
+    # Relax rules for test files:
+    - linters:
+        - funlen
+        - gosec
+      path: '(.+)_test\.go'
+
+severity:
+  thresholds:
+    # Encourage fixing errors and warnings while leaving room for improvements on minor suggestions
+    error: 0
+    warning: 20
+    info: 50

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -41,6 +41,7 @@ linters:
   - ginkgolinter # enforces standards of using ginkgo and gomega
   - gocognit # computes and checks the cognitive complexity of functions
   - gosec # inspects source code for security problems
+  - gosimple # specializes in simplifying code
   - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
   - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
   - ineffassign # detects when assignments to existing variables are not used

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -51,6 +51,7 @@ linters:
   - funlen # tool for detection of long functions
   - ginkgolinter # enforces standards of using ginkgo and gomega
   - gocognit # computes and checks the cognitive complexity of functions
+  - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
   - gosec # inspects source code for security problems
   - gosimple # specializes in simplifying code
   - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -68,6 +68,7 @@ linters:
   - testpackage # makes you use a separate _test package
   - unparam # reports unused function parameters
   - unused # checks for unused constants, variables, functions and types
+  - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
   - usetesting # reports uses of functions with replacement inside the testing package
   - wastedassign # finds wasted assignment statements
 

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -24,6 +24,11 @@ linters-settings:
       - fmt.Fprintf
       - fmt.Fprint
       - fmt.Fprintln
+  exhaustive:
+    check:
+      - switch
+      - map
+    default-signifies-exhaustive: true
   funlen:
     lines: 175  # Starting point for function length
     statements: 94  # Starting point for statement count
@@ -50,6 +55,7 @@ linters:
   - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
   - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
   - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+  - exhaustive # checks exhaustiveness of enum switch statements
   - funlen # tool for detection of long functions
   - ginkgolinter # enforces standards of using ginkgo and gomega
   - gocognit # computes and checks the cognitive complexity of functions

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -31,6 +31,8 @@ linters-settings:
     min-complexity: 57  # Starting point for cognitive complexity
   ineffassign:
     report-ineffassign: true
+  misspell:
+    locale: UK
   nakedret:
     max-func-lines: 0
   nestif:
@@ -58,6 +60,7 @@ linters:
   - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
   - ineffassign # detects when assignments to existing variables are not used
   - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+  - misspell # finds common spelling mistakes
   - nakedret # finds naked returns in functions greater than a specified function length
   - nestif # reports deeply nested if statements
   - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -18,6 +18,12 @@ linters-settings:
     max-complexity: 38  # Starting point for cyclomatic complexity
   dupl:
     threshold: 100  # Token count for duplication detection
+  errcheck:
+    exclude-functions:
+      # Exclude these functions for now
+      - fmt.Fprintf
+      - fmt.Fprint
+      - fmt.Fprintln
   funlen:
     lines: 175  # Starting point for function length
     statements: 94  # Starting point for statement count
@@ -39,6 +45,7 @@ linters:
   - cyclop # checks function and package cyclomatic complexity
   - dupl # tool for code clone detection
   - durationcheck # checks for two durations multiplied together
+  - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
   - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
   - funlen # tool for detection of long functions
   - ginkgolinter # enforces standards of using ginkgo and gomega
@@ -82,6 +89,7 @@ issues:
     # Relax rules for test files:
     - linters:
         - dupl
+        - errcheck
         - funlen
         - gosec
       path: '(.+)_test\.go'

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -37,6 +37,7 @@ linters:
   - cyclop # checks function and package cyclomatic complexity
   - durationcheck # checks for two durations multiplied together
   - funlen # tool for detection of long functions
+  - ginkgolinter # enforces standards of using ginkgo and gomega
   - gocognit # computes and checks the cognitive complexity of functions
   - gosec # inspects source code for security problems
   - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -52,6 +52,7 @@ linters:
   - recvcheck # checks for receiver type consistency
   - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
   - testpackage # makes you use a separate _test package
+  - unparam # reports unused function parameters
   - usetesting # reports uses of functions with replacement inside the testing package
   - wastedassign # finds wasted assignment statements
 

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -53,6 +53,7 @@ linters:
   - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
   - testpackage # makes you use a separate _test package
   - unparam # reports unused function parameters
+  - unused # checks for unused constants, variables, functions and types
   - usetesting # reports uses of functions with replacement inside the testing package
   - wastedassign # finds wasted assignment statements
 

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -69,6 +69,7 @@ linters:
   - misspell # finds common spelling mistakes
   - nakedret # finds naked returns in functions greater than a specified function length
   - nestif # reports deeply nested if statements
+  - nilerr # finds the code that returns nil even if it checks that the error is not nil
   - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
   - nolintlint # reports ill-formed or insufficient nolint directives
   - predeclared # finds code that shadows one of Go's predeclared identifiers

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -16,6 +16,8 @@ output:
 linters-settings:
   cyclop:
     max-complexity: 38  # Starting point for cyclomatic complexity
+  dupl:
+    threshold: 100  # Token count for duplication detection
   funlen:
     lines: 175  # Starting point for function length
     statements: 94  # Starting point for statement count
@@ -35,6 +37,7 @@ linters:
   - bodyclose # checks whether HTTP response body is closed successfully
   - copyloopvar # detects places where loop variables are copied (Go 1.22+)
   - cyclop # checks function and package cyclomatic complexity
+  - dupl # tool for code clone detection
   - durationcheck # checks for two durations multiplied together
   - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
   - funlen # tool for detection of long functions
@@ -78,6 +81,7 @@ issues:
   exclude-rules:
     # Relax rules for test files:
     - linters:
+        - dupl
         - funlen
         - gosec
       path: '(.+)_test\.go'

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -36,6 +36,7 @@ linters:
   - copyloopvar # detects places where loop variables are copied (Go 1.22+)
   - cyclop # checks function and package cyclomatic complexity
   - durationcheck # checks for two durations multiplied together
+  - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
   - funlen # tool for detection of long functions
   - ginkgolinter # enforces standards of using ginkgo and gomega
   - gocognit # computes and checks the cognitive complexity of functions

--- a/.golangci-required.yml
+++ b/.golangci-required.yml
@@ -46,6 +46,7 @@ linters:
   - dupl # tool for code clone detection
   - durationcheck # checks for two durations multiplied together
   - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+  - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
   - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
   - funlen # tool for detection of long functions
   - ginkgolinter # enforces standards of using ginkgo and gomega

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,388 @@
+# This file is licensed under the terms of the MIT license https://opensource.org/license/mit
+# Copyright (c) 2021-2025 Marat Reymers
+
+## Golden config for golangci-lint v1.63.4
+#
+# This is the best config for golangci-lint based on my experience and opinion.
+# It is very strict, but not extremely strict.
+# Feel free to adapt it to suit your needs.
+# If this config helps you, please consider keeping a link to this file (see the next comment).
+
+# Based on https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
+
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 2m
+
+
+# This file contains only configs which differ from defaults.
+# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+linters-settings:
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 30
+    # The maximal average package complexity.
+    # If it's higher than 0.0 (float) the check is enabled
+    # Default: 0.0
+    package-average: 10.0
+
+  depguard:
+    # Rules to apply.
+    #
+    # Variables:
+    # - File Variables
+    #   Use an exclamation mark `!` to negate a variable.
+    #   Example: `!$test` matches any file that is not a go test file.
+    #
+    #   `$all` - matches all go files
+    #   `$test` - matches all go test files
+    #
+    # - Package Variables
+    #
+    #   `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+    #
+    # Default (applies if no custom rules are defined): Only allow $gostd in all files.
+    rules:
+      # Name of a rule.
+      legacy:
+        # List of packages that are not allowed.
+        # Entries can be a variable (starting with $), a string prefix, or an exact match (if ending with $).
+        # Default: []
+        deny:
+          - pkg: "github.com/golang/protobuf"
+            desc: "Use google.golang.org/protobuf instead, see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
+          - pkg: "github.com/satori/go.uuid"
+            desc: "Use github.com/google/uuid instead, satori's package is not maintained"
+          - pkg: "github.com/gofrs/uuid$"
+            desc: "Use github.com/gofrs/uuid/v5 or later, it was not a go module before v5"
+
+  errcheck:
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-type-assertions: true
+
+  exhaustive:
+    # Program elements to check for exhaustiveness.
+    # Default: [ switch ]
+    check:
+      - switch
+      - map
+
+  exhaustruct:
+    # List of regular expressions to exclude struct packages and their names from checks.
+    # Regular expressions must match complete canonical struct package/name/structname.
+    # Default: []
+    exclude:
+      # std libs
+      - "^net/http.Client$"
+      - "^net/http.Cookie$"
+      - "^net/http.Request$"
+      - "^net/http.Response$"
+      - "^net/http.Server$"
+      - "^net/http.Transport$"
+      - "^net/url.URL$"
+      - "^os/exec.Cmd$"
+      - "^reflect.StructField$"
+      # public libs
+      - "^github.com/Shopify/sarama.Config$"
+      - "^github.com/Shopify/sarama.ProducerMessage$"
+      - "^github.com/mitchellh/mapstructure.DecoderConfig$"
+      - "^github.com/prometheus/client_golang/.+Opts$"
+      - "^github.com/spf13/cobra.Command$"
+      - "^github.com/spf13/cobra.CompletionOptions$"
+      - "^github.com/stretchr/testify/mock.Mock$"
+      - "^github.com/testcontainers/testcontainers-go.+Request$"
+      - "^github.com/testcontainers/testcontainers-go.FromDockerfile$"
+      - "^golang.org/x/tools/go/analysis.Analyzer$"
+      - "^google.golang.org/protobuf/.+Options$"
+      - "^gopkg.in/yaml.v3.Node$"
+
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 100
+    # Checks the number of statements in a function.
+    # If lower than 0, disable the check.
+    # Default: 40
+    statements: 50
+    # Ignore comments when counting lines.
+    # Default false
+    ignore-comments: true
+
+  gochecksumtype:
+    # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
+    # Default: true
+    default-signifies-exhaustive: false
+
+  gocognit:
+    # Minimal code complexity to report.
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 20
+
+  gocritic:
+    # Settings passed to gocritic.
+    # The settings key is the name of a supported gocritic checker.
+    # The list of supported checkers can be find in https://go-critic.github.io/overview.
+    settings:
+      captLocal:
+        # Whether to restrict checker to params only.
+        # Default: true
+        paramsOnly: false
+      underef:
+        # Whether to skip (*x).method() calls where x is a pointer receiver.
+        # Default: true
+        skipRecvDeref: false
+
+  govet:
+    # Enable all analyzers.
+    # Default: false
+    enable-all: true
+    # Disable analyzers by name.
+    # Run `go tool vet help` to see all analyzers.
+    # Default: []
+    disable:
+      - fieldalignment # too strict
+    # Settings per analyzer.
+    settings:
+      shadow:
+        # Whether to be strict about shadowing; can be noisy.
+        # Default: false
+        strict: true
+
+  inamedparam:
+    # Skips check for interface methods with only a single parameter.
+    # Default: false
+    skip-single-param: true
+
+  mnd:
+    # List of function patterns to exclude from analysis.
+    # Values always ignored: `time.Date`,
+    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+    # Default: []
+    ignored-functions:
+      - args.Error
+      - flag.Arg
+      - flag.Duration.*
+      - flag.Float.*
+      - flag.Int.*
+      - flag.Uint.*
+      - os.Chmod
+      - os.Mkdir.*
+      - os.OpenFile
+      - os.WriteFile
+      - prometheus.ExponentialBuckets.*
+      - prometheus.LinearBuckets
+
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 0
+
+  nolintlint:
+    # Exclude following linters from requiring an explanation.
+    # Default: []
+    allow-no-explanation: [ funlen, gocognit, lll ]
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: true
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
+    require-specific: true
+
+  perfsprint:
+    # Optimizes into strings concatenation.
+    # Default: true
+    strconcat: false
+
+  reassign:
+    # Patterns for global variable names that are checked for reassignment.
+    # See https://github.com/curioswitch/go-reassign#usage
+    # Default: ["EOF", "Err.*"]
+    patterns:
+      - ".*"
+
+  rowserrcheck:
+    # database/sql is always checked
+    # Default: []
+    packages:
+      - github.com/jmoiron/sqlx
+
+  sloglint:
+    # Enforce not using global loggers.
+    # Values:
+    # - "": disabled
+    # - "all": report all global loggers
+    # - "default": report only the default slog logger
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
+    # Default: ""
+    no-global: "all"
+    # Enforce using methods that accept a context.
+    # Values:
+    # - "": disabled
+    # - "all": report all contextless calls
+    # - "scope": report only if a context exists in the scope of the outermost function
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
+    # Default: ""
+    context: "scope"
+
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
+
+
+linters:
+  disable-all: true
+  enable:
+    ## enabled by default
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - gosimple # specializes in simplifying a code
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # checks for unused constants, variables, functions and types
+    ## disabled by default
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - canonicalheader # checks whether net/http.Header uses canonical header
+    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+    - cyclop # checks function and package cyclomatic complexity
+    - depguard # checks if package imports are in a list of acceptable packages
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
+    - fatcontext # detects nested contexts in loops
+    - forbidigo # forbids identifiers
+    - funlen # tool for detection of long functions
+    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoglobals # checks that no global variables exist
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gochecksumtype # checks exhaustiveness on Go "sum types"
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godot # checks if comments end in a period
+    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
+    - intrange # finds places where for loops could make use of an integer range
+    - lll # reports long lines
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - mirror # reports wrong mirror patterns of bytes/strings usage
+    - mnd # detects magic numbers
+    - musttag # enforces field tags in (un)marshaled structs
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nonamedreturns # reports all named returns
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - protogetter # reports direct reads from proto message fields when getters should be used
+    - reassign # checks that package variables are not reassigned
+    - recvcheck # checks for receiver type consistency
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sloglint # ensure consistent code style when using log/slog
+    - spancheck # checks for mistakes with OpenTelemetry/Census spans
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - stylecheck # is a replacement for golint
+    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - testableexamples # checks if examples are testable (have an expected output)
+    - testifylint # checks usage of github.com/stretchr/testify
+    - testpackage # makes you use a separate _test package
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - usetesting # reports uses of functions with replacement inside the testing package
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
+
+    ## you may want to enable
+    #- decorder # checks declaration order and count of types, constants, variables and functions
+    #- exhaustruct # [highly recommend to enable] checks if all structure fields are initialized
+    #- gci # controls golang package import order and makes it always deterministic
+    #- ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
+    #- godox # detects FIXME, TODO and other comment keywords
+    #- goheader # checks is file header matches to pattern
+    #- inamedparam # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
+    #- interfacebloat # checks the number of methods inside an interface
+    #- ireturn # accept interfaces, return concrete types
+    #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
+    #- tagalign # checks that struct tags are well aligned
+    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- wrapcheck # checks that errors returned from external packages are wrapped
+    #- zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
+
+    ## disabled
+    #- containedctx # detects struct contained context.Context field
+    #- contextcheck # [too many false positives] checks the function whether use a non-inherited context
+    #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    #- dupword # [useless without config] checks for duplicate words in the source code
+    #- err113 # [too strict] checks the errors handling expressions
+    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
+    #- exportloopref # [not necessary from Go 1.22] checks for pointers to enclosing loop variables
+    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
+    #- gofmt # [replaced by goimports] checks whether code was gofmt-ed
+    #- gofumpt # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
+    #- gomodguard # [use more powerful depguard] allow and block lists linter for direct Go module dependencies
+    #- gosmopolitan # reports certain i18n/l10n anti-patterns in your Go codebase
+    #- grouper # analyzes expression groups
+    #- importas # enforces consistent import aliases
+    #- maintidx # measures the maintainability index of each function
+    #- misspell # [useless] finds commonly misspelled English words in comments
+    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    #- tagliatelle # checks the struct tags
+    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 50
+
+  exclude-rules:
+    - source: "(noinspection|TODO)"
+      linters: [ godot ]
+    - source: "//noinspection"
+      linters: [ gocritic ]
+    # Relax rules for test files:
+    - path: "_test\\.go"
+      linters:
+        - bodyclose
+        - dupl
+        - errcheck
+        - funlen
+        - goconst
+        - gosec
+        - noctx
+        - wrapcheck
+    # Ignore autogenerated long lines:
+    - linters:
+        - lll
+      source: "^//go:generate "

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,21 @@ build-and-load-bash: # Build and load all test pipeline images
 build-and-push-bash:
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 --tag syntassodev/bash-promise:dev1 ./test/system/assets/bash-promise
 
+lint-required: # Lint with required config
+	golangci-lint run --config=.golangci-required.yml
+
+lint-changed: # Lint changed files only, with default config
+	@unstaged_files=$$(git diff --name-only --diff-filter=ACM | grep '\.go$$' || true); \
+	staged_files=$$(git diff --name-only --diff-filter=ACM --staged | grep '\.go$$' || true); \
+	if [ -n "$$unstaged_files" ]; then \
+		echo "Linting unstaged Go files"; \
+		golangci-lint run $$unstaged_files; \
+	fi; \
+	if [ -n "$$staged_files" ]; then \
+		echo "Linting staged Go files"; \
+		golangci-lint run $$staged_files; \
+	fi
+
 ##@ Deprecated: will be deleted soon
 
 # build-and-reload-kratix is deprecated in favor of build-and-load-kratix
@@ -252,3 +267,4 @@ DEPRECATED:
 	@echo
 	read -p 'Press any key to continue...'
 	@echo
+

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -1368,7 +1368,7 @@ func matchConfigureConfigmap(c *corev1.ConfigMap, factory *v1alpha1.PipelineFact
 	ExpectWithOffset(1, c.Data).To(
 		HaveKeyWithValue(
 			"destinationSelectors",
-			fmt.Sprintf("- matchlabels:\n    label: value\n  source: promise\n- matchlabels:\n    another-label: another-value\n  source: promise\n")))
+			"- matchlabels:\n    label: value\n  source: promise\n- matchlabels:\n    another-label: another-value\n  source: promise\n"))
 }
 
 func promiseHash(promise *v1alpha1.Promise) string {

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Pipeline", func() {
 				Expect(f.Namespace).To(Equal(v1alpha1.SystemNamespace))
 				Expect(f.WorkflowAction).To(Equal(v1alpha1.WorkflowActionConfigure))
 				Expect(f.WorkflowType).To(Equal(v1alpha1.WorkflowTypePromise))
-				Expect(f.ClusterScoped).To(Equal(true))
+				Expect(f.ClusterScoped).To(BeTrue())
 				Expect(f.ResourceWorkflow).To(BeFalse())
 				Expect(f.CRDPlural).To(Equal("promises"))
 			})
@@ -150,7 +150,7 @@ var _ = Describe("Pipeline", func() {
 				Expect(f.Namespace).To(Equal(resourceRequest.GetNamespace()))
 				Expect(f.WorkflowAction).To(Equal(v1alpha1.WorkflowActionConfigure))
 				Expect(f.WorkflowType).To(Equal(v1alpha1.WorkflowTypeResource))
-				Expect(f.ClusterScoped).To(Equal(false))
+				Expect(f.ClusterScoped).To(BeFalse())
 				Expect(f.ResourceWorkflow).To(BeTrue())
 				Expect(f.CRDPlural).To(Equal("promiseCrdPlural"))
 			})
@@ -162,7 +162,7 @@ var _ = Describe("Pipeline", func() {
 				promise.Spec.API = &runtime.RawExtension{Raw: rawCrd}
 
 				f := pipeline.ForResource(promise, v1alpha1.WorkflowActionConfigure, resourceRequest)
-				Expect(f.ClusterScoped).To(Equal(true))
+				Expect(f.ClusterScoped).To(BeTrue())
 			})
 		})
 	})
@@ -211,8 +211,8 @@ var _ = Describe("Pipeline", func() {
 						Expect(objs).To(ContainElements(
 							serviceAccount, &clusterRoles[0], &clusterRoleBindings[0], configMap,
 						))
-						Expect(roles).To(HaveLen(0))
-						Expect(bindings).To(HaveLen(0))
+						Expect(roles).To(BeEmpty())
+						Expect(bindings).To(BeEmpty())
 
 						Expect(serviceAccount.GetName()).To(Equal("factoryID"))
 						Expect(resources.Job.Name).To(HavePrefix("kratix-%s-%s", promise.GetName(), pipeline.GetName()))
@@ -251,8 +251,8 @@ var _ = Describe("Pipeline", func() {
 						Expect(objs).To(ContainElements(
 							serviceAccount, &clusterRoles[0], &clusterRoleBindings[0],
 						))
-						Expect(roles).To(HaveLen(0))
-						Expect(bindings).To(HaveLen(0))
+						Expect(roles).To(BeEmpty())
+						Expect(bindings).To(BeEmpty())
 
 						Expect(resources.Job.Name).To(HavePrefix("kratix-%s-%s", promise.GetName(), pipeline.GetName()))
 						job.Name = resources.Job.Name
@@ -299,8 +299,8 @@ var _ = Describe("Pipeline", func() {
 						))
 						matchClusterRolesAndBindings(clusterRoles, clusterRoleBindings, factory, serviceAccount)
 					} else {
-						Expect(clusterRoles).To(HaveLen(0))
-						Expect(clusterRoleBindings).To(HaveLen(0))
+						Expect(clusterRoles).To(BeEmpty())
+						Expect(clusterRoleBindings).To(BeEmpty())
 					}
 
 					Expect(resources.Job.Name).To(HavePrefix("kratix-%s-%s-%s", promise.GetName(), resourceRequest.GetName(), pipeline.GetName()))
@@ -835,8 +835,8 @@ var _ = Describe("Pipeline", func() {
 
 					resources, err := factory.Resources(nil)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(resources.Shared.ClusterRoles).To(HaveLen(0))
-					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(0))
+					Expect(resources.Shared.ClusterRoles).To(BeEmpty())
+					Expect(resources.Shared.ClusterRoleBindings).To(BeEmpty())
 					Expect(resources.Shared.Roles).To(ConsistOf(
 						MatchFields(IgnoreExtras, Fields{
 							"ObjectMeta": MatchFields(IgnoreExtras, Fields{
@@ -899,7 +899,7 @@ var _ = Describe("Pipeline", func() {
 					resources, err := factory.Resources(nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(resources.Name).To(Equal(pipeline.GetName()))
-					Expect(resources.Shared.Roles).To(HaveLen(0))
+					Expect(resources.Shared.Roles).To(BeEmpty())
 					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(1))
 
 					Expect(resources.Shared.ClusterRoles).To(ConsistOf(
@@ -950,7 +950,7 @@ var _ = Describe("Pipeline", func() {
 					Expect(resources.Name).To(Equal(pipeline.GetName()))
 
 					Expect(resources.Shared.Roles).To(HaveLen(1))
-					Expect(resources.Shared.ClusterRoleBindings).To(HaveLen(0))
+					Expect(resources.Shared.ClusterRoleBindings).To(BeEmpty())
 
 					Expect(resources.Shared.ClusterRoles).To(HaveLen(1))
 					Expect(resources.Shared.ClusterRoles[0].Rules).To(ConsistOf(rbacv1.PolicyRule{
@@ -1004,8 +1004,8 @@ var _ = Describe("Pipeline", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(resources.Name).To(Equal(pipeline.GetName()))
 
-					Expect(resources.Shared.Roles).To(HaveLen(0))
-					Expect(resources.Shared.RoleBindings).To(HaveLen(0))
+					Expect(resources.Shared.Roles).To(BeEmpty())
+					Expect(resources.Shared.RoleBindings).To(BeEmpty())
 
 					Expect(resources.Shared.ClusterRoles).To(HaveLen(2))
 					Expect(resources.Shared.ClusterRoles[1].Rules).To(ConsistOf(rbacv1.PolicyRule{

--- a/api/v1alpha1/promiserelease_types.go
+++ b/api/v1alpha1/promiserelease_types.go
@@ -18,9 +18,11 @@ package v1alpha1
 
 import (
 	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const TypeHTTP = "http"

--- a/api/v1alpha1/work_types.go
+++ b/api/v1alpha1/work_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"github.com/syntasso/kratix/lib/hash"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/controllers/destination_controller.go
+++ b/controllers/destination_controller.go
@@ -179,11 +179,11 @@ func (r *DestinationReconciler) createDependenciesPathWithExample(writer writers
 func (r *DestinationReconciler) deleteDestination(o opts, destination *v1alpha1.Destination, writer writers.StateStoreWriter) (ctrl.Result, error) {
 	if controllerutil.ContainsFinalizer(destination, destinationCleanupFinalizer) {
 		if success, err := r.deleteDestinationWorkplacements(o, destination); !success || err != nil {
-			return defaultRequeue, nil
+			return defaultRequeue, nil //nolint:nilerr // requeue rather than exponential backoff
 		}
 
 		if err := r.deleteStateStoreContents(o, writer); err != nil {
-			return defaultRequeue, nil
+			return defaultRequeue, nil //nolint:nilerr // requeue rather than exponential backoff
 		}
 
 		controllerutil.RemoveFinalizer(destination, destinationCleanupFinalizer)

--- a/controllers/destination_controller.go
+++ b/controllers/destination_controller.go
@@ -18,8 +18,9 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "k8s.io/api/core/v1"

--- a/controllers/dynamic_resource_request_controller.go
+++ b/controllers/dynamic_resource_request_controller.go
@@ -218,7 +218,7 @@ func (r *DynamicResourceRequestController) deleteResources(o opts, promise *v1al
 	}
 
 	if controllerutil.ContainsFinalizer(resourceRequest, removeAllWorkflowJobsFinalizer) {
-		err := r.deleteWorkflows(o, resourceRequest, resourceRequestIdentifier, removeAllWorkflowJobsFinalizer)
+		err := r.deleteWorkflows(o, resourceRequest, removeAllWorkflowJobsFinalizer)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -257,7 +257,7 @@ func (r *DynamicResourceRequestController) deleteWork(o opts, resourceRequest *u
 	return nil
 }
 
-func (r *DynamicResourceRequestController) deleteWorkflows(o opts, resourceRequest *unstructured.Unstructured, resourceRequestIdentifier, finalizer string) error {
+func (r *DynamicResourceRequestController) deleteWorkflows(o opts, resourceRequest *unstructured.Unstructured, finalizer string) error {
 	jobGVK := schema.GroupVersionKind{
 		Group:   batchv1.SchemeGroupVersion.Group,
 		Version: batchv1.SchemeGroupVersion.Version,

--- a/controllers/dynamic_resource_request_controller_test.go
+++ b/controllers/dynamic_resource_request_controller_test.go
@@ -131,7 +131,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			})
 
 			By("not requeuing, since the controller is watching the job", func() {
-				Expect(err).To(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 			})
 
@@ -229,8 +229,8 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			works := &v1alpha1.WorkList{}
 			Expect(fakeK8sClient.List(ctx, works)).To(Succeed())
 			Expect(fakeK8sClient.List(ctx, jobs)).To(Succeed())
-			Expect(works.Items).To(HaveLen(0))
-			Expect(jobs.Items).To(HaveLen(0))
+			Expect(works.Items).To(BeEmpty())
+			Expect(jobs.Items).To(BeEmpty())
 		})
 	})
 

--- a/controllers/healthrecord_controller.go
+++ b/controllers/healthrecord_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/go-logr/logr"
 	platformv1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/healthrecord_controller_test.go
+++ b/controllers/healthrecord_controller_test.go
@@ -6,13 +6,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"time"
+
 	"github.com/syntasso/kratix/api/v1alpha1"
 	"github.com/syntasso/kratix/controllers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 var _ = Describe("HealthRecordController", func() {

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -501,7 +501,6 @@ func (r *PromiseReconciler) reconcileAllRRs(rrGVK *schema.GroupVersionKind) erro
 }
 
 func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.Promise, rrCRD *apiextensionsv1.CustomResourceDefinition, rrGVK *schema.GroupVersionKind, canCreateResources *bool, logger logr.Logger) error {
-
 	// The Dynamic Controller needs to be started once and only once.
 	if r.dynamicControllerHasAlreadyStarted(promise) {
 		logger.Info("dynamic controller already started, ensuring it is up to date")

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -132,7 +132,7 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	if client.IgnoreNotFound(err) != nil {
 		r.Log.Error(err, "Failed getting Promise", "namespacedName", req.NamespacedName)
-		return defaultRequeue, nil
+		return defaultRequeue, nil //nolint:nilerr // requeue rather than exponential backoff
 	}
 
 	originalStatus := promise.Status.Status
@@ -743,7 +743,7 @@ func (r *PromiseReconciler) deletePromise(o opts, promise *v1alpha1.Promise) (ct
 		o.logger.Info("deleting resources associated with finalizer", "finalizer", dynamicControllerDependantResourcesCleanupFinalizer)
 		err := r.deleteDynamicControllerAndWorkflowResources(o, promise)
 		if err != nil {
-			return defaultRequeue, nil
+			return defaultRequeue, nil //nolint:nilerr // requeue rather than exponential backoff
 		}
 		return fastRequeue, nil
 	}

--- a/controllers/promise_controller_test.go
+++ b/controllers/promise_controller_test.go
@@ -469,7 +469,7 @@ var _ = Describe("PromiseController", func() {
 
 					By("not requeueing while the job is in flight", func() {
 						Expect(result).To(Equal(ctrl.Result{}))
-						Expect(err).To(BeNil())
+						Expect(err).NotTo(HaveOccurred())
 					})
 
 					By("finishing the creation once the job is finished", func() {
@@ -483,7 +483,7 @@ var _ = Describe("PromiseController", func() {
 					By("not creating a Work for the empty static dependencies", func() {
 						works := &v1alpha1.WorkList{}
 						Expect(fakeK8sClient.List(ctx, works)).To(Succeed())
-						Expect(works.Items).To(HaveLen(0))
+						Expect(works.Items).To(BeEmpty())
 					})
 				})
 			})
@@ -516,7 +516,7 @@ var _ = Describe("PromiseController", func() {
 
 					crds, err := fakeApiExtensionsClient.CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(crds.Items).To(HaveLen(0))
+					Expect(crds.Items).To(BeEmpty())
 					works := &v1alpha1.WorkList{}
 					Expect(fakeK8sClient.List(ctx, works)).To(Succeed())
 					Expect(works.Items).To(HaveLen(1))
@@ -593,9 +593,9 @@ var _ = Describe("PromiseController", func() {
 					Expect(fakeK8sClient.List(ctx, serviceAccounts)).To(Succeed())
 					Expect(clusterRoles.Items).To(HaveLen(1))
 					Expect(clusterRoleBindings.Items).To(HaveLen(1))
-					Expect(works.Items).To(HaveLen(0))
-					Expect(jobs.Items).To(HaveLen(0))
-					Expect(serviceAccounts.Items).To(HaveLen(0))
+					Expect(works.Items).To(BeEmpty())
+					Expect(jobs.Items).To(BeEmpty())
+					Expect(serviceAccounts.Items).To(BeEmpty())
 
 					//Delete
 					Expect(fakeK8sClient.Delete(ctx, promise)).To(Succeed())
@@ -606,22 +606,22 @@ var _ = Describe("PromiseController", func() {
 
 					//Check they are all gone
 					Expect(fakeK8sClient.List(ctx, jobs)).To(Succeed())
-					Expect(jobs.Items).To(HaveLen(0))
+					Expect(jobs.Items).To(BeEmpty())
 
 					crds, err = fakeApiExtensionsClient.CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(crds.Items).To(HaveLen(0))
+					Expect(crds.Items).To(BeEmpty())
 					Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(MatchError(ContainSubstring("not found")))
 					Expect(fakeK8sClient.List(ctx, clusterRoles)).To(Succeed())
 					Expect(fakeK8sClient.List(ctx, clusterRoleBindings)).To(Succeed())
 					Expect(fakeK8sClient.List(ctx, works)).To(Succeed())
 					Expect(fakeK8sClient.List(ctx, configMaps)).To(Succeed())
 					Expect(fakeK8sClient.List(ctx, serviceAccounts)).To(Succeed())
-					Expect(clusterRoles.Items).To(HaveLen(0))
-					Expect(clusterRoleBindings.Items).To(HaveLen(0))
-					Expect(works.Items).To(HaveLen(0))
-					Expect(configMaps.Items).To(HaveLen(0))
-					Expect(serviceAccounts.Items).To(HaveLen(0))
+					Expect(clusterRoles.Items).To(BeEmpty())
+					Expect(clusterRoleBindings.Items).To(BeEmpty())
+					Expect(works.Items).To(BeEmpty())
+					Expect(configMaps.Items).To(BeEmpty())
+					Expect(serviceAccounts.Items).To(BeEmpty())
 				})
 
 				When("a resource request exists", func() {
@@ -818,7 +818,7 @@ var _ = Describe("PromiseController", func() {
 					By("deleting the work", func() {
 						works := &v1alpha1.WorkList{}
 						Expect(fakeK8sClient.List(ctx, works)).To(Succeed())
-						Expect(works.Items).To(HaveLen(0))
+						Expect(works.Items).To(BeEmpty())
 					})
 				})
 			})

--- a/controllers/promise_controller_test.go
+++ b/controllers/promise_controller_test.go
@@ -922,7 +922,7 @@ var _ = Describe("PromiseController", func() {
 			})
 		})
 
-		When("promise labeled with ReconcileResources label", func() {
+		When("promise labelled with ReconcileResources label", func() {
 			var resReq *unstructured.Unstructured
 
 			BeforeEach(func() {

--- a/controllers/promiserelease_controller.go
+++ b/controllers/promiserelease_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/scheduler.go
+++ b/controllers/scheduler.go
@@ -179,7 +179,7 @@ func (s *Scheduler) reconcileWorkloadGroup(workloadGroup v1alpha1.WorkloadGroup,
 		}
 	}
 
-	destinationSelectors := resolveDestinationSelectorsForWorkloadGroup(workloadGroup, work)
+	destinationSelectors := resolveDestinationSelectorsForWorkloadGroup(workloadGroup)
 	targetDestinationNames := s.getTargetDestinationNames(destinationSelectors, work)
 	targetDestinationMap := map[string]bool{}
 	for _, dest := range targetDestinationNames {
@@ -216,7 +216,7 @@ func (s *Scheduler) reconcileWorkloadGroup(workloadGroup v1alpha1.WorkloadGroup,
 
 func (s *Scheduler) updateWorkPlacement(workloadGroup v1alpha1.WorkloadGroup, work *v1alpha1.Work, workPlacement *v1alpha1.WorkPlacement) (bool, error) {
 	misscheduled := true
-	destinationSelectors := resolveDestinationSelectorsForWorkloadGroup(workloadGroup, work)
+	destinationSelectors := resolveDestinationSelectorsForWorkloadGroup(workloadGroup)
 	for _, dest := range s.getTargetDestinationNames(destinationSelectors, work) {
 		if dest == workPlacement.Spec.TargetDestinationName {
 			misscheduled = false
@@ -431,7 +431,7 @@ func (s *Scheduler) getDestinationsForWorkloadGroup(destinationSelectors map[str
 	return destinations
 }
 
-func resolveDestinationSelectorsForWorkloadGroup(workloadGroup v1alpha1.WorkloadGroup, work *v1alpha1.Work) map[string]string {
+func resolveDestinationSelectorsForWorkloadGroup(workloadGroup v1alpha1.WorkloadGroup) map[string]string {
 	sortedWorkloadGroupDestinations := sortWorkloadGroupDestinationsByLowestPriority(workloadGroup.DestinationSelectors)
 	destinationSelectors := map[string]string{}
 

--- a/controllers/scheduler_test.go
+++ b/controllers/scheduler_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 				})
 
 				It("sets the scheduling conditions on the Work", func() {
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork)).To(Succeed())
 					Expect(resourceWork.Status.Conditions).To(HaveLen(2))
 
 					Expect(resourceWork.Status.Conditions[0].Type).To(Equal("Scheduled"))
@@ -160,7 +160,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// update the Work's WorkloadGroup with an extra Workload
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork)).To(Succeed())
 					resourceWork.Spec.WorkloadGroups[0].Workloads = append(resourceWork.Spec.WorkloadGroups[0].Workloads, Workload{
 						Content: string(fakeCompressedContent),
 					})
@@ -212,7 +212,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 
 					// the WorkPlacement should now be deleted
 					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-					Expect(workPlacements.Items).To(HaveLen(0))
+					Expect(workPlacements.Items).To(BeEmpty())
 				})
 			})
 
@@ -461,7 +461,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 					preUpdateDestination = workPlacements.Items[0].Spec.TargetDestinationName
 
 					// change the scheduling on the resource work from devDestination to prodDestination
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork)).To(Succeed())
 					resourceWork.Spec.WorkloadGroups[0].DestinationSelectors[0] = schedulingFor(prodDestination)
 					_, err = scheduler.ReconcileWork(&resourceWork)
 					Expect(err).ToNot(HaveOccurred())
@@ -487,7 +487,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 				})
 
 				It("labels the resource Work to indicate it's misscheduled", func() {
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&resourceWork), &resourceWork)).To(Succeed())
 					Expect(resourceWork.Status.Conditions).To(HaveLen(2))
 
 					Expect(resourceWork.Status.Conditions[0].Type).To(Equal("Scheduled"))
@@ -581,12 +581,12 @@ var _ = Describe("Controllers/Scheduler", func() {
 
 						// check that the WorkPlacement has been deleted
 						Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-						Expect(workPlacements.Items).To(HaveLen(0))
+						Expect(workPlacements.Items).To(BeEmpty())
 					})
 
 					It("gets recreated on next reconciliation", func() {
 						// re-reconcile the Work
-						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWorkForProd), &dependencyWorkForProd))
+						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWorkForProd), &dependencyWorkForProd)).To(Succeed())
 						_, err := scheduler.ReconcileWork(&dependencyWorkForProd)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -647,7 +647,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 
 					It("gets recreated on next reconciliation", func() {
 						// re-reconcile the Work
-						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWorkForDev), &dependencyWorkForDev))
+						Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWorkForDev), &dependencyWorkForDev)).To(Succeed())
 						_, err := scheduler.ReconcileWork(&dependencyWorkForDev)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -687,7 +687,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 					var err error
 					unschedulable, err = scheduler.ReconcileWork(&dependencyWork)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork)).To(Succeed())
 				})
 
 				It("creates no workplacements", func() {
@@ -721,7 +721,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 
 				It("creates WorkPlacements for all non-strict label matching registered Destinations", func() {
 					Expect(fakeK8sClient.List(context.Background(), &workPlacements)).To(Succeed())
-					Expect(len(workPlacements.Items)).To(Equal(4))
+					Expect(workPlacements.Items).To(HaveLen(4))
 					for _, workPlacement := range workPlacements.Items {
 						Expect(workPlacement.Spec.Workloads).To(ConsistOf(Workload{
 							Content: "key: value",
@@ -731,7 +731,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 				})
 
 				It("updates WorkPlacements for all registered Destinations", func() {
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork)).To(Succeed())
 					dependencyWork.Spec.WorkloadGroups[0].Workloads = append(dependencyWork.Spec.WorkloadGroups[0].Workloads, Workload{
 						Content: "fake: new-content",
 					})
@@ -759,7 +759,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 
 					// add scheduling for the devDestination, so that the WorkPlacements
 					// for prod and pci are now misscheduled
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork)).To(Succeed())
 					dependencyWork.Spec.WorkloadGroups[0].DestinationSelectors = []v1alpha1.WorkloadGroupScheduling{
 						schedulingFor(devDestination),
 					}
@@ -814,7 +814,7 @@ var _ = Describe("Controllers/Scheduler", func() {
 
 				It("keeps the misscheduled WorkPlacements updated", func() {
 					// update the Work's WorkloadGroup with an extra Workload
-					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork))
+					Expect(fakeK8sClient.Get(context.Background(), client.ObjectKeyFromObject(&dependencyWork), &dependencyWork)).To(Succeed())
 					dependencyWork.Spec.WorkloadGroups[0].Workloads = append(dependencyWork.Spec.WorkloadGroups[0].Workloads, Workload{
 						Content: "fake: new-content",
 					})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -34,11 +34,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	//+kubebuilder:scaffold:imports
@@ -50,16 +48,9 @@ import (
 var (
 	fakeK8sClient           client.Client
 	fakeApiExtensionsClient apiextensionsv1.CustomResourceDefinitionsGetter
-	apiextensionClient      apiextensionsv1.CustomResourceDefinitionsGetter
-	testEnv                 *envtest.Environment
-	k8sManager              ctrl.Manager
 	t                       *testReconciler
 	interceptorsFuncs       interceptor.Funcs
 	subResourceUpdateError  error
-
-	timeout             = "30s"
-	consistentlyTimeout = "6s"
-	interval            = "3s"
 )
 
 var _ = BeforeSuite(func(_ SpecContext) {
@@ -76,7 +67,6 @@ var _ = AfterSuite(func() {
 
 var reconcileConfigureOptsArg workflow.Opts
 var reconcileDeleteOptsArg workflow.Opts
-var callCount int
 
 var _ = BeforeEach(func() {
 	yamlFile, err := os.ReadFile(resourceRequestPath)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -50,7 +50,7 @@ var (
 	fakeApiExtensionsClient apiextensionsv1.CustomResourceDefinitionsGetter
 	t                       *testReconciler
 	interceptorsFuncs       interceptor.Funcs
-	subResourceUpdateError  error
+	errSubResourceUpdate    error
 )
 
 var _ = BeforeSuite(func(_ SpecContext) {
@@ -77,8 +77,8 @@ var _ = BeforeEach(func() {
 
 	interceptorsFuncs = interceptor.Funcs{}
 	interceptorsFuncs.SubResourceUpdate = func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-		if subResourceUpdateError != nil {
-			return subResourceUpdateError
+		if errSubResourceUpdate != nil {
+			return errSubResourceUpdate
 		}
 		return client.Status().Update(ctx, obj, opts...)
 	}

--- a/controllers/work_controller_test.go
+++ b/controllers/work_controller_test.go
@@ -32,8 +32,6 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-var work *v1alpha1.Work
-
 var _ = Describe("WorkReconciler", func() {
 	var (
 		ctx              context.Context

--- a/controllers/workplacement_controller.go
+++ b/controllers/workplacement_controller.go
@@ -267,13 +267,13 @@ func workloadsFilenames(works []v1alpha1.Workload) []string {
 	return result
 }
 
-func cleanupWorkloads(old []string, new []v1alpha1.Workload) []string {
+func cleanupWorkloads(oldWorkloads []string, newWorkloads []v1alpha1.Workload) []string {
 	works := make(map[string]bool)
-	for _, w := range new {
+	for _, w := range newWorkloads {
 		works[w.Filepath] = true
 	}
 	var result []string
-	for _, w := range old {
+	for _, w := range oldWorkloads {
 		if _, ok := works[w]; !ok {
 			result = append(result, w)
 		}

--- a/controllers/workplacement_controller.go
+++ b/controllers/workplacement_controller.go
@@ -204,7 +204,7 @@ func (r *WorkPlacementReconciler) writeWorkloadsToStateStore(writer writers.Stat
 	for _, workload := range workPlacement.Spec.Workloads {
 		decompressedContent, err := compression.DecompressContent([]byte(workload.Content))
 		if err != nil {
-			return "", fmt.Errorf("unable to decompress file content: %s", err)
+			return "", fmt.Errorf("unable to decompress file content: %w", err)
 		}
 
 		workload.Content = string(decompressedContent)
@@ -214,11 +214,11 @@ func (r *WorkPlacementReconciler) writeWorkloadsToStateStore(writer writers.Stat
 	if destination.GetFilepathMode() == v1alpha1.FilepathModeNone {
 		var kratixFile []byte
 		if kratixFile, err = writer.ReadFile(fmt.Sprintf(".kratix/%s-%s.yaml", workPlacement.Namespace, workPlacement.Name)); ignoreNotFound(err) != nil {
-			return "", fmt.Errorf("failed to read .kratix state file: %s", err)
+			return "", fmt.Errorf("failed to read .kratix state file: %w", err)
 		}
 		oldStateFile := StateFile{}
 		if err = yaml.Unmarshal(kratixFile, &oldStateFile); err != nil {
-			return "", fmt.Errorf("failed to unmarshal .kratix state file: %s", err)
+			return "", fmt.Errorf("failed to unmarshal .kratix state file: %w", err)
 		}
 
 		newStateFile := StateFile{
@@ -226,7 +226,7 @@ func (r *WorkPlacementReconciler) writeWorkloadsToStateStore(writer writers.Stat
 		}
 		stateFileContent, marshalErr := yaml.Marshal(newStateFile)
 		if marshalErr != nil {
-			return "", fmt.Errorf("failed to marshal new .kratix state file: %s", err)
+			return "", fmt.Errorf("failed to marshal new .kratix state file: %w", err)
 		}
 
 		stateFileWorkload := v1alpha1.Workload{

--- a/controllers/workplacement_controller.go
+++ b/controllers/workplacement_controller.go
@@ -253,7 +253,7 @@ func (r *WorkPlacementReconciler) writeWorkloadsToStateStore(writer writers.Stat
 }
 
 func ignoreNotFound(err error) error {
-	if errors.Is(err, writers.FileNotFound) {
+	if errors.Is(err, writers.ErrFileNotFound) {
 		return nil
 	}
 	return err

--- a/controllers/workplacement_controller.go
+++ b/controllers/workplacement_controller.go
@@ -26,7 +26,6 @@ import (
 	"gopkg.in/yaml.v2"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -290,25 +289,6 @@ func getDir(workPlacement v1alpha1.WorkPlacement) string {
 		//resources/<rr-namespace>/<promise-name>/<rr-name>/<pipeline-name>/<dir-sha>/
 		return filepath.Join(resourcesDir, workPlacement.GetNamespace(), workPlacement.Spec.PromiseName, workPlacement.Spec.ResourceName, workPlacement.PipelineName(), shortID(workPlacement.Spec.ID))
 	}
-}
-
-func (r *WorkPlacementReconciler) getWork(workName, workNamespace string, logger logr.Logger) *v1alpha1.Work {
-	work := &v1alpha1.Work{}
-	namespaceName := types.NamespacedName{
-		Namespace: workNamespace,
-		Name:      workName,
-	}
-	r.Client.Get(context.Background(), namespaceName, work)
-	return work
-}
-
-func (r *WorkPlacementReconciler) addFinalizer(ctx context.Context, workPlacement *v1alpha1.WorkPlacement, logger logr.Logger) (ctrl.Result, error) {
-	controllerutil.AddFinalizer(workPlacement, repoCleanupWorkPlacementFinalizer)
-	if err := r.Client.Update(ctx, workPlacement); err != nil {
-		logger.Error(err, "failed to add finalizer to WorkPlacement")
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/workplacement_controller_test.go
+++ b/controllers/workplacement_controller_test.go
@@ -382,7 +382,7 @@ files:
 
 		When("updating the status fails", func() {
 			It("applies the Version ID on the next reconcile", func() {
-				subResourceUpdateError = fmt.Errorf("an-error")
+				errSubResourceUpdate = fmt.Errorf("an-error")
 
 				fakeWriter.UpdateFilesReturnsOnCall(0, "an-amazing-version-id", nil)
 
@@ -391,7 +391,7 @@ files:
 				Expect(result).To(Equal(ctrl.Result{}))
 				Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(1))
 
-				subResourceUpdateError = nil
+				errSubResourceUpdate = nil
 
 				result, err = t.reconcileUntilCompletion(reconciler, &workPlacement)
 				Expect(err).ToNot(HaveOccurred())

--- a/hack/worker-resource-builder/main.go
+++ b/hack/worker-resource-builder/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -52,7 +53,7 @@ func main() {
 
 			if us == nil {
 				continue
-			} else if err == io.EOF {
+			} else if errors.Is(err, io.EOF) {
 				break
 			} else {
 				if us.GetNamespace() == "" && us.GetKind() != "Namespace" {

--- a/internal/webhook/v1alpha1/promise_webhook_test.go
+++ b/internal/webhook/v1alpha1/promise_webhook_test.go
@@ -210,7 +210,7 @@ var _ = Describe("PromiseWebhook", func() {
 			})
 		})
 
-		DescribeTable("validates the provided labels", func(key, val, error string) {
+		DescribeTable("validates the provided labels", func(key, val, expectedErr string) {
 			pipeline := v1alpha1.Pipeline{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pipeline-name",
@@ -222,8 +222,8 @@ var _ = Describe("PromiseWebhook", func() {
 			setPipeline(promise, pipeline)
 			warnings, err := validator.ValidateCreate(ctx, promise)
 			Expect(warnings).To(BeEmpty())
-			if error != "" {
-				Expect(err).To(MatchError(ContainSubstring(error)))
+			if expectedErr != "" {
+				Expect(err).To(MatchError(ContainSubstring(expectedErr)))
 			} else {
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/internal/webhook/v1alpha1/promiserelease_webhook.go
+++ b/internal/webhook/v1alpha1/promiserelease_webhook.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+
 	"github.com/syntasso/kratix/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/internal/webhook/v1alpha1/promiserelease_webhook_test.go
+++ b/internal/webhook/v1alpha1/promiserelease_webhook_test.go
@@ -3,6 +3,7 @@ package v1alpha1_test
 import (
 	"context"
 	"fmt"
+
 	kratixWebhook "github.com/syntasso/kratix/internal/webhook/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -1,9 +1,10 @@
 package v1alpha1_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestAPIs(t *testing.T) {

--- a/lib/compression/compression.go
+++ b/lib/compression/compression.go
@@ -35,7 +35,7 @@ func DecompressContent(compressedBytes []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer zr.Close()
+	defer zr.Close() //nolint:errcheck
 
 	decompressed, err := io.ReadAll(zr)
 	if err != nil {

--- a/lib/compression/compression.go
+++ b/lib/compression/compression.go
@@ -48,7 +48,7 @@ func DecompressContent(compressedBytes []byte) ([]byte, error) {
 func InCompressedContents(compressedContent string, content []byte) (bool, error) {
 	decompressedContent, err := DecompressContent([]byte(compressedContent))
 	if err != nil {
-		return false, fmt.Errorf("unable to decompress contents: %s", err)
+		return false, fmt.Errorf("unable to decompress contents: %w", err)
 	}
 	return bytes.Contains(decompressedContent, content), nil
 }

--- a/lib/fetchers/url.go
+++ b/lib/fetchers/url.go
@@ -31,7 +31,7 @@ func (u *URLFetcher) FromURL(urlString, authHeader string) (*v1alpha1.Promise, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to get url: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get Promise from URL: status code %d", resp.StatusCode)

--- a/lib/fetchers/url.go
+++ b/lib/fetchers/url.go
@@ -15,7 +15,7 @@ type URLFetcher struct {
 }
 
 func (u *URLFetcher) FromURL(urlString, authHeader string) (*v1alpha1.Promise, error) {
-	req, err := http.NewRequest("GET", urlString, nil)
+	req, err := http.NewRequest(http.MethodGet, urlString, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/fetchers/url_test.go
+++ b/lib/fetchers/url_test.go
@@ -29,7 +29,8 @@ var _ = Describe("#FromURL", func() {
 				w.WriteHeader(responseStatus)
 				return
 			}
-			w.Write(responseBody)
+			_, err := w.Write(responseBody)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		fakeServer.AppendHandlers(

--- a/lib/resourceutil/util_test.go
+++ b/lib/resourceutil/util_test.go
@@ -278,7 +278,7 @@ var _ = Describe("Conditions", func() {
 
 	Describe("PipelinesToSuspend", func() {
 		It("returns empty if there are no jobs", func() {
-			Expect(resourceutil.SuspendablePipelines(logger, nil)).To(HaveLen(0))
+			Expect(resourceutil.SuspendablePipelines(logger, nil)).To(BeEmpty())
 		})
 
 		It("returns any jobs that aren't suspended and have no active pods", func() {

--- a/lib/workflow/rbac.go
+++ b/lib/workflow/rbac.go
@@ -54,15 +54,15 @@ func getRolesToDelete(opts Opts, desiredRoles []rbacv1.Role, listOptions client.
 
 	if err == nil {
 		for _, existingRole := range existingRoles.Items {
-			delete := true
+			shouldDelete := true
 			for _, desiredRole := range desiredRoles {
 				if rolesMatch(existingRole, desiredRole) {
-					delete = false
+					shouldDelete = false
 					break
 				}
 			}
 
-			if delete {
+			if shouldDelete {
 				rolesToDelete = append(rolesToDelete, &existingRole)
 			}
 		}
@@ -96,15 +96,15 @@ func getRoleBindingsToDelete(opts Opts, desiredRoleBindings []rbacv1.RoleBinding
 
 	if err == nil {
 		for _, existingRoleBinding := range existingRoleBindings.Items {
-			delete := true
+			shouldDelete := true
 			for _, desiredRoleBinding := range desiredRoleBindings {
 				if roleBindingsMatch(existingRoleBinding, desiredRoleBinding) {
-					delete = false
+					shouldDelete = false
 					break
 				}
 			}
 
-			if delete {
+			if shouldDelete {
 				roleBindingsToDelete = append(roleBindingsToDelete, &existingRoleBinding)
 			}
 		}
@@ -138,15 +138,15 @@ func getClusterRolesToDelete(opts Opts, desiredClusterRoles []rbacv1.ClusterRole
 
 	if err == nil {
 		for _, existingClusterRole := range existingClusterRoles.Items {
-			delete := true
+			shouldDelete := true
 			for _, desiredClusterRole := range desiredClusterRoles {
 				if clusterRolesMatch(existingClusterRole, desiredClusterRole) {
-					delete = false
+					shouldDelete = false
 					break
 				}
 			}
 
-			if delete {
+			if shouldDelete {
 				clusterRolesToDelete = append(clusterRolesToDelete, &existingClusterRole)
 			}
 		}
@@ -180,15 +180,15 @@ func getClusterRoleBindingsToDelete(opts Opts, desiredClusterRoleBindings []rbac
 
 	if err == nil {
 		for _, existingClusterRoleBinding := range existingClusterRoleBindings.Items {
-			delete := true
+			shouldDelete := true
 			for _, desiredClusterRoleBinding := range desiredClusterRoleBindings {
 				if clusterRoleBindingsMatch(existingClusterRoleBinding, desiredClusterRoleBinding) {
-					delete = false
+					shouldDelete = false
 					break
 				}
 			}
 
-			if delete {
+			if shouldDelete {
 				opts.logger.Info("No matching cluster role binding found, deleting", "clusterRoleBinding", existingClusterRoleBinding.Name)
 				clusterRoleBindingsToDelete = append(clusterRoleBindingsToDelete, &existingClusterRoleBinding)
 			}

--- a/lib/workflow/rbac.go
+++ b/lib/workflow/rbac.go
@@ -46,6 +46,7 @@ func getObjectsToDelete(opts Opts, pipeline v1alpha1.PipelineJobResources) ([]cl
 	return toDelete, nil
 }
 
+//nolint:dupl
 func getRolesToDelete(opts Opts, desiredRoles []rbacv1.Role, listOptions client.ListOptions) ([]client.Object, error) {
 	rolesToDelete := []client.Object{}
 	existingRoles := rbacv1.RoleList{}
@@ -88,6 +89,7 @@ func rolesMatch(existingRole rbacv1.Role, desiredRole rbacv1.Role) bool {
 	return true
 }
 
+//nolint:dupl
 func getRoleBindingsToDelete(opts Opts, desiredRoleBindings []rbacv1.RoleBinding, listOptions client.ListOptions) ([]client.Object, error) {
 	roleBindingsToDelete := []client.Object{}
 	existingRoleBindings := rbacv1.RoleBindingList{}
@@ -130,6 +132,7 @@ func roleBindingsMatch(existingRoleBinding rbacv1.RoleBinding, desiredRoleBindin
 	return existingRoleBinding.RoleRef.String() == desiredRoleBinding.RoleRef.String()
 }
 
+//nolint:dupl
 func getClusterRolesToDelete(opts Opts, desiredClusterRoles []rbacv1.ClusterRole, listOptions client.ListOptions) ([]client.Object, error) {
 	clusterRolesToDelete := []client.Object{}
 	existingClusterRoles := rbacv1.ClusterRoleList{}

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -384,8 +384,9 @@ func setConfigureWorkflowCompletedConditionStatus(opts Opts, isTheFirstPipeline 
 			return false, err
 		}
 		return true, nil
+	default:
+		return false, nil
 	}
-	return false, nil
 }
 
 func getDeletePipeline(opts Opts, namespace string, pipeline v1alpha1.PipelineJobResources) (*batchv1.Job, error) {

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Workflow Reconciler", func() {
 
 				It("updates the Promise status", func() {
 					Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: promise.Name}, &promise)).To(Succeed())
-					Expect(len(promise.Status.Conditions)).To(Equal(1))
+					Expect(promise.Status.Conditions).To(HaveLen(1))
 					Expect(promise.Status.Conditions[0].Type).To(Equal(string(resourceutil.ConfigureWorkflowCompletedCondition)))
 					Expect(promise.Status.Conditions[0].Message).To(Equal("A Pipeline has failed: pipeline-1"))
 					Expect(promise.Status.Conditions[0].Reason).To(Equal("ConfigureWorkflowFailed"))
@@ -341,7 +341,7 @@ var _ = Describe("Workflow Reconciler", func() {
 					abort, err := workflow.ReconcileConfigure(opts)
 					Expect(err).NotTo(HaveOccurred())
 					jobList := listJobs(namespace)
-					Expect(len(jobList)).To(Equal(1))
+					Expect(jobList).To(HaveLen(1))
 					Expect(abort).To(BeTrue())
 				})
 
@@ -433,7 +433,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				jobList := listJobs(namespace)
-				Expect(len(jobList)).To(Equal(numberOfJobLimit * len(updatedWorkflowPipeline)))
+				Expect(jobList).To(HaveLen(numberOfJobLimit * len(updatedWorkflowPipeline)))
 			})
 		})
 
@@ -937,22 +937,22 @@ var _ = Describe("Workflow Reconciler", func() {
 				roles := &rbacv1.RoleList{}
 				Expect(fakeK8sClient.List(ctx, roles, userPermissionPipelineLabels(promise, pipelines[0]))).To(Succeed())
 
-				Expect(roles.Items).To(HaveLen(0))
+				Expect(roles.Items).To(BeEmpty())
 
 				clusterRoles := &rbacv1.ClusterRoleList{}
 				Expect(fakeK8sClient.List(ctx, clusterRoles, userPermissionPipelineLabels(promise, pipelines[0]))).To(Succeed())
 
-				Expect(clusterRoles.Items).To(HaveLen(0))
+				Expect(clusterRoles.Items).To(BeEmpty())
 
 				roleBindings := &rbacv1.RoleBindingList{}
 				Expect(fakeK8sClient.List(ctx, roleBindings, userPermissionPipelineLabels(promise, pipelines[0]))).To(Succeed())
 
-				Expect(roleBindings.Items).To(HaveLen(0))
+				Expect(roleBindings.Items).To(BeEmpty())
 
 				clusterRoleBindings := &rbacv1.ClusterRoleBindingList{}
 				Expect(fakeK8sClient.List(ctx, clusterRoleBindings, userPermissionPipelineLabels(promise, pipelines[0]))).To(Succeed())
 
-				Expect(clusterRoleBindings.Items).To(HaveLen(0))
+				Expect(clusterRoleBindings.Items).To(BeEmpty())
 			})
 		})
 
@@ -984,7 +984,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				roles := &rbacv1.RoleList{}
 				Expect(fakeK8sClient.List(ctx, roles, userPermissionPipelineLabels(promise, pipelines[0]))).To(Succeed())
 
-				Expect(roles.Items).To(HaveLen(0))
+				Expect(roles.Items).To(BeEmpty())
 			})
 
 			It("removes the user provided pipeline scoped role binding and retains the role binding for the specific namespace", func() {
@@ -1481,7 +1481,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				clusterBindings := &rbacv1.ClusterRoleBindingList{}
 				Expect(fakeK8sClient.List(ctx, clusterBindings, userPermissionPipelineLabels(promise, pipelines[0]))).To(Succeed())
 
-				Expect(clusterBindings.Items).To(HaveLen(0))
+				Expect(clusterBindings.Items).To(BeEmpty())
 
 				By("removing the all-namespace cluster role")
 				clusterRoles := &rbacv1.ClusterRoleList{}

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -1845,6 +1845,8 @@ func markJobAs(conditionType batchv1.JobConditionType, name string) {
 		job.Status.Succeeded = 1
 	case batchv1.JobFailed:
 		job.Status.Failed = 1
+	default:
+		Fail("unsupported condition type")
 	}
 
 	Expect(fakeK8sClient.Status().Update(ctx, job)).To(Succeed())

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -542,7 +542,7 @@ var _ = Describe("Workflow Reconciler", func() {
 						Expect(jobs[2].GetLabels()).To(HaveKeyWithValue("kratix.io/pipeline-name", workflowPipelines[0].Name))
 					})
 
-					By("removing the label from the parent after the first reconcilation", func() {
+					By("removing the label from the parent after the first reconciliation", func() {
 						promise := v1alpha1.Promise{}
 						Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: "redis"}, &promise)).To(Succeed())
 						Expect(promise.GetLabels()).NotTo(HaveKey("kratix.io/manual-reconciliation"))

--- a/lib/writers/git.go
+++ b/lib/writers/git.go
@@ -60,7 +60,11 @@ func NewGitWriter(logger logr.Logger, stateStoreSpec v1alpha1.GitStateStoreSpec,
 			return nil, fmt.Errorf("error creating knownHosts file: %w", err)
 		}
 
-		knownHostsFile.Write(knownHosts)
+		_, err = knownHostsFile.Write(knownHosts)
+		if err != nil {
+			return nil, fmt.Errorf("error writing knownHosts file: %w", err)
+		}
+
 		knownHostsCallback, err := ssh.NewKnownHostsCallback(knownHostsFile.Name())
 		if err != nil {
 			return nil, fmt.Errorf("error parsing known hosts: %w", err)
@@ -128,7 +132,7 @@ func (g *GitWriter) update(subDir, workPlacementName string, workloadsToCreate [
 	if err != nil {
 		return "", err
 	}
-	defer os.RemoveAll(filepath.Dir(localTmpDir))
+	defer os.RemoveAll(filepath.Dir(localTmpDir)) //nolint:errcheck
 
 	err = g.deleteExistingFiles(subDir != "", dirInGitRepo, workloadsToDelete, worktree, logger)
 	if err != nil {
@@ -220,7 +224,7 @@ func (g *GitWriter) ReadFile(filePath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(filepath.Dir(localTmpDir))
+	defer os.RemoveAll(filepath.Dir(localTmpDir)) //nolint:errcheck
 
 	if _, err := worktree.Filesystem.Lstat(fullPath); err != nil {
 		logger.Info("could not stat file", "err", err)

--- a/lib/writers/git.go
+++ b/lib/writers/git.go
@@ -228,7 +228,7 @@ func (g *GitWriter) ReadFile(filePath string) ([]byte, error) {
 
 	if _, err := worktree.Filesystem.Lstat(fullPath); err != nil {
 		logger.Info("could not stat file", "err", err)
-		return nil, FileNotFound
+		return nil, ErrFileNotFound
 	}
 
 	var content []byte

--- a/lib/writers/s3.go
+++ b/lib/writers/s3.go
@@ -86,10 +86,13 @@ func (b *S3Writer) ReadFile(filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer obj.Close()
+	defer obj.Close() //nolint:errcheck
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(obj)
+	_, err = buf.ReadFrom(obj)
+	if err != nil {
+		return nil, err
+	}
 
 	return buf.Bytes(), nil
 

--- a/lib/writers/s3.go
+++ b/lib/writers/s3.go
@@ -77,7 +77,7 @@ func (b *S3Writer) ReadFile(filename string) ([]byte, error) {
 	_, err := b.RepoClient.StatObject(context.Background(), b.BucketName, filepath.Join(b.path, filename), minio.GetObjectOptions{})
 	if err != nil {
 		if minio.ToErrorResponse(err).Code == "NoSuchKey" {
-			return nil, FileNotFound
+			return nil, ErrFileNotFound
 		}
 		return nil, err
 	}

--- a/lib/writers/statestore_writer.go
+++ b/lib/writers/statestore_writer.go
@@ -14,4 +14,4 @@ type StateStoreWriter interface {
 	ReadFile(filename string) ([]byte, error)
 }
 
-var FileNotFound = fmt.Errorf("file not found")
+var ErrFileNotFound = fmt.Errorf("file not found")

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -1053,7 +1053,7 @@ func requestWithNameAndCommand(name string, containerCmds ...string) string {
 //   - By time kratix starts back up, it has already been deleted
 //
 // This means we need a more robust approach for deleting Promises
-func (c destination) eventuallyKubectlDelete(args ...string) string {
+func (c destination) eventuallyKubectlDelete(args ...string) string { //nolint:unparam
 	commandArgs := []string{"get", "--context=" + c.context}
 	commandArgs = append(commandArgs, args...)
 	command := exec.Command("kubectl", commandArgs...)
@@ -1134,7 +1134,7 @@ func (c destination) clone() destination {
 	}
 }
 
-func (c destination) withExitCode(code int) destination {
+func (c destination) withExitCode(code int) destination { //nolint:unparam
 	newDestination := c.clone()
 	newDestination.exitCode = code
 	return newDestination

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -767,7 +767,7 @@ var _ = Describe("Kratix", func() {
 					Expect(platform.kubectl("get", "namespace")).NotTo(ContainSubstring(depNamespaceName))
 				})
 
-				By("labeling the platform Destination, it gets the dependencies assigned", func() {
+				By("labelling the platform Destination, it gets the dependencies assigned", func() {
 					platform.kubectl("label", "destination", platform.name, "security=high", bashPromiseUniqueLabel)
 					platform.eventuallyKubectl("get", "namespace", depNamespaceName)
 					platform.eventuallyKubectl("get", "namespace", declarativeWorkerNamespace)
@@ -1174,7 +1174,7 @@ func listFilesInGitStateStore(subDir string) []string {
 func listFilesInMinIOStateStore(path string) []string {
 	files := []string{}
 
-	// Initialize minio client object.
+	// Initialise minio client object.
 	minioClient, err := minio.New(endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
 		Secure: useSSL,

--- a/work-creator/pipeline/cmd/update-status/main.go
+++ b/work-creator/pipeline/cmd/update-status/main.go
@@ -28,14 +28,14 @@ func run(ctx context.Context) error {
 
 	client, err := helpers.GetK8sClient()
 	if err != nil {
-		return fmt.Errorf("failed to create Kubernetes client: %v", err)
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
 	objectClient := client.Resource(helpers.ObjectGVR(params)).Namespace(params.ObjectNamespace)
 
 	existingObj, err := objectClient.Get(ctx, params.ObjectName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get existing object: %v", err)
+		return fmt.Errorf("failed to get existing object: %w", err)
 	}
 
 	existingStatus := map[string]any{}
@@ -46,7 +46,7 @@ func run(ctx context.Context) error {
 	// Load incoming status.yaml if exists
 	incomingStatus, err := readStatusFile(statusFile)
 	if err != nil {
-		return fmt.Errorf("failed to load incoming status: %v", err)
+		return fmt.Errorf("failed to load incoming status: %w", err)
 	}
 
 	mergedStatus := lib.MergeStatuses(existingStatus, incomingStatus)
@@ -59,7 +59,7 @@ func run(ctx context.Context) error {
 
 	// Update the object's status
 	if _, err = objectClient.UpdateStatus(ctx, existingObj, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("failed to update status: %v", err)
+		return fmt.Errorf("failed to update status: %w", err)
 	}
 
 	return nil
@@ -70,10 +70,10 @@ func readStatusFile(statusFile string) (map[string]any, error) {
 	if _, err := os.Stat(statusFile); err == nil {
 		incomingStatusBytes, err := os.ReadFile(statusFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read status file: %v", err)
+			return nil, fmt.Errorf("failed to read status file: %w", err)
 		}
 		if err := yaml.Unmarshal(incomingStatusBytes, &incomingStatus); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal incoming status: %v", err)
+			return nil, fmt.Errorf("failed to unmarshal incoming status: %w", err)
 		}
 	}
 	return incomingStatus, nil

--- a/work-creator/pipeline/cmd/work-creator/main.go
+++ b/work-creator/pipeline/cmd/work-creator/main.go
@@ -49,7 +49,11 @@ func main() {
 	}
 
 	//Teach our client to speak v1alpha1.Work
-	v1alpha1.AddToScheme(scheme.Scheme)
+	err := v1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		fmt.Println("Error adding v1alpha1 to scheme")
+		os.Exit(1)
+	}
 
 	k8sClient, err := getClient()
 	if err != nil {

--- a/work-creator/pipeline/lib/helpers/helpers.go
+++ b/work-creator/pipeline/lib/helpers/helpers.go
@@ -87,11 +87,11 @@ func getK8sClient() (dynamic.Interface, error) {
 func WriteToYaml(obj interface{}, objectFilePath string) error {
 	objYAML, err := yaml.Marshal(obj)
 	if err != nil {
-		return fmt.Errorf("failed to marshal object: %v", err)
+		return fmt.Errorf("failed to marshal object: %w", err)
 	}
 
 	if err := os.WriteFile(objectFilePath, objYAML, 0644); err != nil {
-		return fmt.Errorf("failed to write object to file: %v", err)
+		return fmt.Errorf("failed to write object to file: %w", err)
 	}
 	return nil
 }

--- a/work-creator/pipeline/lib/reader.go
+++ b/work-creator/pipeline/lib/reader.go
@@ -19,7 +19,7 @@ func (r *Reader) Run(ctx context.Context) error {
 
 	client, err := helpers.GetK8sClient()
 	if err != nil {
-		return fmt.Errorf("failed to create Kubernetes client: %v", err)
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
 	if err := r.writeObjectToFile(ctx, client, params); err != nil {
@@ -34,17 +34,17 @@ func (r *Reader) writeObjectToFile(ctx context.Context, client dynamic.Interface
 
 	obj, err := objectClient.Get(ctx, params.ObjectName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get object: %v", err)
+		return fmt.Errorf("failed to get object: %w", err)
 	}
 
 	objectFilePath := params.GetObjectPath()
 	if err := helpers.WriteToYaml(obj, objectFilePath); err != nil {
-		return fmt.Errorf("failed to write object to file: %v", err)
+		return fmt.Errorf("failed to write object to file: %w", err)
 	}
 
 	fmt.Fprintln(r.Out, "Object file written to:", objectFilePath, "head of file:")
 	if err := helpers.PrintFileHead(r.Out, objectFilePath, 500); err != nil {
-		return fmt.Errorf("failed to print file head: %v", err)
+		return fmt.Errorf("failed to print file head: %w", err)
 	}
 
 	return nil

--- a/work-creator/pipeline/lib/status_updater.go
+++ b/work-creator/pipeline/lib/status_updater.go
@@ -45,6 +45,7 @@ func MarkAsCompleted(status map[string]any) map[string]any {
 func updateConditions(conditions []any, newCondition metav1.Condition) []any {
 	newCondBytes, _ := yaml.Marshal(newCondition)
 	var newCondMap map[string]any
+	//nolint:errcheck,gosec // Marshal/Unmarshal is safe here
 	yaml.Unmarshal(newCondBytes, &newCondMap)
 
 	if conditions == nil {

--- a/work-creator/pipeline/work_creator_test.go
+++ b/work-creator/pipeline/work_creator_test.go
@@ -35,7 +35,8 @@ var _ = Describe("WorkCreator", func() {
 			workCreator = pipeline.WorkCreator{
 				K8sClient: k8sClient,
 			}
-			k8sClient.Create(context.Background(), &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kratix-platform-system"}})
+			err := k8sClient.Create(context.Background(), &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kratix-platform-system"}})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		When("provided a complete set of inputs for a resource request", func() {

--- a/work-creator/pipeline/work_creator_test.go
+++ b/work-creator/pipeline/work_creator_test.go
@@ -337,6 +337,8 @@ func getWork(namespace, promiseName, resourceName, pipelineName string) v1alpha1
 
 	workSelectorLabel := labels.FormatLabels(l)
 	selector, err := labels.Parse(workSelectorLabel)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
 	err = k8sClient.List(context.Background(), &works, &client.ListOptions{
 		LabelSelector: selector,
 		Namespace:     namespace,


### PR DESCRIPTION
## Summary

This PR adds Golang linting config and Make targets.

The new targets are:

- `make lint-required` -- uses `.golangci-required.yml`, a mandatory and currently-green set of config which will run in CI
- `make lint-changed` -- uses the default `.golangci.yml`, a more thorough set of config, which runs on changed files locally (both staged and unstaged)

## Config

### `.golangci.yml`

The default config which the `golangci-lint` CLI uses, and which is also used by IDE plugins by default.

Pretty much taken verbatim from [this GitHub gist](https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322). This is quite opinionated and is intended to be aspirational.

It's very open to changes, and is currently red 🔴

### `.golangci-required.yml`

A required subset of config which will run in CI, intended to include config which:
1. catches issues which are useful, important, and/or trivial-but-nice for future work
2. is either passing already, or easy to make pass by fixing small issues (to reduce the scope of this initial work)

Starting from this baseline green config, we can iteratively improve the codebase (e.g. adding more linters, reducing the limits for cyclomatic/cognitive complexity, etc.).

This config has already caught some bugs!

Open to changes, and is currently green 🟢

> [!NOTE]  
> Linter config is difficult to balance when introducing it fresh into a codebase; everyone has different opinions on what's important/useful/trivial. With this in mind, we're expecting these config files to change quite a lot at the start, and evolve over time. This is just the starting point! 👀

## Commits

The first commit introduces the Make targets, and the baseline config files. Each subsequent commit adds a new linter to `.golangci-required.yml` and fixes any issues which were caught by it.

Reviewing commit-by-commit is recommended!