### PR TITLE
chore: consolidate and refactor labels for pipelines

### DIFF
--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -358,6 +358,7 @@ func (p *PipelineFactory) pipelineJobLabels(requestSHA string) map[string]string
 		promiseNameLabel(p.Promise.GetName()),
 		workflowLabels(string(p.WorkflowType), string(p.WorkflowAction), p.Pipeline.GetName()),
 	)
+	ls = labels.Merge(ls, managedByKratixLabel())
 	if p.ResourceWorkflow {
 		ls = labels.Merge(ls, resourceNameLabel(p.ResourceRequest.GetName()))
 	}

--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -255,6 +255,40 @@ func workflowLabels(workflowType, workflowAction, pipelineName string) map[strin
 	return ls
 }
 
+// TODO: this part will be deprecated when we stop using the legacy labels
+func UserPermissionPipelineResourcesLegacyLabels(promiseName, pipelineName, pipelineNamespace, workflowType, workflowAction string) map[string]string {
+	labels := labels.Merge(
+		promiseNameLabel(promiseName),
+		workflowLegacyLabels(workflowType, workflowAction, pipelineName),
+	)
+	labels[PipelineNamespaceLabel] = pipelineNamespace
+	return labels
+}
+
+// TODO: this part will be deprecated when we stop using the legacy labels
+func workflowLegacyLabels(workflowType, workflowAction, pipelineName string) map[string]string {
+	ls := map[string]string{}
+
+	if workflowType != "" {
+		ls = labels.Merge(ls, map[string]string{
+			WorkTypeLabel: workflowType,
+		})
+	}
+
+	if pipelineName != "" {
+		ls = labels.Merge(ls, map[string]string{
+			PipelineNameLabel: pipelineName,
+		})
+	}
+
+	if workflowAction != "" {
+		ls = labels.Merge(ls, map[string]string{
+			WorkActionLabel: workflowAction,
+		})
+	}
+	return ls
+}
+
 func promiseNameLabel(promiseName string) map[string]string {
 	return map[string]string{
 		PromiseNameLabel: promiseName,

--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -40,6 +40,9 @@ const (
 	kratixPromiseEnvVar      = "KRATIX_PROMISE_NAME"
 	kratixPipelineNameEnvVar = "KRATIX_PIPELINE_NAME"
 
+	WorkflowTypeLabel   = KratixPrefix + "workflow-type"
+	WorkflowActionLabel = KratixPrefix + "workflow-action"
+
 	// This is used to identify the * namespace case in user permissions. Kubernetes does
 	// not allow * as a label value, so we use this value instead.
 	// It contains underscores, which makes it an invalid namespace, so it won't conflict
@@ -234,7 +237,7 @@ func workflowLabels(workflowType, workflowAction, pipelineName string) map[strin
 
 	if workflowType != "" {
 		ls = labels.Merge(ls, map[string]string{
-			WorkTypeLabel: workflowType,
+			WorkflowTypeLabel: workflowType,
 		})
 	}
 
@@ -246,7 +249,7 @@ func workflowLabels(workflowType, workflowAction, pipelineName string) map[strin
 
 	if workflowAction != "" {
 		ls = labels.Merge(ls, map[string]string{
-			WorkActionLabel: workflowAction,
+			WorkflowActionLabel: workflowAction,
 		})
 	}
 	return ls

--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -43,6 +43,9 @@ const (
 	WorkflowTypeLabel   = KratixPrefix + "workflow-type"
 	WorkflowActionLabel = KratixPrefix + "workflow-action"
 
+	ManagedByLabel      = "app.kubernetes.io/managed-by"
+	ManagedByLabelValue = "Kratix"
+
 	// This is used to identify the * namespace case in user permissions. Kubernetes does
 	// not allow * as a label value, so we use this value instead.
 	// It contains underscores, which makes it an invalid namespace, so it won't conflict
@@ -298,5 +301,11 @@ func promiseNameLabel(promiseName string) map[string]string {
 func resourceNameLabel(rName string) map[string]string {
 	return map[string]string{
 		ResourceNameLabel: rName,
+	}
+}
+
+func managedByKratixLabel() map[string]string {
+	return map[string]string{
+		ManagedByLabel: ManagedByLabelValue,
 	}
 }

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -353,8 +353,8 @@ var _ = Describe("Pipeline", func() {
 							for _, definedLabels := range []map[string]string{job.GetLabels(), job.Spec.Template.GetLabels()} {
 								Expect(definedLabels).To(SatisfyAll(
 									HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-									HaveKeyWithValue(v1alpha1.WorkTypeLabel, string(factory.WorkflowType)),
-									HaveKeyWithValue(v1alpha1.WorkActionLabel, string(factory.WorkflowAction)),
+									HaveKeyWithValue(v1alpha1.WorkflowTypeLabel, string(factory.WorkflowType)),
+									HaveKeyWithValue(v1alpha1.WorkflowActionLabel, string(factory.WorkflowAction)),
 									HaveKeyWithValue(v1alpha1.PipelineNameLabel, pipeline.GetName()),
 									HaveKeyWithValue(v1alpha1.KratixResourceHashLabel, promiseHash(promise)),
 									Not(HaveKey(v1alpha1.ResourceNameLabel)),
@@ -447,8 +447,8 @@ var _ = Describe("Pipeline", func() {
 							for _, definedLabels := range []map[string]string{job.GetLabels(), podTemplate.GetLabels()} {
 								Expect(definedLabels).To(SatisfyAll(
 									HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-									HaveKeyWithValue(v1alpha1.WorkTypeLabel, string(factory.WorkflowType)),
-									HaveKeyWithValue(v1alpha1.WorkActionLabel, string(factory.WorkflowAction)),
+									HaveKeyWithValue(v1alpha1.WorkflowTypeLabel, string(factory.WorkflowType)),
+									HaveKeyWithValue(v1alpha1.WorkflowActionLabel, string(factory.WorkflowAction)),
 									HaveKeyWithValue(v1alpha1.PipelineNameLabel, pipeline.GetName()),
 									HaveKeyWithValue(v1alpha1.KratixResourceHashLabel, combinedHash(promiseHash(promise), resourceHash(resourceRequest))),
 									HaveKeyWithValue(v1alpha1.ResourceNameLabel, resourceRequest.GetName()),
@@ -1207,8 +1207,8 @@ var _ = Describe("Pipeline", func() {
 							"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "specific-namespace")),
 							"Labels": SatisfyAll(
 								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-								HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
-								HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
+								HaveKeyWithValue(v1alpha1.WorkflowTypeLabel, "fakeType"),
+								HaveKeyWithValue(v1alpha1.WorkflowActionLabel, "fakeAction"),
 								HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
 								HaveKeyWithValue(v1alpha1.PipelineNamespaceLabel, factory.Namespace),
 								HaveKeyWithValue(v1alpha1.UserPermissionResourceNamespaceLabel, "specific-namespace"),
@@ -1227,8 +1227,8 @@ var _ = Describe("Pipeline", func() {
 							"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, "kratix-all-namespaces")),
 							"Labels": SatisfyAll(
 								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-								HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
-								HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
+								HaveKeyWithValue(v1alpha1.WorkflowTypeLabel, "fakeType"),
+								HaveKeyWithValue(v1alpha1.WorkflowActionLabel, "fakeAction"),
 								HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
 								HaveKeyWithValue(v1alpha1.PipelineNamespaceLabel, factory.Namespace),
 								HaveKeyWithValue(v1alpha1.UserPermissionResourceNamespaceLabel, "kratix_all_namespaces"),
@@ -1251,8 +1251,8 @@ var _ = Describe("Pipeline", func() {
 							"Name": MatchRegexp(fmt.Sprintf(`^%s-%s-\b\w{5}\b$`, factory.ID, resources.Shared.ServiceAccount.GetNamespace())),
 							"Labels": SatisfyAll(
 								HaveKeyWithValue(v1alpha1.PromiseNameLabel, promise.GetName()),
-								HaveKeyWithValue(v1alpha1.WorkTypeLabel, "fakeType"),
-								HaveKeyWithValue(v1alpha1.WorkActionLabel, "fakeAction"),
+								HaveKeyWithValue(v1alpha1.WorkflowTypeLabel, "fakeType"),
+								HaveKeyWithValue(v1alpha1.WorkflowActionLabel, "fakeAction"),
 								HaveKeyWithValue(v1alpha1.PipelineNameLabel, factory.Pipeline.Name),
 								HaveKeyWithValue(v1alpha1.PipelineNamespaceLabel, factory.Namespace),
 								HaveLen(5),
@@ -1299,8 +1299,8 @@ func matchUserPermissionsLabels(pipelineJobResources *v1alpha1.PipelineJobResour
 	Expect(labels).To(SatisfyAll(
 		HaveKeyWithValue(v1alpha1.PromiseNameLabel, jobLabels[v1alpha1.PromiseNameLabel]),
 		HaveKeyWithValue(v1alpha1.PipelineNameLabel, pipelineJobResources.Name),
-		HaveKeyWithValue(v1alpha1.WorkTypeLabel, jobLabels[v1alpha1.WorkTypeLabel]),
-		HaveKeyWithValue(v1alpha1.WorkActionLabel, jobLabels[v1alpha1.WorkActionLabel]),
+		HaveKeyWithValue(v1alpha1.WorkflowTypeLabel, jobLabels[v1alpha1.WorkflowTypeLabel]),
+		HaveKeyWithValue(v1alpha1.WorkflowActionLabel, jobLabels[v1alpha1.WorkflowActionLabel]),
 	))
 }
 

--- a/api/v1alpha1/work_types.go
+++ b/api/v1alpha1/work_types.go
@@ -34,6 +34,7 @@ const (
 	PipelineNameLabel                    = KratixPrefix + "pipeline-name"
 	PipelineNamespaceLabel               = KratixPrefix + "pipeline-namespace"
 	WorkTypeLabel                        = KratixPrefix + "work-type"
+	WorkActionLabel                      = KratixPrefix + "work-action"
 	UserPermissionResourceNamespaceLabel = KratixPrefix + "resource-namespace"
 
 	WorkTypePromise          = "promise"

--- a/api/v1alpha1/work_types.go
+++ b/api/v1alpha1/work_types.go
@@ -34,7 +34,6 @@ const (
 	PipelineNameLabel                    = KratixPrefix + "pipeline-name"
 	PipelineNamespaceLabel               = KratixPrefix + "pipeline-namespace"
 	WorkTypeLabel                        = KratixPrefix + "work-type"
-	WorkActionLabel                      = KratixPrefix + "work-action"
 	UserPermissionResourceNamespaceLabel = KratixPrefix + "resource-namespace"
 
 	WorkTypePromise          = "promise"

--- a/controllers/dynamic_resource_request_controller.go
+++ b/controllers/dynamic_resource_request_controller.go
@@ -275,7 +275,18 @@ func (r *DynamicResourceRequestController) deleteWorkflows(o opts, resourceReque
 		return err
 	}
 
-	if !resourcesRemaining {
+	// TODO: this part will be deprecated when we stop using the legacy labels
+	jobLegacyLabels := map[string]string{
+		v1alpha1.PromiseNameLabel:  r.PromiseIdentifier,
+		v1alpha1.ResourceNameLabel: resourceRequest.GetName(),
+		v1alpha1.WorkTypeLabel:     v1alpha1.WorkTypeResource,
+	}
+	legacyResourcesRemaining, err := deleteAllResourcesWithKindMatchingLabel(o, &jobGVK, jobLegacyLabels)
+	if err != nil {
+		return err
+	}
+
+	if !resourcesRemaining || !legacyResourcesRemaining {
 		controllerutil.RemoveFinalizer(resourceRequest, finalizer)
 		if err := r.Client.Update(o.ctx, resourceRequest); err != nil {
 			return err

--- a/controllers/dynamic_resource_request_controller.go
+++ b/controllers/dynamic_resource_request_controller.go
@@ -267,7 +267,7 @@ func (r *DynamicResourceRequestController) deleteWorkflows(o opts, resourceReque
 	jobLabels := map[string]string{
 		v1alpha1.PromiseNameLabel:  r.PromiseIdentifier,
 		v1alpha1.ResourceNameLabel: resourceRequest.GetName(),
-		v1alpha1.WorkTypeLabel:     v1alpha1.WorkTypeResource,
+		v1alpha1.WorkflowTypeLabel: string(v1alpha1.WorkflowTypeResource),
 	}
 
 	resourcesRemaining, err := deleteAllResourcesWithKindMatchingLabel(o, &jobGVK, jobLabels)

--- a/controllers/dynamic_resource_request_controller_test.go
+++ b/controllers/dynamic_resource_request_controller_test.go
@@ -61,13 +61,6 @@ var _ = Describe("DynamicResourceRequestController", func() {
 
 		resReq = createResourceRequest(resourceRequestPath)
 		resReqNameNamespace = client.ObjectKeyFromObject(resReq)
-
-		promiseCommonLabels = map[string]string{
-			"kratix-promise-resource-request-id": promise.GetName() + "-" + resReq.GetName(),
-			"kratix.io/resource-name":            resReq.GetName(),
-			"kratix.io/promise-name":             promise.GetName(),
-			"kratix.io/work-type":                "resource",
-		}
 	})
 
 	When("resource is being created", func() {

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -772,8 +772,8 @@ func (r *PromiseReconciler) deletePromiseWorkflowJobs(o opts, promise *v1alpha1.
 	}
 
 	jobLabels := map[string]string{
-		v1alpha1.PromiseNameLabel: promise.GetName(),
-		v1alpha1.WorkTypeLabel:    v1alpha1.WorkTypePromise,
+		v1alpha1.PromiseNameLabel:  promise.GetName(),
+		v1alpha1.WorkflowTypeLabel: string(v1alpha1.WorkflowTypePromise),
 	}
 
 	resourcesRemaining, err := deleteAllResourcesWithKindMatchingLabel(o, &jobGVK, jobLabels)

--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -781,7 +781,17 @@ func (r *PromiseReconciler) deletePromiseWorkflowJobs(o opts, promise *v1alpha1.
 		return err
 	}
 
-	if !resourcesRemaining {
+	// TODO: this part will be deprecated when we stop using the legacy labels
+	jobLegacyLabels := map[string]string{
+		v1alpha1.PromiseNameLabel: promise.GetName(),
+		v1alpha1.WorkTypeLabel:    v1alpha1.WorkTypePromise,
+	}
+	legacyResourcesRemaining, err := deleteAllResourcesWithKindMatchingLabel(o, &jobGVK, jobLegacyLabels)
+	if err != nil {
+		return err
+	}
+
+	if !resourcesRemaining || !legacyResourcesRemaining {
 		controllerutil.RemoveFinalizer(promise, finalizer)
 		if err := r.Client.Update(o.ctx, promise); err != nil {
 			return err

--- a/controllers/shared.go
+++ b/controllers/shared.go
@@ -59,6 +59,11 @@ func deleteAllResourcesWithKindMatchingLabel(o opts, gvk *schema.GroupVersionKin
 		return true, err
 	}
 
+	if len(resourceList.Items) == 0 {
+		o.logger.Info("no resources found for deletion", "gvk", resourceList.GroupVersionKind(), "withLabels", resourceLabels)
+		return false, nil
+	}
+
 	o.logger.Info("deleting resources", "gvk", resourceList.GroupVersionKind(), "withLabels", resourceLabels, "resources", resourceutil.GetResourceNames(resourceList.Items))
 
 	for _, resource := range resourceList.Items {

--- a/lib/workflow/rbac.go
+++ b/lib/workflow/rbac.go
@@ -219,10 +219,25 @@ func clusterRoleBindingsMatch(existingClusterRoleBinding rbacv1.ClusterRoleBindi
 }
 
 func getPipelineResourcesLabels(pipeline v1alpha1.PipelineJobResources) map[string]string {
-	return v1alpha1.UserPermissionPipelineResourcesLabels(
+	// TODO: this part will be deprecated when we stop using the legacy labels
+	resourcesLegacyLabels := v1alpha1.UserPermissionPipelineResourcesLegacyLabels(
+		pipeline.Job.GetLabels()[v1alpha1.PromiseNameLabel],
+		pipeline.Name,
+		pipeline.Job.Namespace,
+		pipeline.Job.GetLabels()[v1alpha1.WorkTypeLabel],
+		pipeline.Job.GetLabels()[v1alpha1.WorkActionLabel])
+
+	if len(resourcesLegacyLabels) != 0 {
+		return resourcesLegacyLabels
+	}
+	// TODO end of legacy labels block
+
+	resourcesLabels := v1alpha1.UserPermissionPipelineResourcesLabels(
 		pipeline.Job.GetLabels()[v1alpha1.PromiseNameLabel],
 		pipeline.Name,
 		pipeline.Job.Namespace,
 		pipeline.Job.GetLabels()[v1alpha1.WorkflowTypeLabel],
 		pipeline.Job.GetLabels()[v1alpha1.WorkflowActionLabel])
+
+	return resourcesLabels
 }

--- a/lib/workflow/rbac.go
+++ b/lib/workflow/rbac.go
@@ -223,6 +223,6 @@ func getPipelineResourcesLabels(pipeline v1alpha1.PipelineJobResources) map[stri
 		pipeline.Job.GetLabels()[v1alpha1.PromiseNameLabel],
 		pipeline.Name,
 		pipeline.Job.Namespace,
-		pipeline.Job.GetLabels()[v1alpha1.WorkTypeLabel],
-		pipeline.Job.GetLabels()[v1alpha1.WorkActionLabel])
+		pipeline.Job.GetLabels()[v1alpha1.WorkflowTypeLabel],
+		pipeline.Job.GetLabels()[v1alpha1.WorkflowActionLabel])
 }

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -98,6 +98,14 @@ func ReconcileConfigure(opts Opts) (abort bool, err error) {
 		return false, err
 	}
 
+	// TODO: this part will be deprecated when we stop using the legacy labels
+	allLegacyJobs, err := getJobsWithLabels(opts, legacyLabelsForJobs(opts), namespace)
+	if err != nil {
+		opts.logger.Error(err, "failed to list jobs")
+		return false, err
+	}
+	allJobs = append(allJobs, allLegacyJobs...)
+
 	if len(allJobs) != 0 {
 		opts.logger.Info("found existing jobs, checking to see which pipeline the most recent job is for")
 		resourceutil.SortJobsByCreationDateTime(allJobs, false)
@@ -192,6 +200,20 @@ func labelsForJobs(opts Opts) map[string]string {
 	}
 	promiseName := opts.parentObject.GetName()
 	if opts.source == string(v1alpha1.WorkflowTypeResource) {
+		promiseName = opts.parentObject.GetLabels()[v1alpha1.PromiseNameLabel]
+		l[v1alpha1.ResourceNameLabel] = opts.parentObject.GetName()
+	}
+	l[v1alpha1.PromiseNameLabel] = promiseName
+	return l
+}
+
+// TODO: this part will be deprecated when we stop using the legacy labels
+func legacyLabelsForJobs(opts Opts) map[string]string {
+	l := map[string]string{
+		v1alpha1.WorkTypeLabel: opts.source,
+	}
+	promiseName := opts.parentObject.GetName()
+	if opts.source == string(v1alpha1.WorkTypeResource) {
 		promiseName = opts.parentObject.GetLabels()[v1alpha1.PromiseNameLabel]
 		l[v1alpha1.ResourceNameLabel] = opts.parentObject.GetName()
 	}

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -188,7 +188,7 @@ func getLabelsForPipelineJob(pipeline v1alpha1.PipelineJobResources) map[string]
 
 func labelsForJobs(opts Opts) map[string]string {
 	l := map[string]string{
-		v1alpha1.WorkTypeLabel: opts.source,
+		v1alpha1.WorkflowTypeLabel: opts.source,
 	}
 	promiseName := opts.parentObject.GetName()
 	if opts.source == string(v1alpha1.WorkflowTypeResource) {

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -1923,10 +1923,10 @@ func nextTimestamp() metav1.Time {
 
 func userPermissionPipelineLabels(promise v1alpha1.Promise, pipeline v1alpha1.Pipeline) client.MatchingLabels {
 	return client.MatchingLabels(labels.Set{
-		"kratix.io/promise-name":  promise.GetName(),
-		"kratix.io/pipeline-name": pipeline.Name,
-		"kratix.io/work-type":     "promise",
-		"kratix.io/work-action":   "configure",
+		"kratix.io/promise-name":    promise.GetName(),
+		"kratix.io/pipeline-name":   pipeline.Name,
+		"kratix.io/workflow-type":   "promise",
+		"kratix.io/workflow-action": "configure",
 	})
 }
 


### PR DESCRIPTION
This PR refactors the workflow pipeline job labels as follows: 

```
kratix.io/pipeline-name
kratix.io/promise-name
kratix.io/workflow-action
kratix.io/workflow-type
```

Also, it adds the Kubernetes recommended `managed-by` label to the Jobs: 

```
app.kubernetes.io/managed-by=Kratix
```

Note: 
- This is not a breaking change because we are still supporting the legacy labels. 
