### PR TITLE
fix: remove omitempty from initWorkloads.enable

### DIFF
--- a/api/v1alpha1/destination_types.go
+++ b/api/v1alpha1/destination_types.go
@@ -78,7 +78,7 @@ type DestinationSpec struct {
 type InitWorkloads struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=true
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 }
 
 const (


### PR DESCRIPTION
## Context

Given a destination:
```yaml
apiVersion: platform.kratix.io/v1alpha1
kind: Destination
metadata:
  labels:
    environment: dev
  name: worker-1
spec:
  cleanup: none
  filepath:
    mode: nestedByMetadata
  initWorkloads:
    enabled: false
  path: worker-1
  stateStoreRef:
    kind: BucketStateStore
    name: default

```
spec.initWorkloads.enabled is set to `true` instead of `false` after applying. This is because `omitempty` for boolean values prevents setting the value when set to "false", as it is the zero value for booleans. Then the crd default wins with the value `true`.

Another fix would change `spec.initWorkloads.enabled` to a pointer to boolean. But removing `omitempty` feels like a smaller change. 

Reference issue:
https://github.com/kubernetes-sigs/kubebuilder/issues/2109