### PR TITLE
fix: reconcile destination when spec.cleanup set to all

### DIFF
--- a/internal/controller/destination_controller.go
+++ b/internal/controller/destination_controller.go
@@ -21,15 +21,12 @@ import (
 	"fmt"
 	"path/filepath"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/yaml"
 
@@ -368,7 +365,7 @@ func (r *DestinationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.Destination{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&v1alpha1.Destination{}).
 		Watches(
 			&v1alpha1.BucketStateStore{},
 			handler.EnqueueRequestsFromMapFunc(r.findDestinationsForStateStore("BucketStateStore")),

--- a/test/system/assets/destination/destination-cleanup-all.yaml
+++ b/test/system/assets/destination/destination-cleanup-all.yaml
@@ -1,0 +1,12 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Destination
+metadata:
+  name: cleanup-all
+  labels:
+    target: cleanup-all
+spec:
+  cleanup: all
+  path: cleanup-all
+  stateStoreRef:
+    name: default
+    kind: BucketStateStore

--- a/test/system/assets/destination/promise-cleanup-all.yaml
+++ b/test/system/assets/destination/promise-cleanup-all.yaml
@@ -1,0 +1,65 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  name: cleanup-all
+spec:
+  destinationSelectors:
+    - matchLabels:
+        target: cleanup-all
+  api:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: cleanupalls.test.kratix.io
+    spec:
+      group: test.kratix.io
+      names:
+        kind: Cleanupall
+        plural: cleanupalls
+        singular: cleanupall
+      scope: Namespaced
+      versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+              type: object
+          served: true
+          storage: true
+  workflows:
+    promise:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: promise
+          spec:
+            containers:
+              - name: do-commands
+                image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+                command: ["sh"]
+                args:
+                  - -c
+                  - |
+                    set -eux
+                    kubectl create namespace --dry-run=client --output=yaml cleanup-all-ns > /kratix/output/ns.yaml
+    resource:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: resource
+          spec:
+            containers:
+              - name: do-commands
+                image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+                command: ["sh"]
+                args:
+                  - -c
+                  - |
+                    set -eux
+                    name=$(yq '.spec.name' /kratix/input/object.yaml)
+
+                    kubectl create configmap ${name} --namespace=cleanup-all-ns --dry-run=client --output=yaml --from-literal=key=${name} > /kratix/output/configmap.yaml

--- a/test/system/assets/destination/resources-cleanup-all.yaml
+++ b/test/system/assets/destination/resources-cleanup-all.yaml
@@ -1,0 +1,5 @@
+apiVersion: test.kratix.io/v1alpha1
+kind: Cleanupall
+metadata:
+  name: cleanupall-request-1
+  namespace: default


### PR DESCRIPTION
## Context

closes #429 

Previously we were only queueing request when destination.spec was updated; we remove the filtering so it will queue on any changes to the destination.

This PR also adds a new system test spec to test out the behavior of a destination when `spec.cleanup` is set to `all`.

For destination reconciliation, we want it to be triggered when:
1. its statestore spec has changed
2. its statestore status has changed (from 'not ready' to 'ready' or vice versa)
3. any changes to the destination itself. Arguably, we only need to watch `.spec` and `metadata.finalizers` for now. However, we might need to respond to `labels` and `annotations` changes in the future. We believe filtering on the exact fields might lead to more issues in the future because it might not be obvious that we need to change the filtering when updating the controller.