### PR TITLE
feat: set default imagePullPolicy with kratix config

### DIFF
--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -188,6 +188,7 @@ func (p *PipelineFactory) readerContainer() corev1.Container {
 			{MountPath: "/kratix/output", Name: "shared-output"},
 		},
 		SecurityContext: kratixSecurityContext,
+		ImagePullPolicy: DefaultImagePullPolicy,
 	}
 }
 
@@ -218,6 +219,7 @@ func (p *PipelineFactory) workCreatorContainer() corev1.Container {
 			{MountPath: "/work-creator-files/kratix-system", Name: "promise-scheduling"}, // this volumemount is a configmap
 		},
 		SecurityContext: kratixSecurityContext,
+		ImagePullPolicy: DefaultImagePullPolicy,
 	}
 }
 
@@ -236,6 +238,10 @@ func (p *PipelineFactory) pipelineContainers() ([]corev1.Container, []corev1.Vol
 
 		if c.SecurityContext == nil {
 			c.SecurityContext = DefaultUserProvidedContainersSecurityContext
+		}
+
+		if c.ImagePullPolicy == "" {
+			c.ImagePullPolicy = DefaultImagePullPolicy
 		}
 
 		containers = append(containers, corev1.Container{
@@ -338,6 +344,7 @@ func (p *PipelineFactory) statusWriterContainer(obj *unstructured.Unstructured, 
 			Name:      "shared-metadata",
 		}},
 		SecurityContext: kratixSecurityContext,
+		ImagePullPolicy: DefaultImagePullPolicy,
 	}
 }
 

--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -68,6 +68,7 @@ var (
 	}
 
 	DefaultUserProvidedContainersSecurityContext *corev1.SecurityContext
+	DefaultImagePullPolicy                       corev1.PullPolicy
 )
 
 // PipelineSpec defines the desired state of Pipeline

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,9 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/syntasso/kratix/internal/controller"
-
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -72,6 +69,7 @@ type KratixConfig struct {
 
 type Workflows struct {
 	DefaultContainerSecurityContext corev1.SecurityContext `json:"defaultContainerSecurityContext"`
+	DefaultImagePullPolicy          corev1.PullPolicy      `json:"defaultImagePullPolicy,omitempty"`
 }
 
 var metricsAddr string
@@ -115,6 +113,7 @@ func main() {
 
 	if kratixConfig != nil {
 		v1alpha1.DefaultUserProvidedContainersSecurityContext = &kratixConfig.Workflows.DefaultContainerSecurityContext
+		v1alpha1.DefaultImagePullPolicy = kratixConfig.Workflows.DefaultImagePullPolicy
 	}
 
 	for {


### PR DESCRIPTION
## Context

closes #402. As the commit, tested in unit tests not in system tests.

related docs PR: https://github.com/syntasso/kratix-docs/pull/201

To test:
1. create a kratix configmap with default image pull policy set:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kratix
  namespace: kratix-platform-system
data:
  config: |
    # Number of old successful pipeline pods to keep. Default is 5
    numberOfJobsToKeep: 1
    workflows:
      defaultImagePullPolicy: Never
```

2. restart kratix platform to read in the latest configmap values
3. create a promise or a request and see:

```
❯ k get jobs kratix-redis-example-instance-configure-83699 -oyaml | grep imagePullPolicy
        imagePullPolicy: Never
        imagePullPolicy: Never
        imagePullPolicy: Never
        imagePullPolicy: Never
```