### PR TITLE
feat: inject maxLength validation into promise api

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -43,6 +44,9 @@ const (
 	PromiseAvailableConditionType        = "Available"
 	PromiseAvailableConditionTrueReason  = "PromiseAvailable"
 	PromiseAvailableConditionFalseReason = "PromiseUnavailable"
+
+	// MaxResourceNameLength is the maximum length of a resource namec
+	MaxResourceNameLength int64 = 63
 )
 
 // PromiseSpec defines the desired state of Promise
@@ -192,6 +196,8 @@ func (p *Promise) DoesNotContainAPI() bool {
 	return p.Spec.API == nil || p.Spec.API.Raw == nil
 }
 
+// GetAPI returns the GroupVersionKind and CustomResourceDefinition for the Promise's API
+// If the Promise does not contain an API, ErrNoAPI is returned
 func (p *Promise) GetAPI() (*schema.GroupVersionKind, *apiextensionsv1.CustomResourceDefinition, error) {
 	if p.DoesNotContainAPI() {
 		return nil, nil, ErrNoAPI
@@ -214,6 +220,10 @@ func (p *Promise) GetAPI() (*schema.GroupVersionKind, *apiextensionsv1.CustomRes
 		Group:   crd.Spec.Group,
 		Version: storedVersion.Name,
 		Kind:    crd.Spec.Names.Kind,
+	}
+
+	if storedVersion.Schema != nil && storedVersion.Schema.OpenAPIV3Schema != nil {
+		ensureMetadataSchema(storedVersion.Schema.OpenAPIV3Schema)
 	}
 
 	return gvk, &crd, nil
@@ -244,6 +254,7 @@ func (p *Promise) GetPipelineResourceName() string {
 func (p *Promise) GetPipelineResourceNamespace() string {
 	return "default"
 }
+
 func (p *Promise) GetDynamicControllerName(logger logr.Logger) string {
 	// We only start a dynamic controller if the promise contains an API
 	// so this **should** always be safe
@@ -426,4 +437,29 @@ func NewPipelinesMap(promise *Promise, logger logr.Logger) (pipelineMap, error) 
 	}
 
 	return pipelinesMap, nil
+}
+
+func ensureMetadataSchema(schema *apiextensionsv1.JSONSchemaProps) {
+	if schema.Properties == nil {
+		schema.Properties = make(map[string]apiextensionsv1.JSONSchemaProps)
+	}
+
+	if _, found := schema.Properties["metadata"]; !found {
+		schema.Properties["metadata"] = apiextensionsv1.JSONSchemaProps{
+			Type:       "object",
+			Properties: make(map[string]apiextensionsv1.JSONSchemaProps),
+		}
+	}
+
+	metadataSchema := schema.Properties["metadata"]
+	if metadataSchema.Properties == nil {
+		metadataSchema.Properties = make(map[string]apiextensionsv1.JSONSchemaProps)
+	}
+
+	nameProp := metadataSchema.Properties["name"]
+	if nameProp.Type == "" {
+		nameProp = apiextensionsv1.JSONSchemaProps{Type: "string"}
+	}
+	nameProp.MaxLength = ptr.To(MaxResourceNameLength)
+	metadataSchema.Properties["name"] = nameProp
 }

--- a/api/v1alpha1/promise_types_test.go
+++ b/api/v1alpha1/promise_types_test.go
@@ -1,10 +1,17 @@
 package v1alpha1_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	platformv1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Promise", func() {
@@ -41,4 +48,100 @@ var _ = Describe("Promise", func() {
 		})
 	})
 
+	Describe("GetAPI", func() {
+		var crd *apiextensionsv1.CustomResourceDefinition
+		var promise *platformv1alpha1.Promise
+
+		BeforeEach(func() {
+			crd = &apiextensionsv1.CustomResourceDefinition{
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "promise.crd.group",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Singular: "promiseCrd",
+						Plural:   "promiseCrdPlural",
+						Kind:     "PromiseCrd",
+					},
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name: "v1",
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"apiVersion": {Type: "string"},
+									"kind":       {Type: "string"},
+									"metadata": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"name":      {Type: "string", Description: "the name of the resource"},
+											"namespace": {Type: "string"},
+										},
+									},
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"replicas": {Type: "integer"},
+											"image":    {Type: "string"},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			}
+
+			promise = &platformv1alpha1.Promise{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myPromise",
+				},
+			}
+			setPromiseAPI(promise, crd)
+		})
+
+		It("returns the gvk", func() {
+			gvk, _, _ := promise.GetAPI()
+			Expect(*gvk).To(Equal(schema.GroupVersionKind{
+				Group:   "promise.crd.group",
+				Version: "v1",
+				Kind:    "PromiseCrd",
+			}))
+		})
+
+		It("sets the maxLength on the metadata.name property", func() {
+			_, c, _ := promise.GetAPI()
+			Expect(c.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["metadata"]).To(Equal(
+				apiextensionsv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"name":      {Type: "string", MaxLength: ptr.To(int64(63)), Description: "the name of the resource"},
+						"namespace": {Type: "string"},
+					},
+				}))
+		})
+
+		When("the crd does not define metadata", func() {
+			It("defines it and sets the maxLength", func() {
+				delete(crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties, "metadata")
+				setPromiseAPI(promise, crd)
+
+				_, c, _ := promise.GetAPI()
+				Expect(c.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties).To(HaveKeyWithValue(
+					"metadata",
+					apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"name": {Type: "string", MaxLength: ptr.To(int64(63))},
+						},
+					},
+				))
+			})
+		})
+
+	})
 })
+
+func setPromiseAPI(p *platformv1alpha1.Promise, crd *apiextensionsv1.CustomResourceDefinition) {
+	crdBytes, err := json.Marshal(crd)
+	Expect(err).ToNot(HaveOccurred())
+	p.Spec.API = &runtime.RawExtension{Raw: crdBytes}
+}


### PR DESCRIPTION
* name of resource requests must be 63 chars or less (since kratix uses it to label associated resources like the pipeline and stuff)
* labels must be 63 chars or less

closes https://github.com/syntasso/kratix/issues/419