### PR TITLE
chore: use error wrapping from standard library

### DIFF
--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/syntasso/kratix/lib/hash"
 	"github.com/syntasso/kratix/lib/objectutil"
 	batchv1 "k8s.io/api/batch/v1"
@@ -102,7 +101,7 @@ func (p *PipelineFactory) configMap(workloadGroupScheduling []WorkloadGroupSched
 	}
 	schedulingYAML, err := yaml.Marshal(workloadGroupScheduling)
 	if err != nil {
-		return nil, errors.Wrap(err, "error marshalling destinationSelectors to yaml")
+		return nil, fmt.Errorf("error marshalling destinationSelectors to yaml: %w", err)
 	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/minio/minio-go/v7 v7.0.68
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
-	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.27.0
 	k8s.io/api v0.32.1
 	k8s.io/apiextensions-apiserver v0.32.1
@@ -78,6 +77,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect


### PR DESCRIPTION
The standard library supplies the `fmt.Errorf()` function to wrap errors, so there's no need to import the `github.com/pkg/errors` package purely for error wrapping.