### PR TITLE
chore: increase timeout for core-test

### DIFF
--- a/test/core/core_test.go
+++ b/test/core/core_test.go
@@ -282,6 +282,7 @@ var _ = Describe("Core Tests", Ordered, func() {
 				})
 
 				By("rerunning the resource configure pipeline", func() {
+					// Increased timeout to prevent test failures caused by flux waits
 					Eventually(func(g Gomega) {
 						g.Expect(worker.Kubectl("get", "namespaces")).To(ContainSubstring(rrNsNameUpdated))
 						g.Expect(worker.Kubectl(append(cmArgs, rrConfigMapName+"-1", "-o=jsonpath={.data.timestamp}")...)).ToNot(Equal(originalTimeStampW1))


### PR DESCRIPTION
This is done to prevent CI failures caused by flux waits.