### PR TITLE
feat: validation on promise api scope

### DIFF
--- a/internal/webhook/v1alpha1/promise_webhook.go
+++ b/internal/webhook/v1alpha1/promise_webhook.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/syntasso/kratix/api/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -214,6 +215,10 @@ func validateCRD(p *v1alpha1.Promise) error {
 			return nil
 		}
 		return fmt.Errorf("invalid CRD: %w", err)
+	}
+
+	if newCrd.Spec.Scope != apiextensionsv1.NamespaceScoped {
+		return fmt.Errorf("promise api needs to be namespace scoped; spec.api.spec.scope cannot be: %s", newCrd.Spec.Scope)
 	}
 	return nil
 }


### PR DESCRIPTION
## Context

kratix does not support promise API that's cluster scoped. When creating a promise with cluster scope crd, kratix accepts the promise, but fails to reconcile its resource requests:
```
	{"uid": "4a56b", "promiseID": "redis", "namespace": {"name":"example"}, "resourceRequest": "redis-example", "isManualReconciliation": false, "type": "*v1.Job", "gvk": "/, Kind=", "name": "kratix-redis-example-instance-configure-fb3b1", "namespace": "", "labels": {"app.kubernetes.io/managed-by":"Kratix","kratix.io/hash":"7e3e1952970a4f67f57d2d0ca6c5681c","kratix.io/pipeline-name":"instance-configure","kratix.io/promise-name":"redis","kratix.io/resource-name":"example","kratix.io/workflow-action":"configure","kratix.io/workflow-type":"resource"}, "error": "an empty namespace may not be set during creation"}
github.com/syntasso/kratix/lib/workflow.applyResources
	/workspace/lib/workflow/reconciler.go:530
github.com/syntasso/kratix/lib/workflow.createConfigurePipeline
	/workspace/lib/workflow/reconciler.go:411
github.com/syntasso/kratix/lib/workflow.ReconcileConfigure
	/workspace/lib/workflow/reconciler.go:216
github.com/syntasso/kratix/internal/controller.(*DynamicResourceRequestController).Reconcile
	/workspace/internal/controller/dynamic_resource_request_controller.go:165
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/internal/controller/controller.go:116
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
```

This PR adds validation to the promise webhook. When kratix receives a promise with cluster scoped API, it now rejects the promise definition, giving people a faster and clearer feedback:
```
apiVersion: platform.kratix.io/v1alpha1
kind: Promise
metadata:
  name: redis
spec:
  api:
    apiVersion: apiextensions.k8s.io/v1
    kind: CustomResourceDefinition
    metadata:
      name: redis.marketplace.kratix.io
    spec:
      group: marketplace.kratix.io
      names:
        kind: redis
        plural: redis
        singular: redis
      scope: Cluster
...
❯ k apply -f ~/workspace/kratix-marketplace/redis/promise.yaml
Error from server (Forbidden): error when creating "/Users/chunyilyu/workspace/kratix-marketplace/redis/promise.yaml": admission webhook "vpromise.kb.io" denied the request: promise api needs to be namespace scoped; spec.api.spec.scope cannot be: Cluster
```