### PR TITLE
fix: Prevent mulitple dynamic controllers from starting for a Promise

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -244,6 +244,17 @@ func (p *Promise) GetPipelineResourceName() string {
 func (p *Promise) GetPipelineResourceNamespace() string {
 	return "default"
 }
+func (p *Promise) GetDynamicControllerName() string {
+	name := p.GetName()
+	// We only start a dynamic controller if the promise contains an API
+	// so this **should** always be safe
+	if _, crd, err := p.GetAPI(); err == nil {
+		//using _ as a separator because its not a valid character in a k8s name
+		//therefore it should never cause a conflict with a CRD name or a promise name
+		name += "_" + crd.GetName()
+	}
+	return name
+}
 
 func (p *Promise) ToUnstructured() (*unstructured.Unstructured, error) {
 	objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(p)

--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -244,16 +244,16 @@ func (p *Promise) GetPipelineResourceName() string {
 func (p *Promise) GetPipelineResourceNamespace() string {
 	return "default"
 }
-func (p *Promise) GetDynamicControllerName() string {
-	name := p.GetName()
+func (p *Promise) GetDynamicControllerName(logger logr.Logger) string {
 	// We only start a dynamic controller if the promise contains an API
 	// so this **should** always be safe
-	if _, crd, err := p.GetAPI(); err == nil {
-		//using _ as a separator because its not a valid character in a k8s name
-		//therefore it should never cause a conflict with a CRD name or a promise name
-		name += "_" + crd.GetName()
+	_, crd, err := p.GetAPI()
+	if err != nil {
+		logger.Error(err, "Error generating dynamic controller name, failed to read API name")
+		//if somehow we can't get the API name, we'll just use the promise name.
+		return p.GetName()
 	}
-	return name
+	return p.GetName() + "_" + crd.GetName()
 }
 
 func (p *Promise) ToUnstructured() (*unstructured.Unstructured, error) {

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -534,7 +534,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 	if r.dynamicControllerHasAlreadyStarted(promise) {
 		logger.Info("dynamic controller already started, ensuring it is up to date")
 
-		dynamicController := r.StartedDynamicControllers[string(promise.GetUID())]
+		dynamicController := r.StartedDynamicControllers[promise.GetDynamicControllerName()]
 		dynamicController.GVK = rrGVK
 		dynamicController.CRD = rrCRD
 
@@ -563,7 +563,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		NumberOfJobsToKeep:          r.NumberOfJobsToKeep,
 		EventRecorder:               r.Manager.GetEventRecorderFor("ResourceRequestController"),
 	}
-	r.StartedDynamicControllers[string(promise.GetUID())] = dynamicResourceRequestController
+	r.StartedDynamicControllers[promise.GetDynamicControllerName()] = dynamicResourceRequestController
 
 	unstructuredCRD := &unstructured.Unstructured{}
 	unstructuredCRD.SetGroupVersionKind(*rrGVK)
@@ -575,7 +575,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 }
 
 func (r *PromiseReconciler) dynamicControllerHasAlreadyStarted(promise *v1alpha1.Promise) bool {
-	_, ok := r.StartedDynamicControllers[string(promise.GetUID())]
+	_, ok := r.StartedDynamicControllers[promise.GetDynamicControllerName()]
 	return ok
 }
 
@@ -763,7 +763,7 @@ func (r *PromiseReconciler) deletePromise(o opts, promise *v1alpha1.Promise) (ct
 
 	//temporary fix until https://github.com/kubernetes-sigs/controller-runtime/issues/1884 is resolved
 	//once resolved, delete dynamic controller rather than disable
-	if d, exists := r.StartedDynamicControllers[string(promise.GetUID())]; exists {
+	if d, exists := r.StartedDynamicControllers[promise.GetDynamicControllerName()]; exists {
 		r.RestartManager()
 		enabled := false
 		d.Enabled = &enabled

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -211,7 +211,7 @@ var _ = Describe("PromiseController", func() {
 
 					By("starting the dynamic controller", func() {
 						Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-						Expect(*reconciler.StartedDynamicControllers["1234abcd"].CanCreateResources).To(BeTrue())
+						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeTrue())
 					})
 				})
 			})
@@ -268,7 +268,7 @@ var _ = Describe("PromiseController", func() {
 
 					It("prevents RRs being reconciled", func() {
 						Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-						Expect(*reconciler.StartedDynamicControllers["1234abcd"].CanCreateResources).To(BeFalse())
+						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeFalse())
 					})
 				})
 
@@ -427,7 +427,7 @@ var _ = Describe("PromiseController", func() {
 
 							By("starting the dynamic controller", func() {
 								Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-								Expect(*reconciler.StartedDynamicControllers["1234abcd"].CanCreateResources).To(BeTrue())
+								Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeTrue())
 							})
 						})
 					})
@@ -501,7 +501,7 @@ var _ = Describe("PromiseController", func() {
 
 					It("prevents RRs being reconciled", func() {
 						Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-						Expect(*reconciler.StartedDynamicControllers["1234abcd"].CanCreateResources).To(BeFalse())
+						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeFalse())
 					})
 
 					It("fires an event to indicate the promise is no longer available", func() {

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -211,7 +211,7 @@ var _ = Describe("PromiseController", func() {
 
 					By("starting the dynamic controller", func() {
 						Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeTrue())
+						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName(logr.Logger{})].CanCreateResources).To(BeTrue())
 					})
 				})
 			})
@@ -268,7 +268,7 @@ var _ = Describe("PromiseController", func() {
 
 					It("prevents RRs being reconciled", func() {
 						Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeFalse())
+						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName(logr.Logger{})].CanCreateResources).To(BeFalse())
 					})
 				})
 
@@ -427,7 +427,7 @@ var _ = Describe("PromiseController", func() {
 
 							By("starting the dynamic controller", func() {
 								Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-								Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeTrue())
+								Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName(logr.Logger{})].CanCreateResources).To(BeTrue())
 							})
 						})
 					})
@@ -501,7 +501,7 @@ var _ = Describe("PromiseController", func() {
 
 					It("prevents RRs being reconciled", func() {
 						Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
-						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName()].CanCreateResources).To(BeFalse())
+						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName(logr.Logger{})].CanCreateResources).To(BeFalse())
 					})
 
 					It("fires an event to indicate the promise is no longer available", func() {


### PR DESCRIPTION
I've observed a few times in which a user has issues deleting a Promise, they decide to just force remove all finalizers in order to let the Promise be deleted, and then recreate the Promise. 

This results in both the old and new dynamic controller running because the UID has changed. To get around this issue we should track the dynamic controller by promise name instead.

I've gone for `promisename_crdname` because the above scenario might still happen, but if someone changes the CRD gvk (therefore name) between that, we still need to start a *new controller* that watches the new CRD gvk.

We should probably also have some extra cleanup steps to detect this "ghost" controllers, but that felt like an extra piece of work outside of this bug fix. I've created an [issue](https://github.com/syntasso/kratix/issues/394) for this