### PR TITLE
fix: work creator workflow type matching on prefix

### DIFF
--- a/work-creator/pipeline/work_creator.go
+++ b/work-creator/pipeline/work_creator.go
@@ -33,7 +33,7 @@ type WorkCreator struct {
 
 func (w *WorkCreator) Execute(rootDirectory, promiseName, namespace, resourceName, workflowType, pipelineName string) error {
 	identifier := fmt.Sprintf("%s-%s-%s", promiseName, resourceName, pipelineName)
-	if workflowType != string(v1alpha1.WorkflowTypeResource) {
+	if !strings.HasPrefix(workflowType, string(v1alpha1.WorkflowTypeResource)) {
 		identifier = fmt.Sprintf("%s-%s", promiseName, pipelineName)
 	}
 	if namespace == "" {


### PR DESCRIPTION
## Context

Match on prefix, similar to what work creator is doing in the rest of its function already.