### PR TITLE
Check Pipeline hash and make labels consistent when querying and updating works

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -41,6 +41,7 @@ const (
 	PromiseStatusUnavailable             = "Unavailable"
 	PromisePlural                        = "promises"
 	KratixResourceHashLabel              = "kratix.io/hash"
+	KratixPipelineHashLabel              = "kratix.io/pipeline-hash"
 	PromiseAvailableConditionType        = "Available"
 	PromiseAvailableConditionTrueReason  = "PromiseAvailable"
 	PromiseAvailableConditionFalseReason = "PromiseUnavailable"

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1043,7 +1043,7 @@ func (r *PromiseReconciler) applyWorkForStaticDependencies(o opts, promise *v1al
 		),
 	)
 
-	existingWork, err := resourceutil.GetWork(r.Client, v1alpha1.SystemNamespace, promise.GetName(), "", "")
+	existingWork, err := resourceutil.GetWork(r.Client, v1alpha1.SystemNamespace, work.GetLabels())
 	if err != nil {
 		return err
 	}
@@ -1075,7 +1075,9 @@ func (r *PromiseReconciler) applyWorkForStaticDependencies(o opts, promise *v1al
 }
 
 func (r *PromiseReconciler) deleteWorkForStaticDependencies(o opts, promise *v1alpha1.Promise) error {
-	existingWork, err := resourceutil.GetWork(r.Client, v1alpha1.SystemNamespace, promise.GetName(), "", "")
+	labels := resourceutil.GetWorkLabels(promise.GetName(), "", "", v1alpha1.WorkTypeStaticDependency)
+
+	existingWork, err := resourceutil.GetWork(r.Client, v1alpha1.SystemNamespace, labels)
 	if err != nil {
 		return err
 	}

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -288,6 +288,10 @@ func jobIsForPipeline(pipeline v1alpha1.PipelineJobResources, job *batchv1.Job) 
 		return false
 	}
 
+	if jobLabels[v1alpha1.KratixPipelineHashLabel] != pipelineLabels[v1alpha1.KratixPipelineHashLabel] {
+		return false
+	}
+
 	return jobLabels[v1alpha1.PipelineNameLabel] == pipelineLabels[v1alpha1.PipelineNameLabel]
 }
 

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -52,6 +52,7 @@ func NewOpts(ctx context.Context, client client.Client, eventRecorder record.Eve
 	}
 }
 
+// ReconcileDelete deletes Workflows.
 func ReconcileDelete(opts Opts) (bool, error) {
 	opts.logger.Info("Reconciling Delete Pipeline")
 

--- a/work-creator/pipeline/work_creator.go
+++ b/work-creator/pipeline/work_creator.go
@@ -32,7 +32,7 @@ type WorkCreator struct {
 
 func (w *WorkCreator) Execute(rootDirectory, promiseName, namespace, resourceName, workflowType, pipelineName string) error {
 	identifier := fmt.Sprintf("%s-%s-%s", promiseName, resourceName, pipelineName)
-	if workflowType == string(v1alpha1.WorkflowTypePromise) {
+	if workflowType != string(v1alpha1.WorkflowTypeResource) {
 		identifier = fmt.Sprintf("%s-%s", promiseName, pipelineName)
 	}
 	if namespace == "" {
@@ -168,14 +168,16 @@ func (w *WorkCreator) Execute(rootDirectory, promiseName, namespace, resourceNam
 		work.Labels = v1alpha1.GenerateSharedLabelsForPromise(promiseName)
 	}
 
+	workLabels := resourceutil.GetWorkLabels(promiseName, resourceName, pipelineName, workflowType)
+
 	work.SetLabels(
 		labels.Merge(
 			work.GetLabels(),
-			resourceutil.GetWorkLabels(promiseName, resourceName, pipelineName, workflowType),
+			workLabels,
 		),
 	)
 
-	currentWork, err := resourceutil.GetWork(w.K8sClient, namespace, promiseName, resourceName, pipelineName)
+	currentWork, err := resourceutil.GetWork(w.K8sClient, namespace, work.GetLabels())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For workflows that are dependant on changes outside of the promise spec, this introduced a check on the `kratix.io/pipeline-hash` label (if it is set) to determine whether and updated has been made that should result in the creation of a new job.

Additionally, this PR ensures the labels used when querying works and the same as those used when creating works.