### PR TITLE
feat: to handle delete workflows via a label

### DIFF
--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -130,17 +130,17 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		logger: logger,
 	}
 
-    // Check if delete trigger label is present
-    triggerDelete := false
-    labels := rr.GetLabels()
-    if val, ok := labels[resourceutil.TriggerDeleteLabel]; ok && val == "true" {
-        triggerDelete = true
-        logger.Info("Trigger delete workflows label detected", "resource", rr.GetName())
-    }
+	// Check if delete trigger label is present
+	triggerDelete := false
+	labels := rr.GetLabels()
+	if val, ok := labels[resourceutil.TriggerDeleteLabel]; ok && val == "true" {
+		triggerDelete = true
+		logger.Info("Trigger delete workflows label detected", "resource", rr.GetName())
+	}
 
-    if !rr.GetDeletionTimestamp().IsZero() || triggerDelete {
+	if !rr.GetDeletionTimestamp().IsZero() || triggerDelete {
 		return r.deleteResources(opts, promise, rr, resourceRequestIdentifier)
-	}    
+	}
 
 	if !*r.CanCreateResources {
 		if !resourceutil.IsPromiseMarkedAsUnavailable(rr) {

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -130,9 +130,17 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		logger: logger,
 	}
 
-	if !rr.GetDeletionTimestamp().IsZero() {
+    // Check if delete trigger label is present
+    triggerDelete := false
+    labels := rr.GetLabels()
+    if val, ok := labels[resourceutil.TriggerDeleteLabel]; ok && val == "true" {
+        triggerDelete = true
+        logger.Info("Trigger delete workflows label detected", "resource", rr.GetName())
+    }
+
+    if !rr.GetDeletionTimestamp().IsZero() || triggerDelete {
 		return r.deleteResources(opts, promise, rr, resourceRequestIdentifier)
-	}
+	}    
 
 	if !*r.CanCreateResources {
 		if !resourceutil.IsPromiseMarkedAsUnavailable(rr) {

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -23,7 +23,7 @@ const (
 	PipelinesExecutedSuccessfully          = "PipelinesExecutedSuccessfully"
 	ManualReconciliationLabel              = "kratix.io/manual-reconciliation"
 	ReconcileResourcesLabel                = "kratix.io/reconcile-resources"
-    TriggerDeleteLabel                     = "kratix.io/trigger-delete-workflows"
+	TriggerDeleteLabel                     = "kratix.io/trigger-delete-workflows"
 	promiseAvailableCondition              = clusterv1.ConditionType("PromiseAvailable")
 	promiseRequirementsNotMetReason        = "PromiseRequirementsNotInstalled"
 	promiseRequirementsNotMetMessage       = "Promise Requirements are not installed"

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -23,6 +23,7 @@ const (
 	PipelinesExecutedSuccessfully          = "PipelinesExecutedSuccessfully"
 	ManualReconciliationLabel              = "kratix.io/manual-reconciliation"
 	ReconcileResourcesLabel                = "kratix.io/reconcile-resources"
+    TriggerDeleteLabel                     = "kratix.io/trigger-delete-workflows"
 	promiseAvailableCondition              = clusterv1.ConditionType("PromiseAvailable")
 	promiseRequirementsNotMetReason        = "PromiseRequirementsNotInstalled"
 	promiseRequirementsNotMetMessage       = "Promise Requirements are not installed"


### PR DESCRIPTION
Currently, when a request is deleted via Flux, the resource request disappears while delete pipelines are running. In case of a deletion failure, the job/pods/work/workplacements become orphaned and require manual cleanup by removing finalizers. I am proposing a label feature similar to the manual reconciliation label for delete workflows.

Adding the label "kratix.io/trigger-delete-workflows=true" to trigger the corresponding resource delete workflows.
```
kubectl label {promisename} {requestname} kratix.io/trigger-delete-workflows=true
```