### PR TITLE
chore: remove duplicated envvars from reader container

### DIFF
--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -181,17 +181,12 @@ func (p *PipelineFactory) defaultEnvVars() []corev1.EnvVar {
 }
 
 func (p *PipelineFactory) readerContainer() corev1.Container {
-	envVars := []corev1.EnvVar{
-		{Name: KratixWorkflowType, Value: string(p.WorkflowType)},
-		{Name: KratixCrdPlural, Value: p.CRDPlural},
-		{Name: KratixClusterScoped, Value: fmt.Sprintf("%t", p.ClusterScoped)},
-	}
 
 	return corev1.Container{
 		Name:    "reader",
 		Image:   os.Getenv("PIPELINE_ADAPTER_IMG"),
 		Command: []string{"sh", "-c", "reader"},
-		Env:     append(p.defaultEnvVars(), envVars...),
+		Env:     p.defaultEnvVars(),
 		VolumeMounts: []corev1.VolumeMount{
 			{MountPath: "/kratix/input", Name: "shared-input"},
 			{MountPath: "/kratix/output", Name: "shared-output"},

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -702,7 +702,6 @@ var _ = Describe("Pipeline", func() {
 					{Name: "KRATIX_WORKFLOW_ACTION", Value: "configure"},
 					{Name: "KRATIX_PROMISE_NAME", Value: "promiseName"},
 					{Name: "KRATIX_PIPELINE_NAME", Value: "pipelineName"},
-					{Name: "KRATIX_WORKFLOW_TYPE", Value: "fakeType"},
 				}
 
 				if isResourceWorkflow {
@@ -712,8 +711,6 @@ var _ = Describe("Pipeline", func() {
 						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: resourceRequest.GroupVersionKind().Version},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_NAMESPACE", Value: resourceRequest.GetNamespace()},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_KIND", Value: "promisecrd"},
-						corev1.EnvVar{Name: "KRATIX_CRD_PLURAL", Value: "promiseCrdPlural"},
-						corev1.EnvVar{Name: "KRATIX_CLUSTER_SCOPED", Value: "false"},
 					)
 				} else {
 					expectedEnvVars = append(expectedEnvVars,
@@ -722,8 +719,6 @@ var _ = Describe("Pipeline", func() {
 						corev1.EnvVar{Name: "KRATIX_OBJECT_VERSION", Value: promise.GroupVersionKind().Version},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_NAMESPACE", Value: ""},
 						corev1.EnvVar{Name: "KRATIX_OBJECT_KIND", Value: promise.GroupVersionKind().Kind},
-						corev1.EnvVar{Name: "KRATIX_CRD_PLURAL", Value: "promises"},
-						corev1.EnvVar{Name: "KRATIX_CLUSTER_SCOPED", Value: "true"},
 					)
 				}
 


### PR DESCRIPTION
## Context

`KRATIX_WORKFLOW_TYPE`, `KRATIX_CRD_PLURAL`, and `KRATIX_CLUSTER_SCOPED` were set twice in the reader container. This has caused a flood of warning logs:
```
2025-06-06T14:04:30Z	INFO	promise-webhook	default
2025-06-06T14:04:30Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:30Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:30Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
2025-06-06T14:04:30Z	INFO	promise-webhook	default
2025-06-06T14:04:30Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:30Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:30Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
2025-06-06T14:04:39Z	INFO	promise-webhook	default
2025-06-06T14:04:39Z	INFO	promise-webhook	default
2025-06-06T14:04:39Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:39Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:39Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
2025-06-06T14:04:40Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:40Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:40Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
2025-06-06T14:04:48Z	INFO	promise-webhook	default
2025-06-06T14:04:48Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:48Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:48Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
2025-06-06T14:04:48Z	INFO	promise-webhook	default
2025-06-06T14:04:48Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:48Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:48Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
2025-06-06T14:04:57Z	INFO	promise-webhook	default
2025-06-06T14:04:57Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:57Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:57Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
2025-06-06T14:04:57Z	INFO	promise-webhook	default
2025-06-06T14:04:58Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[11]: hides previous definition of "KRATIX_WORKFLOW_TYPE", which may be dropped when using apply
2025-06-06T14:04:58Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[12]: hides previous definition of "KRATIX_CRD_PLURAL", which may be dropped when using apply
2025-06-06T14:04:58Z	INFO	KubeAPIWarningLogger	spec.template.spec.initContainers[0].env[13]: hides previous definition of "KRATIX_CLUSTER_SCOPED", which may be dropped when using apply
```

Why was this not caught by test? Because the test was wrong and expecting duplicated env vars.