### PR TITLE
fix(#525): stop writing a test file to check perms

### DIFF
--- a/internal/controller/destination_controller_test.go
+++ b/internal/controller/destination_controller_test.go
@@ -169,7 +169,7 @@ var _ = Describe("DestinationReconciler", func() {
 							)))
 						})
 
-						It("does not create any test files", func() {
+						It("only creates canary files", func() {
 							Expect(fakeWriter.UpdateFilesCallCount()).To(Equal(2))
 							dir, workPlacementName, workloadsToCreate, workloadsToDelete := fakeWriter.UpdateFilesArgsForCall(0)
 							Expect(dir).To(Equal(""))

--- a/internal/controller/shared.go
+++ b/internal/controller/shared.go
@@ -26,17 +26,17 @@ const (
 	removeAllWorkflowJobsFinalizer = v1alpha1.KratixPrefix + "workflows-cleanup"
 	runDeleteWorkflowsFinalizer    = v1alpha1.KratixPrefix + "delete-workflows"
 	// DefaultReconciliationInterval is the interval on which the workflows will be re-run.
-	DefaultReconciliationInterval                    = time.Hour * 10
-	secretRefFieldName                               = "secretRef"
-	StatusNotReady                                   = "NotReady"
-	StatusReady                                      = "Ready"
-	StateStoreReadyConditionType                     = "Ready"
-	StateStoreReadyConditionReason                   = "StateStoreReady"
-	StateStoreReadyConditionMessage                  = "State store is ready"
-	StateStoreNotReadyErrorInitialisingWriterReason  = "ErrorInitialisingWriter"
-	StateStoreNotReadyErrorInitialisingWriterMessage = "Error initialising writer"
-	StateStoreNotReadyErrorWritingTestFileReason     = "ErrorWritingTestFile"
-	StateStoreNotReadyErrorWritingTestFileMessage    = "Error writing test file"
+	DefaultReconciliationInterval                       = time.Hour * 10
+	secretRefFieldName                                  = "secretRef"
+	StatusNotReady                                      = "NotReady"
+	StatusReady                                         = "Ready"
+	StateStoreReadyConditionType                        = "Ready"
+	StateStoreReadyConditionReason                      = "StateStoreReady"
+	StateStoreReadyConditionMessage                     = "State store is ready"
+	StateStoreNotReadyErrorInitialisingWriterReason     = "ErrorInitialisingWriter"
+	StateStoreNotReadyErrorInitialisingWriterMessage    = "Error initialising writer"
+	StateStoreNotReadyErrorValidatingPermissionsReason  = "ErrorValidatingPermissions"
+	StateStoreNotReadyErrorValidatingPermissionsMessage = "Error validating state store permissions"
 )
 
 var (

--- a/lib/writers/s3_test.go
+++ b/lib/writers/s3_test.go
@@ -139,7 +139,5 @@ var _ = Describe("S3", func() {
 				Expect(err).To(MatchError("unknown authMethod: foo"))
 			})
 		})
-
 	})
-
 })

--- a/lib/writers/statestore_writer.go
+++ b/lib/writers/statestore_writer.go
@@ -12,6 +12,7 @@ import (
 type StateStoreWriter interface {
 	UpdateFiles(subDir string, workPlacementName string, workloadsToCreate []v1alpha1.Workload, workloadsToDelete []string) (string, error)
 	ReadFile(filename string) ([]byte, error)
+	ValidatePermissions() error
 }
 
 var ErrFileNotFound = fmt.Errorf("file not found")

--- a/lib/writers/writersfakes/fake_state_store_writer.go
+++ b/lib/writers/writersfakes/fake_state_store_writer.go
@@ -38,6 +38,16 @@ type FakeStateStoreWriter struct {
 		result1 string
 		result2 error
 	}
+	ValidatePermissionsStub        func() error
+	validatePermissionsMutex       sync.RWMutex
+	validatePermissionsArgsForCall []struct {
+	}
+	validatePermissionsReturns struct {
+		result1 error
+	}
+	validatePermissionsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -183,6 +193,59 @@ func (fake *FakeStateStoreWriter) UpdateFilesReturnsOnCall(i int, result1 string
 	}{result1, result2}
 }
 
+func (fake *FakeStateStoreWriter) ValidatePermissions() error {
+	fake.validatePermissionsMutex.Lock()
+	ret, specificReturn := fake.validatePermissionsReturnsOnCall[len(fake.validatePermissionsArgsForCall)]
+	fake.validatePermissionsArgsForCall = append(fake.validatePermissionsArgsForCall, struct {
+	}{})
+	stub := fake.ValidatePermissionsStub
+	fakeReturns := fake.validatePermissionsReturns
+	fake.recordInvocation("ValidatePermissions", []interface{}{})
+	fake.validatePermissionsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStateStoreWriter) ValidatePermissionsCallCount() int {
+	fake.validatePermissionsMutex.RLock()
+	defer fake.validatePermissionsMutex.RUnlock()
+	return len(fake.validatePermissionsArgsForCall)
+}
+
+func (fake *FakeStateStoreWriter) ValidatePermissionsCalls(stub func() error) {
+	fake.validatePermissionsMutex.Lock()
+	defer fake.validatePermissionsMutex.Unlock()
+	fake.ValidatePermissionsStub = stub
+}
+
+func (fake *FakeStateStoreWriter) ValidatePermissionsReturns(result1 error) {
+	fake.validatePermissionsMutex.Lock()
+	defer fake.validatePermissionsMutex.Unlock()
+	fake.ValidatePermissionsStub = nil
+	fake.validatePermissionsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStateStoreWriter) ValidatePermissionsReturnsOnCall(i int, result1 error) {
+	fake.validatePermissionsMutex.Lock()
+	defer fake.validatePermissionsMutex.Unlock()
+	fake.ValidatePermissionsStub = nil
+	if fake.validatePermissionsReturnsOnCall == nil {
+		fake.validatePermissionsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validatePermissionsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStateStoreWriter) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -190,6 +253,8 @@ func (fake *FakeStateStoreWriter) Invocations() map[string][][]interface{} {
 	defer fake.readFileMutex.RUnlock()
 	fake.updateFilesMutex.RLock()
 	defer fake.updateFilesMutex.RUnlock()
+	fake.validatePermissionsMutex.RLock()
+	defer fake.validatePermissionsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/test/system/destination_test.go
+++ b/test/system/destination_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Destinations", func() {
 					Eventually(func() string {
 						describeOutput := strings.Split(platform.Kubectl("describe", "bucketstatestores", "destination-test-store"), "\n")
 						return describeOutput[len(describeOutput)-2]
-					}).Should(ContainSubstring("Error writing test file"))
+					}).Should(ContainSubstring("write permission validation failed"))
 				})
 
 				By("showing `Ready` as False in the Destination", func() {
@@ -368,8 +368,8 @@ func parseYAML(contents string) []*unstructured.Unstructured {
 func mc(args ...string) string {
 	command := exec.Command("mc", args...)
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ToNot(HaveOccurred())
-	Eventually(session).Should(gexec.Exit(0))
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	EventuallyWithOffset(1, session).Should(gexec.Exit(0))
 
 	return string(session.Out.Contents())
 }


### PR DESCRIPTION
instead, rely on specific writers implementation.

For the GitWriter, we can do an empty push. If the credentials are
valid, Git should error with a "Already up-to-date" error. If they are
not valid, it will error with "Unauthorized" errors. There may be a
small race condition where the empty push fails but the repository is
not up-to-date, but that should be fixed in the next reconciliation.

For S3, we can initiate a multipart upload. If the server accepts the
initiation, then the credentials are valid. If not, an error is raised.
We can then abort the multipart upload.

Current installations of Kratix will leave the probe behind. Those would
need to be manually removed.

An improvement to this commit is to implement some logic to _not_ check
again on the next reconciliation of the State Store. Since the original
issue was on the excessive commits to the probe file, we can prioritise
this performance improvement later.

Co-authored-by: Chunyi Lyu <chunyi@syntasso.io>
