### PR TITLE
fix: missed 2 envvars from gitea helm chart values

### DIFF
--- a/hack/platform/gitea-server-values.yaml
+++ b/hack/platform/gitea-server-values.yaml
@@ -47,6 +47,16 @@ deployment:
   env:
     - name: GITEA__repository__ENABLE_PUSH_CREATE_USER
       value: "true"
+    - name: KEY_CONTENTS
+      valueFrom:
+        secretKeyRef:
+          key: privateKey
+          name: gitea-credentials
+    - name: CERT_CONTENTS
+      valueFrom:
+        secretKeyRef:
+          key: caFile
+          name: gitea-credentials
 extraVolumes:
   - name: cert
     secret:


### PR DESCRIPTION
This is a small update which is being tested with both the quick start and the workshop prep for KubeCon London.