### PR TITLE
chore: enable to run CI tests locally

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
       - name: Install Kind
         uses: helm/kind-action@v1
         with:
@@ -54,6 +56,8 @@ jobs:
           path: charts
       - name: Install Go
         uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
       - name: Install Kind
         uses: helm/kind-action@v1
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,8 +42,10 @@ jobs:
           version: '2.4.0'
       - name: System Tests
         run: |
-          DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true PLATFORM_CLUSTER_NAME=system-test-platform WORKER1_CLUSTER_NAME=system-test-worker \ 
-            PLATFORM_CONTEXT=kind-system-test-platform WORKER_CONTEXT=kind-system-test-worker make system-test core-test
+          make system-test core-test
+        env:
+          DOCKER_BUILDKIT: 1
+          ACK_GINKGO_RC: true
   integration-test:
     runs-on: ubuntu-latest
     needs: [unit-tests-and-lint] 
@@ -67,7 +69,11 @@ jobs:
         uses: azure/setup-helm@v3
       - name: e2e-demo-test-helm-bucket
         run: |
-          STATE_STORE="bucket" ./scripts/helm-e2e-test.sh
+          ./scripts/helm-e2e-test.sh
+        env:
+          STATE_STORE: "bucket"
       - name: e2e-demo-test-helm-git
         run: |
-          STATE_STORE="git" ./scripts/helm-e2e-test.sh
+          ./scripts/helm-e2e-test.sh
+        env:
+          STATE_STORE: "git"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,7 +42,8 @@ jobs:
           version: '2.4.0'
       - name: System Tests
         run: |
-          DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true make system-test core-test
+          DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true PLATFORM_CLUSTER_NAME=system-test-platform WORKER1_CLUSTER_NAME=system-test-worker \ 
+            PLATFORM_CONTEXT=kind-system-test-platform WORKER_CONTEXT=kind-system-test-worker make system-test core-test
   integration-test:
     runs-on: ubuntu-latest
     needs: [unit-tests-and-lint] 
@@ -70,19 +71,3 @@ jobs:
       - name: e2e-demo-test-helm-git
         run: |
           STATE_STORE="git" ./scripts/helm-e2e-test.sh
-  on-failure:
-    runs-on: ubuntu-latest
-    needs:
-      - unit-tests-and-lint
-      - system-test
-      - integration-test
-    if: ${{ always() && (needs.*.result == 'failure' || needs.*.result == 'timed_out') }}
-    steps:
-      - name: Slack Notification
-        uses: slackapi/slack-github-action@v2
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "*GitHub Action failed!! Failed job: ${{ job.status  }} \n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-

--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout current repository
         uses: actions/checkout@v3
       - name: Trigger CI with latest commit details
+        if: ${{ !env.ACT }}
         run: |
           GITHUB_MESSAGE='${{ github.event.head_commit.message }}'
           if [ -z "$GITHUB_SHA" ]; then

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ lint-all: # Lint with full config
 
 ##@ act targets to run GH Action jobs locally
 
-ACT_JOB = act -j '$(1)' --rm -s GITHUB_TOKEN="$(gh auth token)"
+ACT_JOB = act -j '$(1)' --rm -s GITHUB_TOKEN="$(shell gh auth token)"
 act-test-and-lint:
 	$(call ACT_JOB,unit-tests-and-lint)
 
@@ -241,6 +241,8 @@ act-integration-test:
 
 act-system-test:
 	$(call ACT_JOB,system-test)
+
+act-run-all: act-system-test act-integration-test
 
 ##@ Deprecated: will be deleted soon
 

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,18 @@ lint: # Lint with required config
 lint-all: # Lint with full config
 	golangci-lint run --config=.golangci.yml
 
+##@ act targets to run GH Action jobs locally
+
+ACT_JOB = act -j '$(1)' --rm -s GITHUB_TOKEN="$(gh auth token)"
+act-test-and-lint:
+	$(call ACT_JOB,unit-tests-and-lint)
+
+act-integration-test:
+	$(call ACT_JOB,integration-test)
+
+act-system-test:
+	$(call ACT_JOB,system-test)
+
 ##@ Deprecated: will be deleted soon
 
 # build-and-reload-kratix is deprecated in favor of build-and-load-kratix

--- a/scripts/install-gitops
+++ b/scripts/install-gitops
@@ -10,6 +10,7 @@ CONTEXT=""
 WORKER_STATESTORE_TYPE=${WORKER_STATESTORE_TYPE:-BucketStateStore}
 KUSTOMIZATION_NAME=""
 GITOPS_PROVIDER=${GITOPS_PROVIDER:-"flux"}
+PLATFORM_CLUSTER_NAME="${PLATFORM_CLUSTER_NAME:-"platform"}"
 
 usage() {
     echo -e "Usage: ${BASH_SOURCE[0]} [--help] [--context=""] [--path=""] [--git]"
@@ -20,6 +21,7 @@ usage() {
     echo -e "\t--git, -g,\t Reads from local Gitea installation (default: Read from local MinIO installation)"
     echo -e "\t--kustomization-name, -k,\t Name of the Flux Kustomizations"
     echo -e "\t--gitops-provider, -p,\t Gitops provider, either flux or argo. Defaults to flux"
+    echo -e "\t--platform-cluster-name='', -t,\t The name of the Platform cluster"
     exit "${1:-0}"
 }
 
@@ -33,12 +35,13 @@ load_options() {
         '--kustomization-name')         set -- "$@" '-k'   ;;
         '--gitops-provider')            set -- "$@" '-p'   ;;
         '--git')                        set -- "$@" '-g'   ;;
+        '--platform-cluster-name')      set -- "$@" '-t'   ;;
         *)                              set -- "$@" "$arg" ;;
       esac
     done
 
     OPTIND=1
-    while getopts "hc:gb:k:p:" opt
+    while getopts "hc:gb:k:p:t:" opt
     do
       case "$opt" in
         'h') usage ;;
@@ -47,6 +50,7 @@ load_options() {
         'b') BUCKET_PATH=$OPTARG ;;
         'k') KUSTOMIZATION_NAME=$OPTARG ;;
         'p') GITOPS_PROVIDER=$OPTARG ;;
+        't') PLATFORM_CLUSTER_NAME="$OPTARG";;
         *) usage 1 ;;
       esac
     done
@@ -63,7 +67,7 @@ load_options() {
 patch_kind_networking() {
     local file_name=$1
     if [[ "${CONTEXT}" =~ ^kind-.* ]]; then
-        PLATFORM_DESTINATION_IP=$(docker inspect platform-control-plane | yq ".[0].NetworkSettings.Networks.kind.IPAddress")
+        PLATFORM_DESTINATION_IP=$(docker inspect ${PLATFORM_CLUSTER_NAME}-control-plane | yq ".[0].NetworkSettings.Networks.kind.IPAddress")
         sed "s/172.18.0.2/${PLATFORM_DESTINATION_IP}/g" ${file_name}
     else
         cat "${file_name}"
@@ -87,7 +91,7 @@ install_flux_gitops() {
     resource_file=${ROOT}/hack/destination/gitops-tk-resources.yaml
     if [ ${WORKER_STATESTORE_TYPE} = "GitStateStore" ]; then
         resource_file=${ROOT}/hack/destination/gitops-tk-resources-git.yaml;
-        copy_gitea_credentials kind-platform ${CONTEXT} flux-system
+        copy_gitea_credentials kind-${PLATFORM_CLUSTER_NAME} ${CONTEXT} flux-system
     fi
 
     # install flux crds
@@ -97,7 +101,7 @@ install_flux_gitops() {
 }
 
 patch_argo_secret() {
-    local argo_password=$(kubectl --context kind-platform get secret  gitea-credentials -n gitea -o yaml | yq .data.password | base64 -d)
+    local argo_password=$(kubectl --context kind-${PLATFORM_CLUSTER_NAME} get secret  gitea-credentials -n gitea -o yaml | yq .data.password | base64 -d)
     sed "s/PASSWORD/${argo_password}/g"
 }
 

--- a/scripts/register-destination
+++ b/scripts/register-destination
@@ -9,12 +9,13 @@ LABELS=""
 NAME=""
 DESTINATION_CONTEXT=""
 PLATFORM_CONTEXT="kind-platform"
+PLATFORM_CLUSTER_NAME=""
 STATE_STORE="default"
 STRICT_MATCH_LABELS=false
 GITOPS_PATH=""
 
 usage() {
-    echo -e "Usage: register-destination [--help] [--git] [--with-label foo=bar] [--context k8s-context] [--name  some-name ] [--platform-context 'kind-platform'] [--path platform-cluster] [--strict-match-labels]"
+    echo -e "Usage: register-destination [--help] [--git] [--with-label foo=bar] [--context k8s-context] [--name some-name] [--platform-context 'kind-platform'] [--path platform-cluster] [--strict-match-labels]"
     echo -e "\t--context='', -c,\t The Kubernetes context where to install FluxCD onto"
     echo -e "\t--git, -g\t Use Gitea as local repository in place of default local MinIO"
     echo -e "\t--help, -h\t Prints this message"
@@ -74,6 +75,13 @@ load_options() {
     if [ -z "$GITOPS_PATH" ]; then
       GITOPS_PATH="$NAME"
     fi
+
+    if [[ "$PLATFORM_CONTEXT" =~ ^kind-(.*)$ ]]; then
+      PLATFORM_CLUSTER_NAME="${BASH_REMATCH[1]}"
+    else
+      echo "Error: Platform context must start with 'kind-'"
+      usage 1
+    fi
 }
 
 prepare_destination() {
@@ -84,7 +92,7 @@ prepare_destination() {
     flags="--git"
     state_store_type="GitStateStore"
   fi
-  $ROOT/scripts/install-gitops --context $DESTINATION_CONTEXT --path "$GITOPS_PATH" "$flags"
+  $ROOT/scripts/install-gitops --context $DESTINATION_CONTEXT --path "$GITOPS_PATH" --platform-cluster-name ${PLATFORM_CLUSTER_NAME} "$flags"
 
   local yqOpts=".metadata.name = \"$NAME\" | .metadata.labels = {} | .spec.stateStoreRef.name = \"$STATE_STORE\" | .spec.stateStoreRef.kind = \"$state_store_type\" | .spec.strictMatchLabels = $STRICT_MATCH_LABELS"
   yq "${yqOpts}" $ROOT/config/samples/platform_v1alpha1_worker.yaml |

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -30,7 +30,8 @@ error() {
 }
 
 platform_destination_ip() {
-    docker inspect platform-control-plane | yq ".[0].NetworkSettings.Networks.kind.IPAddress"
+    local platform_cluster_name="${1:-platform}"
+    docker inspect ${platform_cluster_name}-control-plane | yq ".[0].NetworkSettings.Networks.kind.IPAddress"
 }
 
 generate_gitea_credentials() {
@@ -44,7 +45,8 @@ generate_gitea_credentials() {
         exit 1
     fi
     local context="${1:-kind-platform}"
-    $giteabin cert --host "$(platform_destination_ip)" --ca
+    platform_cluster_name=${context#*-}
+    $giteabin cert --host "$(platform_destination_ip ${platform_cluster_name})" --ca
 
     kubectl create namespace gitea --context ${context} || true
 

--- a/test/core/core_suite_test.go
+++ b/test/core/core_suite_test.go
@@ -1,13 +1,53 @@
 package core_test
 
 import (
+	"os"
 	"testing"
+	"time"
+
+	"github.com/syntasso/kratix/test/kubeutils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+var (
+	worker   *kubeutils.Cluster
+	platform *kubeutils.Cluster
+)
+
 func TestCore(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Core Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() {
+	//this runs once for the whole suite
+	platform = &kubeutils.Cluster{
+		Context: getEnvOrDefault("PLATFORM_CONTEXT", "kind-platform"),
+		Name:    getEnvOrDefault("PLATFORM_NAME", "platform-cluster")}
+	worker = &kubeutils.Cluster{
+		Context: getEnvOrDefault("WORKER_CONTEXT", "kind-worker"),
+		Name:    getEnvOrDefault("WORKER_NAME", "worker-1")}
+
+	kubeutils.SetTimeoutAndInterval(30*time.Second, 2*time.Second)
+}, func() {
+	//this runs before each test
+
+	//These variables get set in func above, but only for 1 of the nodes, so we set
+	//them again here to ensure all nodes have them
+	platform = &kubeutils.Cluster{
+		Context: getEnvOrDefault("PLATFORM_CONTEXT", "kind-platform"),
+		Name:    getEnvOrDefault("PLATFORM_NAME", "platform-cluster")}
+	worker = &kubeutils.Cluster{
+		Context: getEnvOrDefault("WORKER_CONTEXT", "kind-worker"),
+		Name:    getEnvOrDefault("WORKER_NAME", "worker-1")}
+})
+
+func getEnvOrDefault(envVar, defaultValue string) string {
+	value := os.Getenv(envVar)
+	if value == "" {
+		return defaultValue
+	}
+	return value
 }

--- a/test/core/core_test.go
+++ b/test/core/core_test.go
@@ -18,16 +18,11 @@ const (
 )
 
 var _ = Describe("Core Tests", Ordered, func() {
-	var platform *kubeutils.Cluster
-	var worker *kubeutils.Cluster
-
 	BeforeAll(func() {
 		SetDefaultEventuallyTimeout(timeout)
 		SetDefaultEventuallyPollingInterval(interval)
 		kubeutils.SetTimeoutAndInterval(timeout, interval)
 
-		platform = &kubeutils.Cluster{Context: "kind-platform", Name: "platform-cluster"}
-		worker = &kubeutils.Cluster{Context: "kind-worker", Name: workerOne}
 		platform.Kubectl("apply", "-f", "assets/destination.yaml")
 		platform.Kubectl("label", "destination", workerOne, "target="+workerOne)
 		platform.Kubectl("label", "destination", workerTwo, "target="+workerTwo)


### PR DESCRIPTION
Closes [#318](https://github.com/syntasso/kratix/issues/318)

We will use `act` to run CI workflows on local dev environments. The following make targets are introduced to run the workflows:

```
make act-test-and-lint
make act-integration-test
make act-system-test
```

If you want to run all in once, run the following command. Please note that this will run the jobs sequentially, not in parallel: 

```
make act-run-all
```

Note: After running the make targets, the platform and worker clusters will keep running on your docker environment.
