### PR TITLE
chore: do not return error when requeue is set

### DIFF
--- a/internal/controller/workplacement_controller.go
+++ b/internal/controller/workplacement_controller.go
@@ -349,7 +349,7 @@ func (r *WorkPlacementReconciler) writeToStateStore(wp *v1alpha1.WorkPlacement, 
 		if statusUpdateErr := r.setWriteFailStatusConditions(opts.ctx, wp, err); statusUpdateErr != nil {
 			opts.logger.Error(statusUpdateErr, "failed to update status condition")
 		}
-		return "", defaultRequeue, err
+		return "", defaultRequeue, nil
 	}
 	r.publishWriteEvent(wp, "WorkloadsWrittenToStateStore", versionID, err)
 
@@ -363,7 +363,7 @@ func (r *WorkPlacementReconciler) writeToStateStore(wp *v1alpha1.WorkPlacement, 
 	if apiMeta.SetStatusCondition(&wp.Status.Conditions, cond) {
 		if statusUpdateErr := r.Client.Status().Update(opts.ctx, wp); statusUpdateErr != nil {
 			opts.logger.Error(statusUpdateErr, "failed to update status condition")
-			return "", defaultRequeue, statusUpdateErr
+			return "", defaultRequeue, nil
 		}
 	}
 	return versionID, ctrl.Result{}, err


### PR DESCRIPTION
## Context

When returned error is not nil, the requeue time is ignored and request will be requeued immediate (given it hasn't reached exponential backoff yet). controller-runtime will also give you a warning if you are running error and requeue at the same time:

```
2025-06-03T09:22:03Z    INFO    Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler        {"controller": "workplacement", "controllerGroup": "[platform.kratix.io](http://platform.kratix.io/)", "controllerKind": "WorkPlacement", ...
```