### PR TITLE
Add default printer columns for resource requests

### DIFF
--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -982,9 +982,19 @@ func setStatusFieldsOnCRD(rrCRD *apiextensionsv1.CustomResourceDefinition) {
 		if len(rrCRD.Spec.Versions[i].AdditionalPrinterColumns) == 0 {
 			rrCRD.Spec.Versions[i].AdditionalPrinterColumns = []apiextensionsv1.CustomResourceColumnDefinition{
 				{
-					Name:     "status",
+					Name:     "WORKFLOWS",
+					Type:     "string",
+					JSONPath: ".status.workflows",
+				},
+				{
+					Name:     "MESSAGE",
 					Type:     "string",
 					JSONPath: ".status.message",
+				},
+				{
+					Name:     "STATUS",
+					Type:     "string",
+					JSONPath: ".status.conditions[?(@.type==\"Ready\")].message",
 				},
 			}
 		}
@@ -997,6 +1007,18 @@ func setStatusFieldsOnCRD(rrCRD *apiextensionsv1.CustomResourceDefinition) {
 					Type: "string",
 				},
 				"observedGeneration": {
+					Type:   "integer",
+					Format: "int64",
+				},
+				"workflows": {
+					Type:   "integer",
+					Format: "int64",
+				},
+				"workflowsSucceeded": {
+					Type:   "integer",
+					Format: "int64",
+				},
+				"workflowsFailed": {
 					Type:   "integer",
 					Format: "int64",
 				},

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -1125,10 +1125,13 @@ var _ = Describe("PromiseController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(crd.Spec.Versions).To(HaveLen(1))
 
-				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns).To(HaveLen(1))
-				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[0].Name).To(Equal("status"))
-				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[0].Type).To(Equal("string"))
-				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[0].JSONPath).To(Equal(".status.message"))
+				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns).To(HaveLen(3))
+				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[0].Name).To(Equal("WORKFLOWS"))
+				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[0].JSONPath).To(Equal(".status.workflows"))
+				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[1].Name).To(Equal("MESSAGE"))
+				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[1].JSONPath).To(Equal(".status.message"))
+				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[2].Name).To(Equal("STATUS"))
+				Expect(crd.Spec.Versions[0].AdditionalPrinterColumns[2].JSONPath).To(Equal(".status.conditions[?(@.type==\"Ready\")].message"))
 			})
 		})
 


### PR DESCRIPTION
## Summary
- add WORKFLOWS, MESSAGE and STATUS printer columns to resource request CRDs
- expand status schema for workflow fields
- update tests to reflect new printer columns

## Testing
- `make fmt vet` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_b_68404ba8346c8322908ab585cff360a4