### PR TITLE
chore: drop direct dependency on k8s.io/utils/ptr

### DIFF
--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -24,13 +24,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
+	"github.com/syntasso/kratix/internal/ptr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/ptr"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -68,15 +68,15 @@ const (
 
 var (
 	kratixSecurityContext = &corev1.SecurityContext{
-		AllowPrivilegeEscalation: ptr.To(false),
+		AllowPrivilegeEscalation: ptr.False(),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
-		RunAsNonRoot: ptr.To(true),
+		RunAsNonRoot: ptr.True(),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: "RuntimeDefault",
 		},
-		Privileged: ptr.To(false),
+		Privileged: ptr.False(),
 	}
 
 	DefaultUserProvidedContainersSecurityContext *corev1.SecurityContext

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/syntasso/kratix/api/v1alpha1"
+	"github.com/syntasso/kratix/internal/ptr"
 	"github.com/syntasso/kratix/lib/hash"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -17,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Pipeline", func() {
@@ -28,9 +28,9 @@ var _ = Describe("Pipeline", func() {
 		resourceRequest              *unstructured.Unstructured
 		globalDefaultSecurityContext *corev1.SecurityContext
 		defaultKratixSecurityContext = &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false),
-			RunAsNonRoot:             ptr.To(true),
-			Privileged:               ptr.To(false),
+			AllowPrivilegeEscalation: ptr.False(),
+			RunAsNonRoot:             ptr.True(),
+			Privileged:               ptr.False(),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},

--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	"github.com/syntasso/kratix/internal/ptr"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 )
 
 const (

--- a/api/v1alpha1/promise_types_test.go
+++ b/api/v1alpha1/promise_types_test.go
@@ -6,12 +6,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	platformv1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
+	"github.com/syntasso/kratix/internal/ptr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Promise", func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,12 +29,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/syntasso/kratix/internal/ptr"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/syntasso/kratix/internal/controller"
@@ -174,7 +174,7 @@ func main() {
 			LeaderElection:         enableLeaderElection,
 			LeaderElectionID:       "2743c979.kratix.io",
 			Controller: controllercfg.Controller{
-				SkipNameValidation: ptr.To(true),
+				SkipNameValidation: ptr.True(),
 			},
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/cluster-api v1.7.2
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/yaml v1.4.0
@@ -125,6 +124,7 @@ require (
 	k8s.io/component-base v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/syntasso/kratix/internal/controller"
+	"github.com/syntasso/kratix/internal/ptr"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -20,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,8 +52,8 @@ var _ = Describe("DynamicResourceRequestController", func() {
 		eventRecorder = record.NewFakeRecorder(1024)
 
 		reconciler = &controller.DynamicResourceRequestController{
-			CanCreateResources:          ptr.To(true),
-			Enabled:                     ptr.To(true),
+			CanCreateResources:          ptr.True(),
+			Enabled:                     ptr.True(),
 			Client:                      fakeK8sClient,
 			Scheme:                      scheme.Scheme,
 			GVK:                         rrGVK,

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/syntasso/kratix/internal/controller/controllerfakes"
 	controllerConfig "sigs.k8s.io/controller-runtime/pkg/config"
 
+	"github.com/syntasso/kratix/internal/ptr"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -67,7 +67,7 @@ var _ = Describe("PromiseController", func() {
 		l = ctrl.Log.WithName("controllers").WithName("Promise")
 		m := &controllerfakes.FakeManager{}
 		m.GetControllerOptionsReturns(controllerConfig.Controller{
-			SkipNameValidation: ptr.To(true)})
+			SkipNameValidation: ptr.True()})
 		eventRecorder = record.NewFakeRecorder(1024)
 		reconciler = &controller.PromiseReconciler{
 			Client:              fakeK8sClient,

--- a/internal/ptr/ptr.go
+++ b/internal/ptr/ptr.go
@@ -1,0 +1,13 @@
+package ptr
+
+func To[A any](input A) *A {
+	return &input
+}
+
+func True() *bool {
+	return To(true)
+}
+
+func False() *bool {
+	return To(false)
+}

--- a/internal/ptr/ptr_suite_test.go
+++ b/internal/ptr/ptr_suite_test.go
@@ -1,0 +1,13 @@
+package ptr_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPtr(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ptr Suite")
+}

--- a/internal/ptr/ptr_test.go
+++ b/internal/ptr/ptr_test.go
@@ -1,0 +1,52 @@
+package ptr_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/syntasso/kratix/internal/ptr"
+)
+
+var _ = Describe("ptr", func() {
+	Describe("To", func() {
+		It("returns a pointer to a copy of the input", func() {
+			By("checking the dereferenced value")
+			v := 5
+			vp := ptr.To(v)
+			Expect(*vp).To(Equal(5))
+
+			By("checking immutability of the original")
+			*vp = 4 // updates a copy of the original
+			Expect(v).To(Equal(5))
+
+			By("checking with a different type")
+			s := "Hello, world!"
+			Expect(*ptr.To(s)).To(Equal("Hello, world!"))
+		})
+
+	})
+
+	Describe("True()", func() {
+		It("is true", func() {
+			Expect(*ptr.True()).To(BeTrue())
+		})
+
+		It("produces independent values", func() {
+			v := ptr.True()
+			*v = false
+			Expect(*ptr.True()).To(BeTrue())
+		})
+	})
+
+	Describe("False()", func() {
+		It("is false", func() {
+			Expect(*ptr.False()).To(BeFalse())
+		})
+
+		It("produces independent values", func() {
+			v := ptr.False()
+			*v = true
+			Expect(*ptr.False()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
- because k8s.io/utils does not use semver, Dependabot will not update it
- a relatively big dependency can be avoided with a tiny bit of duplication
- True() and False() functions were added to improve readability