### PR TITLE
fix: controller panics when not providing secret for bucketstatestore auth using IAM

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -61,6 +61,9 @@ resources:
   kind: BucketStateStore
   path: github.com/syntasso/kratix/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/api/v1alpha1/bucketstatestore_types.go
+++ b/api/v1alpha1/bucketstatestore_types.go
@@ -17,8 +17,15 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	AuthMethodIAM       = "IAM"
+	AuthMethodAccessKey = "accessKey"
 )
 
 // BucketStateStoreSpec defines the desired state of BucketStateStore
@@ -57,6 +64,21 @@ type BucketStateStore struct {
 
 func (b *BucketStateStore) GetSecretRef() *corev1.SecretReference {
 	return b.Spec.SecretRef
+}
+
+func (b *BucketStateStore) ValidateSecretRef() error {
+	if b.Spec.AuthMethod == AuthMethodAccessKey {
+		if b.Spec.SecretRef == nil {
+			return fmt.Errorf("spec.secretRef must be set when using authentication method accessKey")
+		}
+		if b.Spec.SecretRef.Name == "" {
+			return fmt.Errorf("spec.secretRef must contain secret name")
+		}
+		if b.Spec.SecretRef.Namespace == "" {
+			return fmt.Errorf("spec.secretRef must contain secret namespace")
+		}
+	}
+	return nil
 }
 
 func (b *BucketStateStore) GetStatus() *StateStoreStatus {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/syntasso/kratix/internal/controller"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +36,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/syntasso/kratix/internal/controller"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -300,6 +301,10 @@ func main() {
 			EventRecorder: mgr.GetEventRecorderFor("GitStateStoreController"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitStateStore")
+			os.Exit(1)
+		}
+		if err = kratixWebhook.SetupBucketStateStoreWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "BucketStateStore")
 			os.Exit(1)
 		}
 		//+kubebuilder:scaffold:builder

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -56,6 +56,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-platform-kratix-io-v1alpha1-bucketstatestore
+  failurePolicy: Fail
+  name: vbucketstatestore-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - platform.kratix.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bucketstatestores
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-platform-kratix-io-v1alpha1-destination
   failurePolicy: Fail
   name: vdestination.kb.io

--- a/internal/controller/bucketstatestore_controller.go
+++ b/internal/controller/bucketstatestore_controller.go
@@ -88,7 +88,13 @@ func (r *BucketStateStoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1alpha1.BucketStateStore{}, secretRefFieldName,
 		func(rawObj client.Object) []string {
 			stateStore := rawObj.(*v1alpha1.BucketStateStore)
-			return []string{secretRefIndexKey(stateStore.Spec.SecretRef.Name, stateStore.Spec.SecretRef.Namespace)}
+			if stateStore.Spec.AuthMethod == v1alpha1.AuthMethodAccessKey {
+				if validateErr := stateStore.ValidateSecretRef(); validateErr != nil {
+					return nil
+				}
+				return []string{secretRefIndexKey(stateStore.Spec.SecretRef.Name, stateStore.Spec.SecretRef.Namespace)}
+			}
+			return nil
 		},
 	)
 	if err != nil {

--- a/internal/controller/bucketstatestore_controller.go
+++ b/internal/controller/bucketstatestore_controller.go
@@ -84,7 +84,7 @@ func (r *BucketStateStoreReconciler) findStateStoresReferencingSecret() handler.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BucketStateStoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Create an index on the secret reference
+	// Create an index on the secret reference if auth method is access key
 	err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1alpha1.BucketStateStore{}, secretRefFieldName,
 		func(rawObj client.Object) []string {
 			stateStore := rawObj.(*v1alpha1.BucketStateStore)

--- a/internal/webhook/v1alpha1/bucketstatestore_webhook.go
+++ b/internal/webhook/v1alpha1/bucketstatestore_webhook.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -30,10 +29,8 @@ import (
 	v1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
 )
 
-// log is for logging in this package.
 var bucketstatestorelog = logf.Log.WithName("bucketstatestore-resource")
 
-// SetupBucketStateStoreWebhookWithManager registers the webhook for BucketStateStore in the manager.
 func SetupBucketStateStoreWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&v1alpha1.BucketStateStore{}).
 		WithValidator(&BucketStateStoreCustomValidator{}).
@@ -42,18 +39,13 @@ func SetupBucketStateStoreWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/validate-platform-kratix-io-v1alpha1-bucketstatestore,mutating=false,failurePolicy=fail,sideEffects=None,groups=platform.kratix.io,resources=bucketstatestores,verbs=create;update,versions=v1alpha1,name=vbucketstatestore-v1alpha1.kb.io,admissionReviewVersions=v1
 
-// BucketStateStoreCustomValidator struct is responsible for validating the BucketStateStore resource
-// when it is created, updated, or deleted.
-//
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
 type BucketStateStoreCustomValidator struct {
-	Client client.Client
 }
 
 var _ webhook.CustomValidator = &BucketStateStoreCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BucketStateStore.
 func (v *BucketStateStoreCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	bucket, ok := obj.(*v1alpha1.BucketStateStore)
 	if !ok {
@@ -68,7 +60,6 @@ func (v *BucketStateStoreCustomValidator) ValidateCreate(ctx context.Context, ob
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type BucketStateStore.
 func (v *BucketStateStoreCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	bucket, ok := newObj.(*v1alpha1.BucketStateStore)
 	if !ok {
@@ -83,7 +74,6 @@ func (v *BucketStateStoreCustomValidator) ValidateUpdate(ctx context.Context, ol
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type BucketStateStore.
 func (v *BucketStateStoreCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/internal/webhook/v1alpha1/bucketstatestore_webhook.go
+++ b/internal/webhook/v1alpha1/bucketstatestore_webhook.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 Syntasso.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/syntasso/kratix/lib/writers"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	platformv1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var bucketstatestorelog = logf.Log.WithName("bucketstatestore-resource")
+
+// SetupBucketStateStoreWebhookWithManager registers the webhook for BucketStateStore in the manager.
+func SetupBucketStateStoreWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&platformv1alpha1.BucketStateStore{}).
+		WithValidator(&BucketStateStoreCustomValidator{}).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-platform-kratix-io-v1alpha1-bucketstatestore,mutating=false,failurePolicy=fail,sideEffects=None,groups=platform.kratix.io,resources=bucketstatestores,verbs=create;update,versions=v1alpha1,name=vbucketstatestore-v1alpha1.kb.io,admissionReviewVersions=v1
+
+// BucketStateStoreCustomValidator struct is responsible for validating the BucketStateStore resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type BucketStateStoreCustomValidator struct {
+	Client client.Client
+}
+
+var _ webhook.CustomValidator = &BucketStateStoreCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type BucketStateStore.
+func (v *BucketStateStoreCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	bucket, ok := obj.(*platformv1alpha1.BucketStateStore)
+	if !ok {
+		return nil, fmt.Errorf("expected a BucketStateStore object but got %T", obj)
+	}
+	bucketstatestorelog.Info("Validation for BucketStateStore upon creation", "name", bucket.GetName())
+
+	if bucket.Spec.AuthMethod == writers.AuthMethodAccessKey {
+		if err := validateSecretRef(bucket); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}
+
+func validateSecretRef(bucket *platformv1alpha1.BucketStateStore) error {
+	if bucket.Spec.SecretRef == nil {
+		return fmt.Errorf("spec.secretRef must be set when using authentication method accessKey")
+	}
+	if bucket.Spec.SecretRef.Name == "" {
+		return fmt.Errorf("spec.secretRef must contain secret name")
+	}
+	if bucket.Spec.SecretRef.Namespace == "" {
+		return fmt.Errorf("spec.secretRef must contain secret namespace")
+	}
+	return nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type BucketStateStore.
+func (v *BucketStateStoreCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	bucket, ok := newObj.(*platformv1alpha1.BucketStateStore)
+	if !ok {
+		return nil, fmt.Errorf("expected a BucketStateStore object for the newObj but got %T", newObj)
+	}
+	bucketstatestorelog.Info("Validation for BucketStateStore upon update", "name", bucket.GetName())
+
+	if bucket.Spec.AuthMethod == writers.AuthMethodAccessKey {
+		if err := validateSecretRef(bucket); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type BucketStateStore.
+func (v *BucketStateStoreCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/internal/webhook/v1alpha1/bucketstatestore_webhook_test.go
+++ b/internal/webhook/v1alpha1/bucketstatestore_webhook_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021 Syntasso.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
+)
+
+var _ = Describe("BucketStateStore Webhook", func() {
+	var (
+		obj       *v1alpha1.BucketStateStore
+		oldObj    *v1alpha1.BucketStateStore
+		validator BucketStateStoreCustomValidator
+	)
+
+	BeforeEach(func() {
+		obj = &v1alpha1.BucketStateStore{}
+		oldObj = &v1alpha1.BucketStateStore{}
+		validator = BucketStateStoreCustomValidator{}
+		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
+		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
+		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
+	})
+
+	Context("auth method is accessKey", func() {
+		Context("create", func() {
+			It("denies creation if secretRef not set", func() {
+				obj.Spec.AuthMethod = "accessKey"
+				obj.Spec.SecretRef = nil
+				_, err := validator.ValidateCreate(context.TODO(), obj)
+				Expect(err).To(MatchError("spec.secretRef must be set when using authentication method accessKey"))
+			})
+
+			It("denies creation if secretRef is missing 'name'", func() {
+				obj.Spec.AuthMethod = "accessKey"
+				obj.Spec.SecretRef = &corev1.SecretReference{
+					Namespace: "set",
+					Name:      "",
+				}
+				_, err := validator.ValidateCreate(context.TODO(), obj)
+				Expect(err).To(MatchError("spec.secretRef must contain secret name"))
+			})
+
+			It("denies creation if secretRef is missing 'namespace'", func() {
+				obj.Spec.AuthMethod = "accessKey"
+				obj.Spec.SecretRef = &corev1.SecretReference{
+					Namespace: "",
+					Name:      "set",
+				}
+				_, err := validator.ValidateCreate(context.TODO(), obj)
+				Expect(err).To(MatchError("spec.secretRef must contain secret namespace"))
+			})
+		})
+		Context("update", func() {
+			BeforeEach(func() {
+				oldObj.Spec.AuthMethod = "accessKey"
+				oldObj.Spec.SecretRef = &corev1.SecretReference{
+					Namespace: "set",
+					Name:      "set",
+				}
+				obj.Spec.AuthMethod = "accessKey"
+			})
+
+			It("denies update if secretRef not set", func() {
+				obj.Spec.SecretRef = nil
+				_, err := validator.ValidateUpdate(context.TODO(), oldObj, obj)
+				Expect(err).To(MatchError("spec.secretRef must be set when using authentication method accessKey"))
+			})
+
+			It("denies creation if secretRef is missing 'name'", func() {
+				obj.Spec.SecretRef = &corev1.SecretReference{
+					Namespace: "set",
+					Name:      "",
+				}
+				_, err := validator.ValidateUpdate(context.TODO(), oldObj, obj)
+				Expect(err).To(MatchError("spec.secretRef must contain secret name"))
+			})
+
+			It("denies creation if secretRef is missing 'namespace'", func() {
+				obj.Spec.SecretRef = &corev1.SecretReference{
+					Namespace: "",
+					Name:      "set",
+				}
+				_, err := validator.ValidateUpdate(context.TODO(), oldObj, obj)
+				Expect(err).To(MatchError("spec.secretRef must contain secret namespace"))
+			})
+		})
+	})
+
+	Context("IAM", func() {
+		It("succeed with no secretRef", func() {
+			obj.Spec.AuthMethod = "IAM"
+			obj.Spec.SecretRef = nil
+			warnings, err := validator.ValidateCreate(context.TODO(), obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+
+			warnings, err = validator.ValidateUpdate(context.TODO(), oldObj, obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+	})
+})

--- a/internal/webhook/v1alpha1/bucketstatestore_webhook_test.go
+++ b/internal/webhook/v1alpha1/bucketstatestore_webhook_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
 	"context"
@@ -24,22 +24,23 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	v1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
+	kratixWebhook "github.com/syntasso/kratix/internal/webhook/v1alpha1"
 )
 
 var _ = Describe("BucketStateStore Webhook", func() {
 	var (
 		obj       *v1alpha1.BucketStateStore
 		oldObj    *v1alpha1.BucketStateStore
-		validator BucketStateStoreCustomValidator
+		validator kratixWebhook.BucketStateStoreCustomValidator
 	)
 
 	BeforeEach(func() {
 		obj = &v1alpha1.BucketStateStore{}
 		oldObj = &v1alpha1.BucketStateStore{}
-		validator = BucketStateStoreCustomValidator{}
-		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
-		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
-		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
+		validator = kratixWebhook.BucketStateStoreCustomValidator{}
+		Expect(validator).NotTo(BeNil())
+		Expect(oldObj).NotTo(BeNil())
+		Expect(obj).NotTo(BeNil())
 	})
 
 	Context("auth method is accessKey", func() {

--- a/internal/webhook/v1alpha1/bucketstatestore_webhook_test.go
+++ b/internal/webhook/v1alpha1/bucketstatestore_webhook_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BucketStateStore Webhook", func() {
 				Expect(err).To(MatchError("spec.secretRef must be set when using authentication method accessKey"))
 			})
 
-			It("denies creation if secretRef is missing 'name'", func() {
+			It("denies update if secretRef is missing 'name'", func() {
 				obj.Spec.SecretRef = &corev1.SecretReference{
 					Namespace: "set",
 					Name:      "",
@@ -97,7 +97,7 @@ var _ = Describe("BucketStateStore Webhook", func() {
 				Expect(err).To(MatchError("spec.secretRef must contain secret name"))
 			})
 
-			It("denies creation if secretRef is missing 'namespace'", func() {
+			It("denies update if secretRef is missing 'namespace'", func() {
 				obj.Spec.SecretRef = &corev1.SecretReference{
 					Namespace: "",
 					Name:      "set",


### PR DESCRIPTION
## Context 

closes #461 

This PR introduces a webhook for BucketStateStore ensuring a secret is provided when auth method is set to `accessKey`.

It fixes bucket state store with IAM auth method by not assuming secrets are always provided when building a secret index to watch. See the below panics for reference

```
E0515 09:08:52.027744       1 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
	goroutine 120 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x218f700, 0x3509e60}, {0x1a96820, 0x3476300})
		/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/runtime/runtime.go:107 +0x98
```

### To test
Iam with no secret provided does not panic
```
apiVersion: platform.kratix.io/v1alpha1
kind: BucketStateStore
metadata:
  name: iam
spec:
  authMethod: IAM
  bucketName: kratix
  endpoint: blah
  insecure: true

2025-05-15T11:18:41Z	INFO	bucketstatestore-resource	Validation for BucketStateStore upon creation	{"name": "iam"}
2025-05-15T11:18:41Z	INFO	controllers.BucketStateStoreController	Reconciling BucketStateStore	{"bucketStateStore": {"name":"iam"}, "requestName": "iam"}
2025-05-15T11:18:41Z	INFO	controllers.BucketStateStoreController.writers.BucketStateStoreWriter	setting up s3 client	{"bucketStateStore": {"name":"iam"}, "authMethod": "IAM", "endpoint": "blah", "insecure": true}
 ```

Missing secretRef when using `accessKey` will get validation error from webhook
```bash
apiVersion: platform.kratix.io/v1alpha1
kind: BucketStateStore
metadata:
  name: access
spec:
  authMethod: accessKey
  bucketName: kratix
  endpoint: minio.kratix-platform-system.svc.cluster.local

❯ k apply -f statestore.yaml
Error from server (Forbidden): error when creating "panic-statestore.yaml": admission webhook "vbucketstatestore-v1alpha1.kb.io" denied the request: spec.secretRef must be set when using authentication method accessKey

```