### PR TITLE
Add workflow status integration

### DIFF
--- a/api/v1alpha1/promise_ready_test.go
+++ b/api/v1alpha1/promise_ready_test.go
@@ -1,0 +1,87 @@
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	platformv1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
+	"github.com/syntasso/kratix/lib/resourceutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type readyCase struct {
+	conditions      []metav1.Condition
+	workflowsFailed int64
+	expectedStatus  metav1.ConditionStatus
+	expectedMessage string
+}
+
+var _ = Describe("Promise ComputeReadyCondition", func() {
+	DescribeTable("derives the Ready condition", func(rc readyCase) {
+		p := &platformv1alpha1.Promise{}
+		p.Status.Conditions = rc.conditions
+		p.Status.WorkflowsFailed = rc.workflowsFailed
+		cond := p.ComputeReadyCondition()
+		Expect(cond.Status).To(Equal(rc.expectedStatus))
+		Expect(cond.Message).To(Equal(rc.expectedMessage))
+	},
+		Entry("no conditions present", readyCase{
+			expectedStatus:  metav1.ConditionFalse,
+			expectedMessage: "Pending",
+		}),
+		Entry("configure workflow incomplete", readyCase{
+			conditions: []metav1.Condition{{
+				Type:   string(resourceutil.ConfigureWorkflowCompletedCondition),
+				Status: metav1.ConditionFalse,
+			}},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedMessage: "Pending",
+		}),
+		Entry("workflow failed", readyCase{
+			conditions: []metav1.Condition{
+				{Type: string(resourceutil.ConfigureWorkflowCompletedCondition), Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseRequirementsFulfilledType, Status: metav1.ConditionTrue},
+			},
+			workflowsFailed: 1,
+			expectedStatus:  metav1.ConditionFalse,
+			expectedMessage: "Failing",
+		}),
+		Entry("works not succeeded", readyCase{
+			conditions: []metav1.Condition{
+				{Type: string(resourceutil.ConfigureWorkflowCompletedCondition), Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseRequirementsFulfilledType, Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseWorksSucceededConditionType, Status: metav1.ConditionFalse},
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedMessage: "Failing",
+		}),
+		Entry("works unknown", readyCase{
+			conditions: []metav1.Condition{
+				{Type: string(resourceutil.ConfigureWorkflowCompletedCondition), Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseRequirementsFulfilledType, Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseWorksSucceededConditionType, Status: metav1.ConditionUnknown},
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedMessage: "Pending",
+		}),
+		Entry("misplaced resources", readyCase{
+			conditions: []metav1.Condition{
+				{Type: string(resourceutil.ConfigureWorkflowCompletedCondition), Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseRequirementsFulfilledType, Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseWorksSucceededConditionType, Status: metav1.ConditionTrue},
+				{Type: "ResourcesMisplaced", Status: metav1.ConditionTrue, Reason: "Misplaced", Message: "Misplaced"},
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedMessage: "Misplaced",
+		}),
+		Entry("all success", readyCase{
+			conditions: []metav1.Condition{
+				{Type: string(resourceutil.ConfigureWorkflowCompletedCondition), Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseRequirementsFulfilledType, Status: metav1.ConditionTrue},
+				{Type: platformv1alpha1.PromiseWorksSucceededConditionType, Status: metav1.ConditionTrue},
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedMessage: "Requested",
+		}),
+	)
+})

--- a/config/crd/bases/platform.kratix.io_promises.yaml
+++ b/config/crd/bases/platform.kratix.io_promises.yaml
@@ -17,7 +17,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
     - jsonPath: .status.kind
@@ -224,6 +224,15 @@ spec:
                 type: string
               version:
                 type: string
+              workflows:
+                format: int64
+                type: integer
+              workflowsFailed:
+                format: int64
+                type: integer
+              workflowsSucceeded:
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -153,6 +153,14 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("Error converting Promise to Unstructured: %w", err)
 	}
 
+	expected := promise.TotalWorkflows()
+	if promise.Status.Workflows != expected {
+		promise.Status.Workflows = expected
+		if result, err := r.updatePromiseStatus(ctx, promise); err != nil || !result.IsZero() {
+			return result, err
+		}
+	}
+
 	if value, found := promise.Labels[v1alpha1.PromiseVersionLabel]; found {
 		if promise.Status.Version != value {
 			promise.Status.Version = value

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -50,6 +50,7 @@ func MarkConfigureWorkflowAsRunning(logger logr.Logger, obj *unstructured.Unstru
 }
 
 func MarkConfigureWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstructured, failedPipeline string) {
+	IncrementStatusInt(obj, "workflowsFailed")
 	SetCondition(obj, &clusterv1.Condition{
 		Type:               ConfigureWorkflowCompletedCondition,
 		Status:             v1.ConditionFalse,
@@ -61,6 +62,7 @@ func MarkConfigureWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstruc
 }
 
 func MarkDeleteWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstructured) {
+	IncrementStatusInt(obj, "workflowsFailed")
 	condition := clusterv1.Condition{
 		Type:               DeleteWorkflowCompletedCondition,
 		Status:             v1.ConditionFalse,
@@ -201,6 +203,15 @@ func SetStatus(rr *unstructured.Unstructured, logger logr.Logger, statuses ...in
 	if err != nil {
 		logger.Info("failed to set status; ignoring", "map", nestedMap)
 	}
+}
+
+// IncrementStatusInt increments the given integer status field by one.
+func IncrementStatusInt(obj *unstructured.Unstructured, key string) {
+	current, found, err := unstructured.NestedInt64(obj.Object, "status", key)
+	if err != nil || !found {
+		current = 0
+	}
+	unstructured.SetNestedField(obj.Object, current+1, "status", key)
 }
 
 func GetStatus(rr *unstructured.Unstructured, key string) string {

--- a/lib/resourceutil/util_test.go
+++ b/lib/resourceutil/util_test.go
@@ -430,6 +430,20 @@ var _ = Describe("Conditions", func() {
 			})
 		})
 	})
+
+	Describe("MarkConfigureWorkflowAsFailed", func() {
+		It("increments workflowsFailed", func() {
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+			resourceutil.MarkConfigureWorkflowAsFailed(logger, obj, "pipe")
+			val, found, err := unstructured.NestedInt64(obj.Object, "status", "workflowsFailed")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal(int64(1)))
+			resourceutil.MarkConfigureWorkflowAsFailed(logger, obj, "pipe")
+			val, _, _ = unstructured.NestedInt64(obj.Object, "status", "workflowsFailed")
+			Expect(val).To(Equal(int64(2)))
+		})
+	})
 })
 
 func markWorkflowAsCompleted(obj *unstructured.Unstructured) {

--- a/work-creator/pipeline/lib/status_updater.go
+++ b/work-creator/pipeline/lib/status_updater.go
@@ -39,6 +39,18 @@ func MarkAsCompleted(status map[string]any) map[string]any {
 	}
 
 	status["conditions"] = updateConditions(existingConditions, newCondition)
+
+	switch v := status["workflowsSucceeded"].(type) {
+	case int:
+		status["workflowsSucceeded"] = v + 1
+	case int64:
+		status["workflowsSucceeded"] = v + 1
+	case float64:
+		status["workflowsSucceeded"] = int(v) + 1
+	default:
+		status["workflowsSucceeded"] = 1
+	}
+
 	return status
 }
 

--- a/work-creator/pipeline/lib/status_updater_test.go
+++ b/work-creator/pipeline/lib/status_updater_test.go
@@ -147,5 +147,16 @@ var _ = Describe("StatusUpdater", func() {
 				))
 			})
 		})
+
+		It("increments workflowsSucceeded", func() {
+			status := map[string]any{"workflowsSucceeded": 2}
+			result := lib.MarkAsCompleted(status)
+			Expect(result).To(HaveKeyWithValue("workflowsSucceeded", BeEquivalentTo(3)))
+		})
+
+		It("initializes workflowsSucceeded if missing", func() {
+			result := lib.MarkAsCompleted(map[string]any{})
+			Expect(result).To(HaveKeyWithValue("workflowsSucceeded", BeEquivalentTo(1)))
+		})
 	})
 })


### PR DESCRIPTION
## Summary
- add TotalWorkflows helper on Promise
- populate workflow count in Promise reconciler
- track workflow failures and successes in util helpers
- increment workflowsSucceeded via status updater
- test workflow progress helpers

## Testing
- `make fmt`
- `make manifests`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_6841693f05d08322bb3f7ed5c561da5c