### PR TITLE
fix: correct destination path migration

### DIFF
--- a/internal/controller/destination_controller.go
+++ b/internal/controller/destination_controller.go
@@ -84,7 +84,7 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// this destination was created prior to `spec.path` being required and
 		// the destination name being used as part of the path.
 		metav1.SetMetaDataAnnotation(&destination.ObjectMeta, v1alpha1.SkipPathDefaultingAnnotation, "true")
-		destination.Spec.Path = path.Join(destination.Name, destination.Spec.Path)
+		destination.Spec.Path = path.Join(destination.Spec.Path, destination.Name)
 		return ctrl.Result{}, r.Client.Update(ctx, destination)
 	}
 

--- a/internal/controller/destination_controller_test.go
+++ b/internal/controller/destination_controller_test.go
@@ -105,7 +105,7 @@ var _ = Describe("DestinationReconciler", func() {
 		})
 
 		It("should patch the path with the destination name", func() {
-			Expect(updatedDestination.Spec.Path).To(Equal(updatedDestination.Name + "/foo/bar"))
+			Expect(updatedDestination.Spec.Path).To(Equal("foo/bar/" + updatedDestination.Name))
 		})
 
 		It("should add the skip annotation", func() {


### PR DESCRIPTION
## Context

It should be `destination.spec.path/destination.name`, not `destination.name/destination.spec.path`

Related to PR #352 