### PR TITLE
Add golangci-lint install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,8 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-lint: # Lint with required config
-	golangci-lint run --config=.golangci-required.yml
+lint: golangci-lint # Lint with required config
+	$(GOLANGCI_LINT) run --config=.golangci-required.yml
 
 lint-all: # Lint with full config
 	golangci-lint run --config=.golangci.yml
@@ -290,10 +290,12 @@ GINKGO = github.com/onsi/ginkgo/v2/ginkgo
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
+GOLANGCI_LINT_VERSION ?= v1.63.4
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -305,6 +307,11 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary


### PR DESCRIPTION
## Summary
- install golangci-lint locally via Makefile
- ensure `make lint` installs the linter before running

## Testing
- `make golangci-lint --dry-run`
- `make lint --dry-run`

------
https://chatgpt.com/codex/tasks/task_b_6841604ab80c8322984dcc64a7c24bbe