### PR TITLE
fix: update promise requirements when promise unavailable

### DIFF
--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -165,14 +165,15 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	promise.Status.Status = v1alpha1.PromiseStatusUnavailable
 	updateConditionOnPromise(promise, promiseUnavailableStatusCondition(metav1.Time{Time: time.Now()}))
 	requirementsChanged := r.hasPromiseRequirementsChanged(ctx, promise)
-
-	if requirementsChanged && originalStatus == v1alpha1.PromiseStatusAvailable {
+	if requirementsChanged {
 		if result, statusUpdateErr := r.updatePromiseStatus(ctx, promise); statusUpdateErr != nil || !result.IsZero() {
 			return result, statusUpdateErr
 		}
-		r.EventRecorder.Eventf(
-			promise, "Warning", "Unavailable", "Promise no longer available: %s",
-			"Requirements have changed")
+		if originalStatus == v1alpha1.PromiseStatusAvailable {
+			r.EventRecorder.Eventf(
+				promise, "Warning", "Unavailable", "Promise no longer available: %s",
+				"Requirements have changed")
+		}
 
 		logger.Info("Requeueing: requirements changed")
 		return ctrl.Result{}, nil


### PR DESCRIPTION
## Context

closes #431

The previous check is wrong for promise with original status unavailable. 
`if requirementsChanged && originalStatus == v1alpha1.PromiseStatusAvailable` 
Requirements can change but it will never get updated since compound promise with missing required promises never becomes `available`.

To verify the fix, you can:
```
k apply -f ~/workspace/kratix-marketplace/app-as-a-service/promise.yaml
k apply -f ~/workspace/kratix-marketplace/app-as-a-service/promises/postgresql-promise-release.yaml
```

Then wait for postgresql to be available, and
```
k get promises app -oyaml
apiVersion: platform.kratix.io/v1alpha1
kind: Promise
metadata:
  annotations:
...
status:
  apiVersion: marketplace.kratix.io/v1
  conditions:
  - lastTransitionTime: "2025-05-16T15:54:46Z"
    message: Cannot fulfil resource requests
    reason: PromiseUnavailable
    status: "False"
    type: Available
  - lastTransitionTime: "2025-05-16T15:54:46Z"
    message: Requirements not fulfilled
    reason: RequirementsNotInstalled
    status: "False"
    type: RequirementsFulfilled
  kind: app
  requiredPromises:
  - name: postgresql
    state: Requirement installed
    version: v1.0.0-beta.1
  - name: nginx-ingress
    state: Requirement not installed
    version: v1.0.0-beta.1
  status: Unavailable
```

You can repeat the above steps against main and observed that both requirements are marked as not installed.
