### PR TITLE
chore: remove unnecessary pointer reference/dereference

### DIFF
--- a/internal/webhook/v1alpha1/promise_webhook_test.go
+++ b/internal/webhook/v1alpha1/promise_webhook_test.go
@@ -382,8 +382,8 @@ func randomString(length int) string {
 func setPipeline(promise *v1alpha1.Promise, pipeline v1alpha1.Pipeline) {
 	objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pipeline)
 	Expect(err).NotTo(HaveOccurred())
-	unstructuredPipeline := &unstructured.Unstructured{Object: objMap}
+	unstructuredPipeline := unstructured.Unstructured{Object: objMap}
 	unstructuredPipeline.SetAPIVersion("platform.kratix.io/v1alpha1")
 	unstructuredPipeline.SetKind("Pipeline")
-	promise.Spec.Workflows.Resource.Configure = []unstructured.Unstructured{*unstructuredPipeline}
+	promise.Spec.Workflows.Resource.Configure = []unstructured.Unstructured{unstructuredPipeline}
 }


### PR DESCRIPTION
Value syntax is simpler, more concise, and does the same thing