### PR TITLE
feat: expose more envvars for pipeline containers

### DIFF
--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -149,10 +149,10 @@ func (p *PipelineFactory) defaultPipelineVolumes() ([]corev1.Volume, []corev1.Vo
 }
 
 func (p *PipelineFactory) defaultEnvVars() []corev1.EnvVar {
+	var objNamespace string
 	objGroup := p.Promise.GroupVersionKind().Group
 	objName := p.Promise.GetName()
 	objVersion := p.Promise.GroupVersionKind().Version
-	objNamespace := ""
 
 	if p.ResourceWorkflow {
 		objGroup = p.ResourceRequest.GroupVersionKind().Group

--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -149,11 +149,23 @@ func (p *PipelineFactory) defaultPipelineVolumes() ([]corev1.Volume, []corev1.Vo
 }
 
 func (p *PipelineFactory) defaultEnvVars() []corev1.EnvVar {
+	objGroup := p.Promise.GroupVersionKind().Group
+	objName := p.Promise.GetName()
+	objVersion := p.Promise.GroupVersionKind().Version
+
+	if p.ResourceWorkflow {
+		objGroup = p.ResourceRequest.GroupVersionKind().Group
+		objName = p.ResourceRequest.GetName()
+		objVersion = p.ResourceRequest.GroupVersionKind().Version
+	}
 	return []corev1.EnvVar{
 		{Name: kratixActionEnvVar, Value: string(p.WorkflowAction)},
 		{Name: kratixTypeEnvVar, Value: string(p.WorkflowType)},
-		{Name: kratixPromiseEnvVar, Value: p.Promise.GetName()},
+		{Name: KratixPromiseNameEnvVar, Value: p.Promise.GetName()},
 		{Name: kratixPipelineNameEnvVar, Value: p.Pipeline.Name},
+		{Name: KratixObjectGroupEnvVar, Value: objGroup},
+		{Name: KratixObjectNameEnvVar, Value: objName},
+		{Name: KratixObjectVersionEnvVar, Value: objVersion},
 	}
 }
 
@@ -169,13 +181,13 @@ func (p *PipelineFactory) readerContainer() corev1.Container {
 	}
 
 	envVars := []corev1.EnvVar{
-		{Name: "OBJECT_GROUP", Value: group},
-		{Name: "OBJECT_NAME", Value: name},
-		{Name: "OBJECT_VERSION", Value: version},
-		{Name: "OBJECT_NAMESPACE", Value: p.Namespace},
-		{Name: "KRATIX_WORKFLOW_TYPE", Value: string(p.WorkflowType)},
-		{Name: "CRD_PLURAL", Value: p.CRDPlural},
-		{Name: "CLUSTER_SCOPED", Value: fmt.Sprintf("%t", p.ClusterScoped)},
+		{Name: KratixObjectGroupEnvVar, Value: group},
+		{Name: KratixObjectNameEnvVar, Value: name},
+		{Name: KratixObjectVersionEnvVar, Value: version},
+		{Name: KratixObjectNamespaceEnvVar, Value: p.Namespace},
+		{Name: KratixWorkflowType, Value: string(p.WorkflowType)},
+		{Name: KratixCrdPlural, Value: p.CRDPlural},
+		{Name: KratixClusterScoped, Value: fmt.Sprintf("%t", p.ClusterScoped)},
 	}
 
 	return corev1.Container{
@@ -331,13 +343,13 @@ func (p *PipelineFactory) statusWriterContainer(obj *unstructured.Unstructured, 
 		Image:   os.Getenv("PIPELINE_ADAPTER_IMG"),
 		Command: []string{"sh", "-c", "update-status"},
 		Env: append(env,
-			corev1.EnvVar{Name: "OBJECT_KIND", Value: strings.ToLower(obj.GetKind())},
-			corev1.EnvVar{Name: "OBJECT_GROUP", Value: obj.GroupVersionKind().Group},
-			corev1.EnvVar{Name: "OBJECT_VERSION", Value: obj.GroupVersionKind().Version},
-			corev1.EnvVar{Name: "OBJECT_NAME", Value: obj.GetName()},
-			corev1.EnvVar{Name: "OBJECT_NAMESPACE", Value: p.Namespace},
-			corev1.EnvVar{Name: "CRD_PLURAL", Value: p.CRDPlural},
-			corev1.EnvVar{Name: "CLUSTER_SCOPED", Value: fmt.Sprintf("%t", p.ClusterScoped)},
+			corev1.EnvVar{Name: KratixObjectKindEnvVar, Value: strings.ToLower(obj.GetKind())},
+			corev1.EnvVar{Name: KratixObjectGroupEnvVar, Value: obj.GroupVersionKind().Group},
+			corev1.EnvVar{Name: KratixObjectVersionEnvVar, Value: obj.GroupVersionKind().Version},
+			corev1.EnvVar{Name: KratixObjectNameEnvVar, Value: obj.GetName()},
+			corev1.EnvVar{Name: KratixObjectNamespaceEnvVar, Value: p.Namespace},
+			corev1.EnvVar{Name: KratixCrdPluralEnvVar, Value: p.CRDPlural},
+			corev1.EnvVar{Name: KratixClusterScopedEnvVar, Value: fmt.Sprintf("%t", p.ClusterScoped)},
 		),
 		VolumeMounts: []corev1.VolumeMount{{
 			MountPath: "/work-creator-files/metadata",

--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -38,8 +38,20 @@ import (
 const (
 	kratixActionEnvVar       = "KRATIX_WORKFLOW_ACTION"
 	kratixTypeEnvVar         = "KRATIX_WORKFLOW_TYPE"
-	kratixPromiseEnvVar      = "KRATIX_PROMISE_NAME"
+	KratixPromiseNameEnvVar  = "KRATIX_PROMISE_NAME"
 	kratixPipelineNameEnvVar = "KRATIX_PIPELINE_NAME"
+
+	KratixObjectKindEnvVar      = "KRATIX_OBJECT_KIND"
+	KratixObjectGroupEnvVar     = "KRATIX_OBJECT_GROUP"
+	KratixObjectVersionEnvVar   = "KRATIX_OBJECT_VERSION"
+	KratixObjectNameEnvVar      = "KRATIX_OBJECT_NAME"
+	KratixObjectNamespaceEnvVar = "KRATIX_OBJECT_NAMESPACE"
+	KratixCrdPluralEnvVar       = "KRATIX_CRD_PLURAL"
+	KratixClusterScopedEnvVar   = "KRATIX_CLUSTER_SCOPED"
+
+	KratixWorkflowType  = "KRATIX_WORKFLOW_TYPE"
+	KratixCrdPlural     = "KRATIX_CRD_PLURAL"
+	KratixClusterScoped = "KRATIX_CLUSTER_SCOPED"
 
 	WorkflowTypeLabel   = KratixPrefix + "workflow-type"
 	WorkflowActionLabel = KratixPrefix + "workflow-action"

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -573,7 +573,7 @@ var _ = Describe("Pipeline", func() {
 			Describe("DefaultEnvVars", func() {
 				It("should return a list of default environment variables", func() {
 					envVars := resources.Job.Spec.Template.Spec.InitContainers[1].Env
-					Expect(envVars).To(HaveLen(8))
+					Expect(envVars).To(HaveLen(9))
 					Expect(envVars).To(ContainElements(
 						corev1.EnvVar{Name: "KRATIX_WORKFLOW_ACTION", Value: "configure"},
 						corev1.EnvVar{Name: "KRATIX_WORKFLOW_TYPE", Value: "fakeType"},
@@ -586,6 +586,7 @@ var _ = Describe("Pipeline", func() {
 						corev1.EnvVar{Name: "KRATIX_OBJECT_GROUP", Value: promise.GroupVersionKind().Group},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_NAME", Value: promise.GetName()},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: promise.GroupVersionKind().Version},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAMESPACE", Value: ""},
 					))
 				})
 			})
@@ -617,10 +618,13 @@ var _ = Describe("Pipeline", func() {
 				}))
 
 				expectedEnvVars := []corev1.EnvVar{
-					{Name: "KRATIX_OBJECT_NAMESPACE", Value: factory.Namespace},
 					{Name: "KRATIX_WORKFLOW_TYPE", Value: string(factory.WorkflowType)},
 					{Name: "KRATIX_CLUSTER_SCOPED", Value: fmt.Sprintf("%t", factory.ClusterScoped)},
 					{Name: "KRATIX_CRD_PLURAL", Value: factory.CRDPlural},
+					{Name: "KRATIX_WORKFLOW_ACTION", Value: "configure"},
+					{Name: "KRATIX_PROMISE_NAME", Value: "promiseName"},
+					{Name: "KRATIX_PIPELINE_NAME", Value: "pipelineName"},
+					{Name: "KRATIX_WORKFLOW_TYPE", Value: "fakeType"},
 				}
 
 				if isResourceWorkflow {
@@ -628,12 +632,14 @@ var _ = Describe("Pipeline", func() {
 						corev1.EnvVar{Name: "KRATIX_OBJECT_GROUP", Value: resourceRequest.GroupVersionKind().Group},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_NAME", Value: resourceRequest.GetName()},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: resourceRequest.GroupVersionKind().Version},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAMESPACE", Value: resourceRequest.GetNamespace()},
 					)
 				} else {
 					expectedEnvVars = append(expectedEnvVars,
 						corev1.EnvVar{Name: "KRATIX_OBJECT_GROUP", Value: promise.GroupVersionKind().Group},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_NAME", Value: promise.GetName()},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: promise.GroupVersionKind().Version},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAMESPACE", Value: ""},
 					)
 				}
 

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -573,12 +573,19 @@ var _ = Describe("Pipeline", func() {
 			Describe("DefaultEnvVars", func() {
 				It("should return a list of default environment variables", func() {
 					envVars := resources.Job.Spec.Template.Spec.InitContainers[1].Env
-					Expect(envVars).To(HaveLen(5))
+					Expect(envVars).To(HaveLen(8))
 					Expect(envVars).To(ContainElements(
 						corev1.EnvVar{Name: "KRATIX_WORKFLOW_ACTION", Value: "configure"},
 						corev1.EnvVar{Name: "KRATIX_WORKFLOW_TYPE", Value: "fakeType"},
 						corev1.EnvVar{Name: "KRATIX_PROMISE_NAME", Value: promise.GetName()},
 						corev1.EnvVar{Name: "KRATIX_PIPELINE_NAME", Value: "pipelineName"},
+					))
+
+					// TODO: Expected because Promise is default, should test for RR
+					Expect(envVars).To(ContainElements(
+						corev1.EnvVar{Name: "KRATIX_OBJECT_GROUP", Value: promise.GroupVersionKind().Group},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAME", Value: promise.GetName()},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: promise.GroupVersionKind().Version},
 					))
 				})
 			})
@@ -610,23 +617,23 @@ var _ = Describe("Pipeline", func() {
 				}))
 
 				expectedEnvVars := []corev1.EnvVar{
-					{Name: "OBJECT_NAMESPACE", Value: factory.Namespace},
+					{Name: "KRATIX_OBJECT_NAMESPACE", Value: factory.Namespace},
 					{Name: "KRATIX_WORKFLOW_TYPE", Value: string(factory.WorkflowType)},
-					{Name: "CLUSTER_SCOPED", Value: fmt.Sprintf("%t", factory.ClusterScoped)},
-					{Name: "CRD_PLURAL", Value: factory.CRDPlural},
+					{Name: "KRATIX_CLUSTER_SCOPED", Value: fmt.Sprintf("%t", factory.ClusterScoped)},
+					{Name: "KRATIX_CRD_PLURAL", Value: factory.CRDPlural},
 				}
 
 				if isResourceWorkflow {
 					expectedEnvVars = append(expectedEnvVars,
-						corev1.EnvVar{Name: "OBJECT_GROUP", Value: resourceRequest.GroupVersionKind().Group},
-						corev1.EnvVar{Name: "OBJECT_NAME", Value: resourceRequest.GetName()},
-						corev1.EnvVar{Name: "OBJECT_VERSION", Value: resourceRequest.GroupVersionKind().Version},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_GROUP", Value: resourceRequest.GroupVersionKind().Group},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAME", Value: resourceRequest.GetName()},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: resourceRequest.GroupVersionKind().Version},
 					)
 				} else {
 					expectedEnvVars = append(expectedEnvVars,
-						corev1.EnvVar{Name: "OBJECT_GROUP", Value: promise.GroupVersionKind().Group},
-						corev1.EnvVar{Name: "OBJECT_NAME", Value: promise.GetName()},
-						corev1.EnvVar{Name: "OBJECT_VERSION", Value: promise.GroupVersionKind().Version},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_GROUP", Value: promise.GroupVersionKind().Group},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAME", Value: promise.GetName()},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: promise.GroupVersionKind().Version},
 					)
 				}
 
@@ -843,13 +850,13 @@ var _ = Describe("Pipeline", func() {
 					Expect(container.ImagePullPolicy).To(BeEmpty())
 					Expect(container.Command).To(Equal([]string{"sh", "-c", "update-status"}))
 					Expect(container.Env).To(ConsistOf(
-						corev1.EnvVar{Name: "OBJECT_KIND", Value: resourceRequest.GroupVersionKind().Kind},
-						corev1.EnvVar{Name: "OBJECT_GROUP", Value: resourceRequest.GroupVersionKind().Group},
-						corev1.EnvVar{Name: "OBJECT_VERSION", Value: resourceRequest.GroupVersionKind().Version},
-						corev1.EnvVar{Name: "CRD_PLURAL", Value: promiseCrd.Spec.Names.Plural},
-						corev1.EnvVar{Name: "OBJECT_NAME", Value: resourceRequest.GetName()},
-						corev1.EnvVar{Name: "OBJECT_NAMESPACE", Value: factory.Namespace},
-						corev1.EnvVar{Name: "CLUSTER_SCOPED", Value: "false"},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_KIND", Value: resourceRequest.GroupVersionKind().Kind},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_GROUP", Value: resourceRequest.GroupVersionKind().Group},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: resourceRequest.GroupVersionKind().Version},
+						corev1.EnvVar{Name: "KRATIX_CRD_PLURAL", Value: promiseCrd.Spec.Names.Plural},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAME", Value: resourceRequest.GetName()},
+						corev1.EnvVar{Name: "KRATIX_OBJECT_NAMESPACE", Value: factory.Namespace},
+						corev1.EnvVar{Name: "KRATIX_CLUSTER_SCOPED", Value: "false"},
 						corev1.EnvVar{Name: "env1", Value: "value1"},
 						corev1.EnvVar{Name: "env2", Value: "value2"},
 					))

--- a/work-creator/pipeline/lib/helpers/helpers.go
+++ b/work-creator/pipeline/lib/helpers/helpers.go
@@ -33,13 +33,13 @@ type Parameters struct {
 
 func getParametersFromEnv() *Parameters {
 	p := &Parameters{
-		ObjectGroup:     os.Getenv("OBJECT_GROUP"),
-		ObjectName:      os.Getenv("OBJECT_NAME"),
-		ObjectVersion:   os.Getenv("OBJECT_VERSION"),
-		ObjectNamespace: os.Getenv("OBJECT_NAMESPACE"),
-		PromiseName:     os.Getenv("PROMISE_NAME"),
-		CRDPlural:       os.Getenv("CRD_PLURAL"),
-		ClusterScoped:   os.Getenv("CLUSTER_SCOPED") == "true",
+		ObjectGroup:     os.Getenv(v1alpha1.KratixObjectGroupEnvVar),
+		ObjectVersion:   os.Getenv(v1alpha1.KratixObjectVersionEnvVar),
+		ObjectName:      os.Getenv(v1alpha1.KratixObjectNameEnvVar),
+		ObjectNamespace: os.Getenv(v1alpha1.KratixObjectNamespaceEnvVar),
+		CRDPlural:       os.Getenv(v1alpha1.KratixCrdPluralEnvVar),
+		ClusterScoped:   os.Getenv(v1alpha1.KratixClusterScopedEnvVar) == "true",
+		PromiseName:     os.Getenv(v1alpha1.KratixPromiseNameEnvVar),
 		IsLastPipeline:  os.Getenv("IS_LAST_PIPELINE") == "true",
 		InputDir:        os.Getenv("INPUT_DIR"),
 		OutputDir:       os.Getenv("OUTPUT_DIR"),


### PR DESCRIPTION
Standardise KRATIX_ prefix for envvars and expose the object name in the pipeline images by default. This allows people to do more useful inline containers as they can use vars that are unique.