### PR TITLE
feat: introduce promise available status condition

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -36,10 +36,13 @@ import (
 )
 
 const (
-	PromiseStatusAvailable   = "Available"
-	PromiseStatusUnavailable = "Unavailable"
-	PromisePlural            = "promises"
-	KratixResourceHashLabel  = "kratix.io/hash"
+	PromiseStatusAvailable               = "Available"
+	PromiseStatusUnavailable             = "Unavailable"
+	PromisePlural                        = "promises"
+	KratixResourceHashLabel              = "kratix.io/hash"
+	PromiseAvailableConditionType        = "Available"
+	PromiseAvailableConditionTrueReason  = "PromiseAvailable"
+	PromiseAvailableConditionFalseReason = "PromiseUnavailable"
 )
 
 // PromiseSpec defines the desired state of Promise


### PR DESCRIPTION
## Context

closes #321 

Set exactly the same way as the promise available status this makes it easier to set up automation such as kubectl wait on promise availability.

When it's unavailable:
```
status:
  apiVersion: marketplace.kratix.io/v1alpha1
  conditions:
  - lastTransitionTime: "2025-02-26T16:47:31Z"
    message: Cannot fulfil resource requests
    reason: PromiseUnavailable
    status: "False"
    type: Available
...
  kind: redis
  status: Unavailable
 ```

When promise is available:
```
status:
  apiVersion: marketplace.kratix.io/v1alpha1
  conditions:
  - lastTransitionTime: "2025-02-26T16:56:22Z"
    message: Ready to accept resource requests
    reason: PromiseAvailable
    status: "True"
    type: Available
...
  kind: redis
  lastAvailableTime: "2025-02-26T16:56:22Z"
  status: Available
```
