### PR TITLE
chore: replace deprecated golang.org/x/exp/rand with math/rand/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.1
 	k8s.io/apiextensions-apiserver v0.32.1
@@ -102,6 +101,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect

--- a/internal/webhook/v1alpha1/promise_webhook_test.go
+++ b/internal/webhook/v1alpha1/promise_webhook_test.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
+	"math/rand/v2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"golang.org/x/exp/rand"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
@@ -198,7 +197,7 @@ var _ = Describe("PromiseWebhook", func() {
 			It("returns an error it is too long", func() {
 				pipeline := v1alpha1.Pipeline{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: randomString(maxLimit + 1),
+						Name: randomishString(maxLimit + 1),
 					},
 				}
 				objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pipeline)
@@ -216,7 +215,7 @@ var _ = Describe("PromiseWebhook", func() {
 			It("succeeds when it is within the character limit", func() {
 				pipeline := v1alpha1.Pipeline{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: randomString(maxLimit),
+						Name: randomishString(maxLimit),
 					},
 				}
 				objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pipeline)
@@ -372,11 +371,13 @@ var _ = Describe("PromiseWebhook", func() {
 	})
 })
 
-func randomString(length int) string {
-	rand.Seed(uint64(time.Now().UnixNano()))
-	b := make([]byte, length+2)
-	rand.Read(b)
-	return fmt.Sprintf("%x", b)[2 : length+2]
+func randomishString(length int) string {
+	bufLen := 1 + length>>1 // half of length plus 1
+	buf := make([]byte, bufLen)
+	for i := range bufLen {
+		buf[i] = byte(rand.IntN(255))
+	}
+	return fmt.Sprintf("%x", buf)[:length]
 }
 
 func setPipeline(promise *v1alpha1.Promise, pipeline v1alpha1.Pipeline) {


### PR DESCRIPTION
The package golang.org/x/exp/rand is deprecated and no longer maintained, so it makes sense to move to the recommeded replacement of math/rand/v2

The function "randomString()" was renamed to "randomishString()" to make it crystal clear that it's not cryptographically random.