### PR TITLE
feat: align manual delete workflows with configure behaviour

### DIFF
--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -22,7 +22,6 @@ const (
 	DeleteWorkflowCompletedFailedReason    = "DeleteWorkflowFailed"
 	PipelinesExecutedSuccessfully          = "PipelinesExecutedSuccessfully"
 	ManualReconciliationLabel              = "kratix.io/manual-reconciliation"
-	ManualRerunDeleteLabel                 = "kratix.io/manual-rerun-delete"
 	ReconcileResourcesLabel                = "kratix.io/reconcile-resources"
 	promiseAvailableCondition              = clusterv1.ConditionType("PromiseAvailable")
 	promiseRequirementsNotMetReason        = "PromiseRequirementsNotInstalled"


### PR DESCRIPTION
closes #383.

* The previous manual-rerun-delete label is removed and now using manual-reconciliation label instead
* Labeling a resource with manual-reconciliation now will suspend the running delete workflow job and re-create it