### PR TITLE
chore: improve core system tests

### DIFF
--- a/test/kubeutils/cluster.go
+++ b/test/kubeutils/cluster.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"sigs.k8s.io/yaml"
 )
 
 type Cluster struct {
@@ -75,4 +76,9 @@ func (c Cluster) EventuallyKubectlDelete(args ...string) string {
 		content = string(session.Out.Contents())
 	}, timeout, time.Millisecond).Should(Succeed())
 	return content
+}
+
+func ParseOutput(output string, v interface{}) {
+	err := yaml.Unmarshal([]byte(output), v)
+	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
 }

--- a/test/kubeutils/cluster.go
+++ b/test/kubeutils/cluster.go
@@ -78,6 +78,7 @@ func (c Cluster) EventuallyKubectlDelete(args ...string) string {
 	return content
 }
 
+// ParseOutput parses the output of a kubectl command into the given v.
 func ParseOutput(output string, v interface{}) {
 	err := yaml.Unmarshal([]byte(output), v)
 	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
with the recent change to use a single worker as two different
destinations, the tests were no longer covering multi-destination
scheduling.

To validate that Kratix is indeed scheduling the workloads to the
appropriate place, we no longer can rely solely on the workload showing
up on the worker. Instead, we must check the WorkPlacements and verify
that the target destination for that workload is indeed the right
destination.

also removed a few duplicated assertions.
