### PR TITLE
revert: "chore: consolidate on a single YAML parser (#485)"

### DIFF
--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/syntasso/kratix/lib/hash"
 	"github.com/syntasso/kratix/lib/objectutil"
+	"gopkg.in/yaml.v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/yaml"
 )
 
 type PipelineFactory struct {

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -1745,7 +1745,7 @@ func matchConfigureConfigmap(c *corev1.ConfigMap, factory *v1alpha1.PipelineFact
 	ExpectWithOffset(1, c.Data).To(
 		HaveKeyWithValue(
 			"destinationSelectors",
-			"- matchLabels:\n    label: value\n  source: promise\n- matchLabels:\n    another-label: another-value\n  source: promise\n"))
+			"- matchlabels:\n    label: value\n  source: promise\n- matchlabels:\n    another-label: another-value\n  source: promise\n"))
 }
 
 func promiseHash(promise *v1alpha1.Promise) string {

--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -299,18 +299,16 @@ func (p *Promise) GenerateFullAccessForRR(group, rrPluralName string) []rbacv1.P
 }
 
 func (d Dependencies) Marshal() ([]byte, error) {
-	var buf bytes.Buffer
+	buf := new(bytes.Buffer)
+	encoder := yaml.NewEncoder(buf)
 	for _, workload := range d {
-		data, err := yaml.Marshal(workload.Object)
+		err := encoder.Encode(workload.Object)
 		if err != nil {
-			return nil, err
-		}
-		if _, err := buf.Write(data); err != nil {
 			return nil, err
 		}
 	}
 
-	return io.ReadAll(&buf)
+	return io.ReadAll(buf)
 }
 
 func (p *Promise) GetCondition(conditionType string) *metav1.Condition {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	go.uber.org/zap v1.27.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.1
 	k8s.io/apiextensions-apiserver v0.32.1
 	k8s.io/apimachinery v0.32.1

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,7 @@ gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -127,7 +127,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				Expect(configMap.Data).To(HaveKey("destinationSelectors"))
 				space := regexp.MustCompile(`\s+`)
 				destinationSelectors := space.ReplaceAllString(configMap.Data["destinationSelectors"], " ")
-				Expect(strings.TrimSpace(destinationSelectors)).To(Equal(`- matchLabels: environment: dev source: promise`))
+				Expect(strings.TrimSpace(destinationSelectors)).To(Equal(`- matchlabels: environment: dev source: promise`))
 			})
 
 			By("not requeuing, since the controller is watching the job", func() {

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -558,7 +558,7 @@ var _ = Describe("PromiseController", func() {
 						Expect(configMap.Data).To(HaveKey("destinationSelectors"))
 						space := regexp.MustCompile(`\s+`)
 						destinationSelectors := space.ReplaceAllString(configMap.Data["destinationSelectors"], " ")
-						Expect(strings.TrimSpace(destinationSelectors)).To(Equal(`- matchLabels: environment: dev source: promise`))
+						Expect(strings.TrimSpace(destinationSelectors)).To(Equal(`- matchlabels: environment: dev source: promise`))
 					})
 
 					promiseResourcesName.Namespace = ""

--- a/internal/controller/workplacement_controller.go
+++ b/internal/controller/workplacement_controller.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,7 +34,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/yaml"
 
 	"github.com/syntasso/kratix/api/v1alpha1"
 	"github.com/syntasso/kratix/lib/compression"

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/syntasso/kratix/api/v1alpha1"
 	"github.com/syntasso/kratix/lib/resourceutil"
+	"gopkg.in/yaml.v2"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 )
 
 type Opts struct {


### PR DESCRIPTION
## Context

This reverts commit 5d6864a21ba9a4c594e767809eb23ba810fb3f84.

The recent change to our yaml parser resulted in malformat dependencies:
```
...
  workflows: # taken from state store
    resource:
      configure:
      - apiVersion: platform.kratix.io/v1alpha1
        kind: Pipeline
        metadata:
          name: instance-configure
          namespace: default
        spec:
          containers:
          - image: syntasso/demo-nginx-configure-pipeline:v0.1.1
            name: demo-nginx-configure-pipeline
status: {} # there should be '---' below this line
apiVersion: platform.kratix.io/v1alpha1
kind: Promise
metadata:
  name: postgresql
  namespace: default
spec:
  api:
    apiVersion: apiextensions.k8s.io/v1
    kind: CustomResourceDefinition
    metadata:
      name: postgresqls.marketplace.kratix.io
    spec:
      group: marketplace.kratix.io
...
```

The above can be reproduced by applying easy-app `k apply -f samples/easy-app/promise.yaml` and then check the resulted dependencies in state store.