### PR TITLE
chore: better msg with pipeline unmarshall error

### DIFF
--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -169,16 +169,18 @@ func PipelinesFromUnstructured(pipelines []unstructured.Unstructured, logger log
 		if pipeline.GetKind() == "Pipeline" && pipeline.GetAPIVersion() == "platform.kratix.io/v1alpha1" {
 			jsonPipeline, err := pipeline.MarshalJSON()
 			if err != nil {
-				pipelineLogger.Error(err, "Failed marshalling pipeline to json")
-				return nil, err
+				fmtErr := fmt.Errorf("failed marshalling pipeline %s to json: %w", pipeline.GetName(), err)
+				pipelineLogger.Error(fmtErr, "error parsing pipelines")
+				return nil, fmtErr
 			}
 			decoder := json.NewDecoder(bytes.NewReader(jsonPipeline))
 			decoder.DisallowUnknownFields()
 
 			var p Pipeline
 			if err = decoder.Decode(&p); err != nil {
-				pipelineLogger.Error(err, "Failed unmarshalling pipeline")
-				return nil, err
+				fmtErr := fmt.Errorf("failed unmarshalling pipeline %s: %w", pipeline.GetName(), err)
+				pipelineLogger.Error(fmtErr, "error parsing pipelines")
+				return nil, fmtErr
 			}
 			ps = append(ps, p)
 		} else {

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -1457,7 +1457,7 @@ var _ = Describe("Pipeline", func() {
 				}
 
 				_, err := v1alpha1.PipelinesFromUnstructured(unstructuredPipelines, logr.Discard())
-				Expect(err).To(MatchError(ContainSubstring("json: unknown field \"rbac\"")))
+				Expect(err).To(MatchError(ContainSubstring("failed unmarshalling pipeline pipeline1: json: unknown field")))
 			})
 		})
 	})

--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -404,7 +404,7 @@ func NewPipelinesMap(promise *Promise, logger logr.Logger) (pipelineMap, error) 
 		for action, uPipeline := range actions {
 			pipelines, err := PipelinesFromUnstructured(uPipeline, logger)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed parsing %s.%s pipeline: %w", typ, action, err)
 			}
 			pipelinesMap[typ][action] = pipelines
 		}


### PR DESCRIPTION
## Context

Follow up of PR #363 

Better error message at failed to unmarshall pipelines:

```
❯ k apply -f test/core/assets/promise.yaml
Error from server (Forbidden): error when creating "test/core/assets/promise.yaml":
admission webhook "vpromise.kb.io" denied the request:
failed parsing promise.configure pipeline:
failed unmarshalling pipeline setup-deps: json: unknown field "rbac"
```

Instead of:
```
❯ k apply -f test/core/assets/promise.yaml
Error from server (Forbidden): error when creating "test/core/assets/promise.yaml": admission webhook "vpromise.kb.io" denied the request: json: unknown field "rbac"
```

