### PR TITLE
feat: handle failed resource delete pipelines

### DIFF
--- a/controllers/promise_controller.go
+++ b/controllers/promise_controller.go
@@ -527,6 +527,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		Enabled:                     &enabled,
 		CanCreateResources:          canCreateResources,
 		NumberOfJobsToKeep:          r.NumberOfJobsToKeep,
+		EventRecorder:               r.Manager.GetEventRecorderFor("ResourceRequestController"),
 	}
 	r.StartedDynamicControllers[string(promise.GetUID())] = dynamicResourceRequestController
 

--- a/controllers/promise_controller_test.go
+++ b/controllers/promise_controller_test.go
@@ -880,7 +880,7 @@ var _ = Describe("PromiseController", func() {
 					uPromise, err := promise.ToUnstructured()
 					Expect(err).NotTo(HaveOccurred())
 
-					resourceutil.MarkWorkflowAsRunning(logr.Logger{}, uPromise)
+					resourceutil.MarkConfigureWorkflowAsRunning(logr.Logger{}, uPromise)
 					Expect(fakeK8sClient.Status().Update(ctx, uPromise)).To(Succeed())
 
 					result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: promise.GetName(), Namespace: promise.GetNamespace()}})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -135,3 +135,17 @@ func setReconcileDeleteWorkflowToReturnFinished(obj client.Object) {
 		return false, nil
 	})
 }
+
+func setReconcileDeleteWorkflowToReturnError(obj client.Object) {
+	controllers.SetReconcileDeleteWorkflow(func(w workflow.Opts) (bool, error) {
+		us := &unstructured.Unstructured{}
+		us.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+		Expect(fakeK8sClient.Get(ctx, types.NamespacedName{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		}, us)).To(Succeed())
+
+		reconcileDeleteOptsArg = w
+		return false, workflow.ErrDeletePipelineFailed
+	})
+}

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -18,6 +18,8 @@ import (
 const (
 	ConfigureWorkflowCompletedCondition    = clusterv1.ConditionType("ConfigureWorkflowCompleted")
 	ConfigureWorkflowCompletedFailedReason = "ConfigureWorkflowFailed"
+	DeleteWorkflowCompletedCondition       = clusterv1.ConditionType("DeleteWorkflowCompleted")
+	DeleteWorkflowCompletedFailedReason    = "DeleteWorkflowFailed"
 	PipelinesExecutedSuccessfully          = "PipelinesExecutedSuccessfully"
 	ManualReconciliationLabel              = "kratix.io/manual-reconciliation"
 	ReconcileResourcesLabel                = "kratix.io/reconcile-resources"
@@ -36,7 +38,7 @@ func GetConfigureWorkflowCompletedConditionStatus(obj *unstructured.Unstructured
 	return condition.Status
 }
 
-func MarkWorkflowAsRunning(logger logr.Logger, obj *unstructured.Unstructured) {
+func MarkConfigureWorkflowAsRunning(logger logr.Logger, obj *unstructured.Unstructured) {
 	SetCondition(obj, &clusterv1.Condition{
 		Type:               ConfigureWorkflowCompletedCondition,
 		Status:             v1.ConditionFalse,
@@ -47,15 +49,27 @@ func MarkWorkflowAsRunning(logger logr.Logger, obj *unstructured.Unstructured) {
 	logger.Info("set conditions", "condition", ConfigureWorkflowCompletedCondition, "value", v1.ConditionFalse, "reason", "PipelinesInProgress")
 }
 
-func MarkWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstructured, failedPipeline string) {
+func MarkConfigureWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstructured, failedPipeline string) {
 	SetCondition(obj, &clusterv1.Condition{
 		Type:               ConfigureWorkflowCompletedCondition,
 		Status:             v1.ConditionFalse,
-		Message:            fmt.Sprintf("A Pipeline has failed: %s", failedPipeline),
+		Message:            fmt.Sprintf("A Configure Pipeline has failed: %s", failedPipeline),
 		Reason:             ConfigureWorkflowCompletedFailedReason,
 		LastTransitionTime: metav1.NewTime(time.Now()),
 	})
 	logger.Info("set conditions", "condition", ConfigureWorkflowCompletedCondition, "value", v1.ConditionFalse, "reason", ConfigureWorkflowCompletedFailedReason)
+}
+
+func MarkDeleteWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstructured) {
+	condition := clusterv1.Condition{
+		Type:               DeleteWorkflowCompletedCondition,
+		Status:             v1.ConditionFalse,
+		Message:            "The Delete Pipeline has failed",
+		Reason:             DeleteWorkflowCompletedFailedReason,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+	SetCondition(obj, &condition)
+	logger.Info("set conditions", "condition", condition.Type, "value", condition.Status, "reason", condition.Reason)
 }
 
 func SortJobsByCreationDateTime(jobs []batchv1.Job, desc bool) []batchv1.Job {


### PR DESCRIPTION
Fixes [#356](https://github.com/syntasso/kratix/issues/356)

Added a new condition: DeleteWorkflowCompletedCondition

When a resource delete pipeline fails, we now:
- update the DeleteWorkflowCompletedCondition to convey that the delete pipeline failed
- send an event to the resource to notify of the delete pipeline failure
- return an error in the reconciler