### PR TITLE
Demonstrate new slices/maps packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syntasso/kratix
 
-go 1.22.5
+go 1.23
 
 require (
 	github.com/go-git/go-git/v5 v5.13.1

--- a/work-creator/pipeline/lib/status_updater.go
+++ b/work-creator/pipeline/lib/status_updater.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"maps"
+	"slices"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,12 +73,7 @@ func updateConditions(conditions []any, newCondition metav1.Condition) []any {
 }
 
 func mergeRecursive(existing, incoming map[string]any) map[string]any {
-	result := make(map[string]any)
-
-	// First, copy all keys from base
-	for k, v := range existing {
-		result[k] = v
-	}
+	result := maps.Clone(existing)
 
 	// Then merge or overwrite with overlay
 	for k, v := range incoming {
@@ -119,11 +116,5 @@ func mergeConditions(existing, incoming []any) []any {
 		}
 	}
 
-	// Convert back to slice
-	result := make([]any, 0, len(merged))
-	for _, item := range merged {
-		result = append(result, item)
-	}
-
-	return result
+	return slices.Collect(maps.Values(merged))
 }


### PR DESCRIPTION
Upgrading to Go 1.23 would allow you to leverage the new rangefunc iterators and the slices / maps package improvements. This PR contains a small demo of the simplifications you could make.

Also here's a shameless plug for [go-functional](https://github.com/BooleanCat/go-functional) (which I maintain) which leverages the Go 1.23 features and could further simplify (although not included in this PR) some your your code from this:

```go
func mergeConditions(existing, incoming []any) []any {
	// Create a map to track conditions by their type
	merged := make(map[string]any)

	// Add base conditions first
	for _, cond := range existing {
		if condMap, ok := cond.(map[string]any); ok {
			if condType, typeOk := condMap["type"].(string); typeOk {
				merged[condType] = condMap
			}
		}
	}

	// Merge or add overlay conditions
	for _, cond := range incoming {
		if condMap, ok := cond.(map[string]any); ok {
			if condType, typeOk := condMap["type"].(string); typeOk {
				merged[condType] = condMap
			}
		}
	}

	return slices.Collect(maps.Values(merged))
}
```

To this:

```go
func mergeConditions(existing, incoming []any) []any {
	// Create a map to track conditions by their type
	merged := make(map[string]any)

	// Add base conditions first
	for cond := range itx.FromSlice(existing).Chain(slices.Values(incoming)) {
		if condMap, ok := cond.(map[string]any); ok {
			if condType, typeOk := condMap["type"].(string); typeOk {
				merged[condType] = condMap
			}
		}
	}

	return slices.Collect(maps.Values(merged))
}
```