### PR TITLE
feat: make destination.spec.path a required field

### DIFF
--- a/api/v1alpha1/destination_types.go
+++ b/api/v1alpha1/destination_types.go
@@ -36,11 +36,6 @@ type StateStoreCoreFields struct {
 // (i.e. kratix-platform-system) or if we want to allow users to specify a
 // namespace for each destination secret.
 
-// SkipPathDefaultingAnnotation defines whether the Destination controller
-// should prefix the `spec.path` with the Destination name. This should be
-// removed in later versions of Kratix.
-const SkipPathDefaultingAnnotation = "kratix.io/skip-path-defaulting"
-
 // DestinationSpec defines the desired state of Destination.
 type DestinationSpec struct {
 	// Path within StateStore to write documents, this will be appended to any
@@ -50,7 +45,7 @@ type DestinationSpec struct {
 	// Kratix may create other subdirectories, depending on the Filepath.mode you select.
 	// To write to the root of the StateStore.Spec.Path, set Path to "." or "/".
 	// Defaults to the Destination name
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	Path string `json:"path,omitempty"`
 
 	StateStoreRef *StateStoreReference `json:"stateStoreRef,omitempty"`

--- a/config/crd/bases/platform.kratix.io_destinations.yaml
+++ b/config/crd/bases/platform.kratix.io_destinations.yaml
@@ -123,6 +123,8 @@ spec:
                   destinationSelectors. An empty label set on the work won't be scheduled
                   to this destination, unless the destination label set is also empty
                 type: boolean
+            required:
+            - path
             type: object
           status:
             description: DestinationStatus defines the observed state of Destination

--- a/config/samples/platform_v1alpha1_worker.yaml
+++ b/config/samples/platform_v1alpha1_worker.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     environment: dev
 spec:
+  path: worker-1
   stateStoreRef:
     name: default
     kind: BucketStateStore

--- a/config/samples/platform_v1alpha1_worker_2.yaml
+++ b/config/samples/platform_v1alpha1_worker_2.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     environment: production
 spec:
+  path: worker-2
   stateStoreRef:
     name: default
     kind: BucketStateStore

--- a/internal/controller/destination_controller.go
+++ b/internal/controller/destination_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"path"
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -83,14 +82,6 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
-	}
-
-	if !metav1.HasAnnotation(destination.ObjectMeta, v1alpha1.SkipPathDefaultingAnnotation) {
-		// this destination was created prior to `spec.path` being required and
-		// the destination name being used as part of the path.
-		metav1.SetMetaDataAnnotation(&destination.ObjectMeta, v1alpha1.SkipPathDefaultingAnnotation, "true")
-		destination.Spec.Path = path.Join(destination.Spec.Path, destination.Name)
-		return ctrl.Result{}, r.Client.Update(ctx, destination)
 	}
 
 	opts := opts{

--- a/internal/controller/destination_controller_test.go
+++ b/internal/controller/destination_controller_test.go
@@ -95,30 +95,6 @@ var _ = Describe("DestinationReconciler", func() {
 		})
 	})
 
-	When("the destination does not have the migration annotation", func() {
-		BeforeEach(func() {
-			testDestination.Spec.Path = "foo/bar"
-			Expect(fakeK8sClient.Create(ctx, testDestination)).To(Succeed())
-
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: testDestinationName})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
-
-			Expect(fakeK8sClient.Get(ctx, testDestinationName, updatedDestination)).To(Succeed())
-		})
-
-		It("should patch the path with the destination name", func() {
-			Expect(updatedDestination.Spec.Path).To(Equal("foo/bar/" + updatedDestination.Name))
-		})
-
-		It("should add the skip annotation", func() {
-			Expect(updatedDestination.Annotations).To(
-				HaveKeyWithValue(v1alpha1.SkipPathDefaultingAnnotation, "true"),
-			)
-		})
-
-	})
-
 	Describe("destinations backed by", func() {
 		for stateStoreKind, setup := range stateStoreSetups {
 			Context(fmt.Sprintf("a %s", stateStoreKind), func() {

--- a/internal/webhook/v1alpha1/destination_webhook.go
+++ b/internal/webhook/v1alpha1/destination_webhook.go
@@ -65,20 +65,6 @@ func (d *DestinationCustomDefaulter) Default(ctx context.Context, obj runtime.Ob
 		if !errors.IsNotFound(err) {
 			return err
 		}
-
-		// add the annotation so the controller doesn't try to append the
-		// destination name to the path on the next reconcile
-		desiredDestination.Annotations[v1alpha1.SkipPathDefaultingAnnotation] = "true"
-	}
-
-	// Defaults the destination path to the destination name if not set
-	if desiredDestination.Spec.Path == "" {
-		desiredDestination.Spec.Path = desiredDestination.Name
-	}
-
-	// this is here to prevent the annotation from being removed on already patched destinations
-	if _, found := currentDestination.Annotations[v1alpha1.SkipPathDefaultingAnnotation]; found {
-		desiredDestination.Annotations[v1alpha1.SkipPathDefaultingAnnotation] = "true"
 	}
 
 	if desiredDestination.Spec.Filepath.Mode == v1alpha1.FilepathModeAggregatedYAML &&

--- a/internal/webhook/v1alpha1/destination_webhook_test.go
+++ b/internal/webhook/v1alpha1/destination_webhook_test.go
@@ -57,55 +57,6 @@ var _ = Describe("Destination Webhook", func() {
 		}
 	})
 
-	Describe("defaulting `path`", func() {
-		Describe("for new destinations", func() {
-			It("adds the skip annotation", func() {
-				err := defaulter.Default(ctx, destination)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(destination.Annotations[v1alpha1.SkipPathDefaultingAnnotation]).To(Equal("true"))
-			})
-
-			When("the path is empty", func() {
-				It("uses the destination name as the default path", func() {
-					destination.Spec.Path = ""
-					err := defaulter.Default(ctx, destination)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(destination.Spec.Path).To(Equal(destination.Name))
-				})
-			})
-		})
-
-		Describe("for existing destinations with the skip annotation", func() {
-			BeforeEach(func() {
-				destination.SetAnnotations(
-					map[string]string{v1alpha1.SkipPathDefaultingAnnotation: "true"},
-				)
-				Expect(fakeClient.Create(ctx, destination)).To(Succeed())
-			})
-
-			When("the incoming path is empty", func() {
-				It("uses the destination name as the default path", func() {
-					destination.Spec.Path = ""
-					err := defaulter.Default(ctx, destination)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(destination.Spec.Path).To(Equal(destination.Name))
-				})
-			})
-
-			When("the annotation is removed", func() {
-				BeforeEach(func() {
-					destination.SetAnnotations(nil)
-				})
-
-				It("restores the annotation", func() {
-					err := defaulter.Default(ctx, destination)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(destination.Annotations[v1alpha1.SkipPathDefaultingAnnotation]).To(Equal("true"))
-				})
-			})
-		})
-	})
-
 	Describe("validating path uniqueness", func() {
 		var (
 			existingDestination *v1alpha1.Destination

--- a/scripts/register-destination
+++ b/scripts/register-destination
@@ -94,7 +94,7 @@ prepare_destination() {
   fi
   $ROOT/scripts/install-gitops --context $DESTINATION_CONTEXT --path "$GITOPS_PATH" --platform-cluster-name ${PLATFORM_CLUSTER_NAME} "$flags"
 
-  local yqOpts=".metadata.name = \"$NAME\" | .metadata.labels = {} | .spec.stateStoreRef.name = \"$STATE_STORE\" | .spec.stateStoreRef.kind = \"$state_store_type\" | .spec.strictMatchLabels = $STRICT_MATCH_LABELS"
+  local yqOpts=".metadata.name = \"$NAME\" | .metadata.labels = {} | .spec.path = \"$NAME\" | .spec.stateStoreRef.name = \"$STATE_STORE\" | .spec.stateStoreRef.kind = \"$state_store_type\" | .spec.strictMatchLabels = $STRICT_MATCH_LABELS"
   yq "${yqOpts}" $ROOT/config/samples/platform_v1alpha1_worker.yaml |
     kubectl --context $PLATFORM_CONTEXT apply -f -
 


### PR DESCRIPTION
# Context
- Make destination.spec.path a required field. Create and update will fail without path being set.
- Remove all prior migration logic

1. when creating a destination without `spec.path` or `spec.path` set to ""
```
❯ cat test.yaml
apiVersion: platform.kratix.io/v1alpha1
kind: Destination
metadata:
  labels:
    environment: dev
  name: test
spec:
  path: ""
  cleanup: none
  filepath:
    mode: nestedByMetadata
  initWorkloads:
    enabled: true
  stateStoreRef:
    kind: BucketStateStore
    name: default

❯ k apply -f test.yaml
The Destination "test" is invalid:
* spec.path: Required value
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```