### PR TITLE
chore: bump go to 1.23 in go.mod

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
           check-latest: true
       - name: Unit Tests
         run: |
@@ -31,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
       - name: Install Kind
         uses: helm/kind-action@v1
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
       - name: Install Kind
         uses: helm/kind-action@v1
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/syntasso/kratix
 
-go 1.22.5
+go 1.23
+
+toolchain go1.23.6
 
 require (
 	github.com/go-git/go-git/v5 v5.13.1


### PR DESCRIPTION
## Context

We are already building with 1.23 in Dockerfiles, so updating go.mod and version in github action.