### PR TITLE
chore: Separate quick start image for install-all-in-one.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION ?= dev
 # Image URL to use all building/pushing image targets
 IMG_NAME ?= docker.io/syntasso/kratix-platform
-QUICKSTART_TAG ?= docker.io/syntasso/kratix-quickstart:latest
+QUICKSTART_TAG ?= docker.io/syntasso/kratix-platform-quickstart:latest
 IMG_VERSION ?= ${VERSION}
 IMG_TAG ?= ${IMG_NAME}:${IMG_VERSION}
 IMG_MIRROR ?= syntassodev/kratix-platform:${VERSION}
@@ -115,8 +115,7 @@ debug-run: manifests generate fmt vet ## Run a controller in debug mode from you
 	dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient debug ./main.go
 
 docker-build: ## Build docker image with the manager.
-	docker build -t ${QUICKSTART_TAG} -t ${IMG_TAG} -t ${IMG_NAME}:latest .
-	docker tag ${IMG_TAG} ${IMG_MIRROR}
+	docker build -t ${QUICKSTART_TAG} -t ${IMG_MIRROR} -t ${IMG_TAG} -t ${IMG_NAME}:latest .
 
 docker-build-and-push: ## Push multi-arch docker image with the manager.
 	if ! docker buildx ls | grep -q "kratix-image-builder"; then \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 VERSION ?= dev
 # Image URL to use all building/pushing image targets
 IMG_NAME ?= docker.io/syntasso/kratix-platform
+QUICKSTART_TAG ?= docker.io/syntasso/kratix-quickstart:latest
 IMG_VERSION ?= ${VERSION}
 IMG_TAG ?= ${IMG_NAME}:${IMG_VERSION}
 IMG_MIRROR ?= syntassodev/kratix-platform:${VERSION}
@@ -114,14 +115,14 @@ debug-run: manifests generate fmt vet ## Run a controller in debug mode from you
 	dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient debug ./main.go
 
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG_TAG} -t ${IMG_NAME}:latest .
+	docker build -t ${QUICKSTART_TAG} -t ${IMG_TAG} -t ${IMG_NAME}:latest .
 	docker tag ${IMG_TAG} ${IMG_MIRROR}
 
 docker-build-and-push: ## Push multi-arch docker image with the manager.
 	if ! docker buildx ls | grep -q "kratix-image-builder"; then \
 		docker buildx create --name kratix-image-builder; \
 	fi;
-	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG_TAG} -t ${IMG_NAME}:latest .
+	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${QUICKSTART_TAG} -t ${IMG_TAG} -t ${IMG_NAME}:latest .
 	docker buildx build --builder kratix-image-builder --push --platform linux/arm64,linux/amd64 -t ${IMG_MIRROR} .
 
 build-and-push-work-creator: ## Build and push the Work Creator image

--- a/scripts/make-distribution
+++ b/scripts/make-distribution
@@ -35,9 +35,11 @@ function generate_all_manifests() {
 
 export IMG_TAG=$(fetch_digest "syntasso/kratix-platform-quickstart")
 export PIPELINE_ADAPTER_IMG=$(fetch_digest "syntasso/kratix-platform-pipeline-adapter-quickstart")
+# Generate kratix.yaml with the quickstat images, so we can generate the install-all-in-one.yaml with the quickstart images
 make distribution
 generate_all_manifests
 
 export IMG_TAG=$(fetch_digest "syntasso/kratix-platform")
 export PIPELINE_ADAPTER_IMG=$(fetch_digest "syntasso/kratix-platform-pipeline-adapter")
+# Regenerate kratix.yaml with the normal images
 make distribution

--- a/scripts/make-distribution
+++ b/scripts/make-distribution
@@ -2,7 +2,7 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
 
-set -eu
+set -euo pipefail
 
 cd $ROOT
 source "$ROOT/scripts/utils.sh"
@@ -39,6 +39,16 @@ mkdir -p distribution/single-cluster
 cat distribution/kratix.yaml <(echo "---") \
 hack/destination/gitops-tk-install.yaml <(echo "---") \
 hack/platform/minio-install.yaml > distribution/single-cluster/install-all-in-one.yaml
+
+KRATIX_QUICKSTART_MANIFEST_DIGEST=$(skopeo --override-os linux inspect docker://docker.io/syntasso/kratix-quickstart:latest | jq -r .Digest)
+export QUICKSTART_TAG=syntasso.docker.scarf.sh/syntasso/kratix-quickstart@${KRATIX_QUICKSTART_MANIFEST_DIGEST}
+
+yq eval-all '
+  select(.kind == "Deployment" and .metadata.name == "kratix-platform-controller-manager")
+  |= (.spec.template.spec.containers[0].image = strenv(QUICKSTART_TAG))
+  // select(.kind != "Deployment" or .metadata.name != "kratix-platform-controller-manager")
+' distribution/single-cluster/install-all-in-one.yaml > distribution/single-cluster/install-all-in-one.new.yaml
+mv distribution/single-cluster/install-all-in-one.new.yaml distribution/single-cluster/install-all-in-one.yaml
 
 cat config/samples/platform_v1alpha1_worker.yaml <(echo "---") \
 config/samples/platform_v1alpha1_bucketstatestore.yaml <(echo "---") \

--- a/scripts/make-distribution
+++ b/scripts/make-distribution
@@ -4,52 +4,81 @@ ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
 
 set -euo pipefail
 
-cd $ROOT
+cd "$ROOT"
 source "$ROOT/scripts/utils.sh"
 
 export VERSION="${VERSION:-$(commit_sha)}"
 
-docker pull syntasso/kratix-platform-pipeline-adapter
+function pull_image() {
+  local image="$1"
+  docker pull "$image"
+}
 
-docker pull syntasso/kratix-platform
+function fetch_digest() {
+  local image="$1"
+  skopeo --override-os linux inspect "docker://docker.io/${image}:latest" | jq -r .Digest
+}
 
-PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST=$(skopeo --override-os linux inspect docker://docker.io/syntasso/kratix-platform-pipeline-adapter:latest | jq -r .Digest)
-export PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST
+function validate_digest() {
+  local name="$1"
+  local value="$2"
 
-KRATIX_PLATFORM_MANIFEST_DIGEST=$(skopeo --override-os linux inspect docker://docker.io/syntasso/kratix-platform:latest | jq -r .Digest)
-export KRATIX_PLATFORM_MANIFEST_DIGEST
-
-export PIPELINE_ADAPTER_IMG=syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter@${PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST}
-export IMG_TAG=syntasso.docker.scarf.sh/syntasso/kratix-platform@${KRATIX_PLATFORM_MANIFEST_DIGEST}
-
-if [ -z "${KRATIX_PLATFORM_MANIFEST_DIGEST}" ]; then
-    echo "Error: KRATIX_PLATFORM_MANIFEST_DIGEST is empty"
+  if [ -z "$value" ]; then
+    echo "Error: $name is empty"
     exit 1
-fi
+  fi
+}
 
-if [ -z "${PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST}" ]; then
-    echo "Error: PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST is empty"
-    exit 1
-fi
+function generate_distribution_manifests() {
+  pull_image syntasso/kratix-platform-pipeline-adapter
+  pull_image syntasso/kratix-platform
 
-make distribution
+  export PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST=$(fetch_digest syntasso/kratix-platform-pipeline-adapter)
+  export KRATIX_PLATFORM_MANIFEST_DIGEST=$(fetch_digest syntasso/kratix-platform)
 
-mkdir -p distribution/single-cluster
+  validate_digest "KRATIX_PLATFORM_MANIFEST_DIGEST" "$KRATIX_PLATFORM_MANIFEST_DIGEST"
+  validate_digest "PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST" "$PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST"
 
-cat distribution/kratix.yaml <(echo "---") \
-hack/destination/gitops-tk-install.yaml <(echo "---") \
-hack/platform/minio-install.yaml > distribution/single-cluster/install-all-in-one.yaml
+  export PIPELINE_ADAPTER_IMG="syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter@${PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST}"
+  export IMG_TAG="syntasso.docker.scarf.sh/syntasso/kratix-platform@${KRATIX_PLATFORM_MANIFEST_DIGEST}"
 
-KRATIX_QUICKSTART_MANIFEST_DIGEST=$(skopeo --override-os linux inspect docker://docker.io/syntasso/kratix-quickstart:latest | jq -r .Digest)
-export QUICKSTART_TAG=syntasso.docker.scarf.sh/syntasso/kratix-quickstart@${KRATIX_QUICKSTART_MANIFEST_DIGEST}
+  make distribution
+  mkdir -p distribution/single-cluster
 
-yq eval-all '
-  select(.kind == "Deployment" and .metadata.name == "kratix-platform-controller-manager")
-  |= (.spec.template.spec.containers[0].image = strenv(QUICKSTART_TAG))
-  // select(.kind != "Deployment" or .metadata.name != "kratix-platform-controller-manager")
-' distribution/single-cluster/install-all-in-one.yaml > distribution/single-cluster/install-all-in-one.new.yaml
-mv distribution/single-cluster/install-all-in-one.new.yaml distribution/single-cluster/install-all-in-one.yaml
+  cat config/samples/platform_v1alpha1_worker.yaml <(echo "---") \
+      config/samples/platform_v1alpha1_bucketstatestore.yaml <(echo "---") \
+      hack/destination/gitops-tk-resources-single-cluster.yaml > distribution/single-cluster/config-all-in-one.yaml
 
-cat config/samples/platform_v1alpha1_worker.yaml <(echo "---") \
-config/samples/platform_v1alpha1_bucketstatestore.yaml <(echo "---") \
-hack/destination/gitops-tk-resources-single-cluster.yaml > distribution/single-cluster/config-all-in-one.yaml
+  cat distribution/kratix.yaml <(echo "---") \
+      hack/destination/gitops-tk-install.yaml <(echo "---") \
+      hack/platform/minio-install.yaml > distribution/single-cluster/install-all-in-one.yaml
+}
+
+function patch_quickstart_images() {
+  local quickstart_digest
+  local adapter_quickstart_digest
+
+  quickstart_digest=$(fetch_digest syntasso/kratix-platform-quickstart)
+  validate_digest "KRATIX_QUICKSTART_MANIFEST_DIGEST" "$quickstart_digest"
+
+  adapter_quickstart_digest=$(fetch_digest syntasso/kratix-platform-pipeline-adapter-quickstart)
+  validate_digest "KRATIX_QUICKSTART_PIPELINE_ADAPTER_MANIFEST_DIGEST" "$adapter_quickstart_digest"
+
+  export QUICKSTART_TAG="syntasso.docker.scarf.sh/syntasso/kratix-platform-quickstart@${quickstart_digest}"
+  export QUICKSTART_PIPELINE_ADAPTER_TAG="syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter-quickstart@${adapter_quickstart_digest}"
+
+  yq eval '
+    select(.kind == "Deployment" and .metadata.name == "kratix-platform-controller-manager")
+    .spec.template.spec.containers[0].image = strenv(QUICKSTART_TAG)
+    // select(.kind != "Deployment" or .metadata.name != "kratix-platform-controller-manager")
+  ' distribution/single-cluster/install-all-in-one.yaml > tmp.yaml && mv tmp.yaml distribution/single-cluster/install-all-in-one.yaml
+
+  yq eval '
+    select(.kind == "ConfigMap" and .metadata.name == "kratix-platform-pipeline-adapter-config")
+    .data.PIPELINE_ADAPTER_IMG = strenv(QUICKSTART_PIPELINE_ADAPTER_TAG)
+    // select(.kind != "ConfigMap" or .metadata.name != "kratix-platform-pipeline-adapter-config")
+  ' distribution/single-cluster/install-all-in-one.yaml > tmp.yaml && mv tmp.yaml distribution/single-cluster/install-all-in-one.yaml
+}
+
+generate_distribution_manifests
+patch_quickstart_images

--- a/scripts/make-distribution
+++ b/scripts/make-distribution
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
-
 set -euo pipefail
 
 cd "$ROOT"
@@ -9,76 +8,36 @@ source "$ROOT/scripts/utils.sh"
 
 export VERSION="${VERSION:-$(commit_sha)}"
 
-function pull_image() {
-  local image="$1"
-  docker pull "$image"
-}
-
 function fetch_digest() {
   local image="$1"
-  skopeo --override-os linux inspect "docker://docker.io/${image}:latest" | jq -r .Digest
-}
+  local digest
 
-function validate_digest() {
-  local name="$1"
-  local value="$2"
-
-  if [ -z "$value" ]; then
-    echo "Error: $name is empty"
+  digest=$(skopeo --override-os linux inspect "docker://docker.io/${image}:latest" | jq -r .Digest)
+  if [ -z "$digest" ]; then
+    echo "Error: digest for image '$image' is empty"
     exit 1
   fi
+
+  echo "syntasso.docker.scarf.sh/${image}@${digest}"
 }
 
-function generate_distribution_manifests() {
-  pull_image syntasso/kratix-platform-pipeline-adapter
-  pull_image syntasso/kratix-platform
-
-  export PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST=$(fetch_digest syntasso/kratix-platform-pipeline-adapter)
-  export KRATIX_PLATFORM_MANIFEST_DIGEST=$(fetch_digest syntasso/kratix-platform)
-
-  validate_digest "KRATIX_PLATFORM_MANIFEST_DIGEST" "$KRATIX_PLATFORM_MANIFEST_DIGEST"
-  validate_digest "PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST" "$PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST"
-
-  export PIPELINE_ADAPTER_IMG="syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter@${PIPELINE_ADAPTER_VERSION_MANIFEST_DIGEST}"
-  export IMG_TAG="syntasso.docker.scarf.sh/syntasso/kratix-platform@${KRATIX_PLATFORM_MANIFEST_DIGEST}"
-
-  make distribution
+function generate_all_manifests() {
   mkdir -p distribution/single-cluster
-
-  cat config/samples/platform_v1alpha1_worker.yaml <(echo "---") \
-      config/samples/platform_v1alpha1_bucketstatestore.yaml <(echo "---") \
-      hack/destination/gitops-tk-resources-single-cluster.yaml > distribution/single-cluster/config-all-in-one.yaml
 
   cat distribution/kratix.yaml <(echo "---") \
       hack/destination/gitops-tk-install.yaml <(echo "---") \
       hack/platform/minio-install.yaml > distribution/single-cluster/install-all-in-one.yaml
+
+  cat config/samples/platform_v1alpha1_worker.yaml <(echo "---") \
+      config/samples/platform_v1alpha1_bucketstatestore.yaml <(echo "---") \
+      hack/destination/gitops-tk-resources-single-cluster.yaml > distribution/single-cluster/config-all-in-one.yaml
 }
 
-function patch_quickstart_images() {
-  local quickstart_digest
-  local adapter_quickstart_digest
+export IMG_TAG=$(fetch_digest "syntasso/kratix-platform-quickstart")
+export PIPELINE_ADAPTER_IMG=$(fetch_digest "syntasso/kratix-platform-pipeline-adapter-quickstart")
+make distribution
+generate_all_manifests
 
-  quickstart_digest=$(fetch_digest syntasso/kratix-platform-quickstart)
-  validate_digest "KRATIX_QUICKSTART_MANIFEST_DIGEST" "$quickstart_digest"
-
-  adapter_quickstart_digest=$(fetch_digest syntasso/kratix-platform-pipeline-adapter-quickstart)
-  validate_digest "KRATIX_QUICKSTART_PIPELINE_ADAPTER_MANIFEST_DIGEST" "$adapter_quickstart_digest"
-
-  export QUICKSTART_TAG="syntasso.docker.scarf.sh/syntasso/kratix-platform-quickstart@${quickstart_digest}"
-  export QUICKSTART_PIPELINE_ADAPTER_TAG="syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter-quickstart@${adapter_quickstart_digest}"
-
-  yq eval '
-    select(.kind == "Deployment" and .metadata.name == "kratix-platform-controller-manager")
-    .spec.template.spec.containers[0].image = strenv(QUICKSTART_TAG)
-    // select(.kind != "Deployment" or .metadata.name != "kratix-platform-controller-manager")
-  ' distribution/single-cluster/install-all-in-one.yaml > tmp.yaml && mv tmp.yaml distribution/single-cluster/install-all-in-one.yaml
-
-  yq eval '
-    select(.kind == "ConfigMap" and .metadata.name == "kratix-platform-pipeline-adapter-config")
-    .data.PIPELINE_ADAPTER_IMG = strenv(QUICKSTART_PIPELINE_ADAPTER_TAG)
-    // select(.kind != "ConfigMap" or .metadata.name != "kratix-platform-pipeline-adapter-config")
-  ' distribution/single-cluster/install-all-in-one.yaml > tmp.yaml && mv tmp.yaml distribution/single-cluster/install-all-in-one.yaml
-}
-
-generate_distribution_manifests
-patch_quickstart_images
+export IMG_TAG=$(fetch_digest "syntasso/kratix-platform")
+export PIPELINE_ADAPTER_IMG=$(fetch_digest "syntasso/kratix-platform-pipeline-adapter")
+make distribution

--- a/work-creator/Makefile
+++ b/work-creator/Makefile
@@ -3,6 +3,7 @@ PIPELINE_ADAPTER_IMG_NAME ?= docker.io/syntasso/kratix-platform-pipeline-adapter
 PIPELINE_ADAPTER_IMG_VERSION ?= dev
 PIPELINE_ADAPTER_IMG_TAG ?= ${PIPELINE_ADAPTER_IMG_NAME}:${PIPELINE_ADAPTER_IMG_VERSION}
 PIPELINE_ADAPTER_IMG_MIRROR ?= docker.io/syntassodev/kratix-platform-pipeline-adapter:dev
+PIPELINE_ADAPTER_QUICKSTART_TAG ?= docker.io/syntasso/kratix-platform-pipeline-adapter-quickstart:latest
 # Enable buildkit for docker
 DOCKER_BUILDKIT ?= 1
 
@@ -31,12 +32,10 @@ kind-load-image: docker-build ## Load locally built image into KinD, use export 
 ##@ Build
 
 docker-build: ## Build docker image with work-creator binary
-	docker build -f ../Dockerfile.pipeline-adapter --tag ${PIPELINE_ADAPTER_IMG_TAG} --tag ${PIPELINE_ADAPTER_IMG_NAME}:latest ../
-	docker build -f ../Dockerfile.pipeline-adapter --tag ${PIPELINE_ADAPTER_IMG_MIRROR} ../
+	docker build -f ../Dockerfile.pipeline-adapter -t ${PIPELINE_ADAPTER_QUICKSTART_TAG} -t ${PIPELINE_ADAPTER_IMG_TAG} -t ${PIPELINE_ADAPTER_IMG_MIRROR} -t ${PIPELINE_ADAPTER_IMG_NAME}:latest ../
 
 docker-build-and-push: ## Push multi-arch docker image with the manager.
 	if ! docker buildx ls | grep -q "work-creator-image-builder"; then \
 		docker buildx create --name work-creator-image-builder; \
 	fi;
-	docker buildx build --builder work-creator-image-builder --push --platform linux/arm64,linux/amd64 --file ../Dockerfile.pipeline-adapter --tag ${PIPELINE_ADAPTER_IMG_TAG} --tag ${PIPELINE_ADAPTER_IMG_NAME}:latest ../
-	docker buildx build --builder work-creator-image-builder --push --platform linux/arm64,linux/amd64 --file ../Dockerfile.pipeline-adapter --tag ${PIPELINE_ADAPTER_IMG_MIRROR} ../
+	docker buildx build --builder work-creator-image-builder --push --platform linux/arm64,linux/amd64 --file ../Dockerfile.pipeline-adapter -t ${PIPELINE_ADAPTER_QUICKSTART_TAG} -t ${PIPELINE_ADAPTER_IMG_TAG} -t ${PIPELINE_ADAPTER_IMG_MIRROR} -t ${PIPELINE_ADAPTER_IMG_NAME}:latest ../


### PR DESCRIPTION
In order to get metrics of how many people run the quick start, this PR updates the manifest to use a separate identical imagine, so we can gather metrics.

Verified the changes to the script
```
diff prior-to-change-install-all-in-one.yaml post-changes-to-install-all-in-one.yaml
1612c1612
<   PIPELINE_ADAPTER_IMG: syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter@sha256:89dd4c316914ea259b9a2ee95089c0ecc711152e016f1f8568f27516b9318280
---
>   PIPELINE_ADAPTER_IMG: syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter-quickstart@sha256:98ed3239c179a4014ecfa29463c31f5c84127b2db5d4f228b44370f5ea50620c
1699c1699
<           image: syntasso.docker.scarf.sh/syntasso/kratix-platform@sha256:5c63a74db894aaf9b6abf88466f7837ee9a73659204ab89d3053a1be56a1623a
---
>           image: syntasso.docker.scarf.sh/syntasso/kratix-platform-quickstart@sha256:701e4c83125c7e69e2db83ba36ed73701e1fc92cb3594a23954c84104aaf34b1
```

Verified install-all-in-one still works:
```
(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [15:57:18] [~/workspace/kratix] [custom-quickstart-image *]
kubectl apply -f distribution/single-cluster/install-all-in-one.yaml
namespace/kratix-platform-system created
...


(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [15:57:18] [~/workspace/kratix] [custom-quickstart-image *]
-> % kubectl get pod -n kratix-platform-system kratix-platform-controller-manager-69b8bcd44c-p75k4 -o yaml | grep image
    image: syntasso.docker.scarf.sh/syntasso/kratix-platform-quickstart@sha256:701e4c83125c7e69e2db83ba36ed73701e1fc92cb3594a23954c84104aaf34b1
    imagePullPolicy: IfNotPresent
  - image: syntasso.docker.scarf.sh/syntasso/kratix-platform-quickstart@sha256:701e4c83125c7e69e2db83ba36ed73701e1fc92cb3594a23954c84104aaf34b1
    imageID: ""

(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [15:58:01] [~/workspace/kratix] [custom-quickstart-image *]
-> % pods
=================================
           PLATFORM
=================================
NAMESPACE                NAME                                                  READY   STATUS      RESTARTS   AGE
default                  minio-create-bucket-5xfjf                             0/1     Completed   0          43s
kratix-platform-system   kratix-platform-controller-manager-69b8bcd44c-p75k4   1/1     Running     0          44s
kratix-platform-system   minio-6c6bdc6456-hxb2f                                1/1     Running     0          44s

(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [15:58:02] [~/workspace/kratix] [custom-quickstart-image *]
-> % kubectl apply -f ~/workspace/kratix-marketplace/redis/promise.yaml
promise.platform.kratix.io/redis created
(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [15:58:14] [~/workspace/kratix] [custom-quickstart-image *]
-> % kubectl apply -f ~/workspace/kratix-marketplace/redis/resource-request.yaml
redis.marketplace.kratix.io/example created
(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [15:58:18] [~/workspace/kratix] [custom-quickstart-image *]
-> % pods
=================================
           PLATFORM
=================================
NAMESPACE                NAME                                                  READY   STATUS      RESTARTS   AGE
default                  kratix-redis-example-instance-configure-9a6aa-srkqz   0/1     Completed   0          6s
default                  minio-create-bucket-5xfjf                             0/1     Completed   0          80s
kratix-platform-system   kratix-platform-controller-manager-69b8bcd44c-p75k4   1/1     Running     0          81s
kratix-platform-system   kratix-redis-promise-configure-5d6fb-n6gf4            0/1     Completed   0          19s
kratix-platform-system   minio-6c6bdc6456-hxb2f                                1/1     Running     0          81s

(⎈|kind-platform:default) | jake@Jakes-MacBook-Pro-2 [15:58:39] [~/workspace/kratix] [custom-quickstart-image *]
-> % k get pod kratix-redis-example-instance-configure-9a6aa-srkqz -o yaml | grep image
    image: syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter-quickstart@sha256:98ed3239c179a4014ecfa29463c31f5c84127b2db5d4f228b44370f5ea50620c
    imagePullPolicy: IfNotPresent
    image: syntasso.docker.scarf.sh/syntasso/kratix-platform-pipeline-adapter-quickstart@sha256:98ed3239c179a4014ecfa29463c31f5c84127b2db5d4f228b44370f5ea50620c

```