### PR TITLE
chore: some more work events

### DIFF
--- a/internal/controller/scheduler.go
+++ b/internal/controller/scheduler.go
@@ -129,7 +129,8 @@ func (s *Scheduler) updateWorkStatus(w *v1alpha1.Work, unscheduledWorkloadGroupI
 			Message: "Misplaced",
 		}
 		s.EventRecorder.Eventf(w, corev1.EventTypeWarning, scheduleSucceededConditionMismatchReason,
-			"Target destination no longer matches destinationSelectors for workloadGroups: [%s] ", strings.Join(unscheduledWorkloadGroupIDs, ","))
+			"Target destination no longer matches destinationSelectors for workloadGroups: [%s] ",
+			strings.Join(misplacedWorkloadGroupIDs, ","))
 	} else { // all works are scheduled and none is misplaced
 		readyCond = metav1.Condition{
 			Type:    "Ready",

--- a/internal/controller/scheduler.go
+++ b/internal/controller/scheduler.go
@@ -143,6 +143,8 @@ func (s *Scheduler) updateWorkStatus(w *v1alpha1.Work, unscheduledWorkloadGroupI
 			Reason:  "AllWorkplacementsScheduled",
 			Message: "All workplacements scheduled successfully",
 		}
+		s.EventRecorder.Eventf(w, corev1.EventTypeNormal, "AllWorkplacementsScheduled",
+			"All workplacements scheduled successfully")
 	}
 
 	if apimeta.SetStatusCondition(&w.Status.Conditions, scheduleSucceededCond) {

--- a/internal/controller/scheduler_test.go
+++ b/internal/controller/scheduler_test.go
@@ -488,6 +488,10 @@ var _ = Describe("Controllers/Scheduler", func() {
 					resourceWork.Status.Conditions[0].LastTransitionTime = metav1.Time{}
 					resourceWork.Status.Conditions[1].LastTransitionTime = metav1.Time{}
 					Expect(resourceWork.Status.Conditions).To(ConsistOf(misplacedConditions(resourceWork.Spec.WorkloadGroups[0].ID)))
+					Eventually(schedulerRecorder.Events).Should(Receive(ContainSubstring(
+						fmt.Sprintf(
+							"Target destination no longer matches destinationSelectors for workloadGroups: [%s]",
+							resourceWork.Spec.WorkloadGroups[0].ID))))
 				})
 			})
 

--- a/internal/controller/scheduler_test.go
+++ b/internal/controller/scheduler_test.go
@@ -849,12 +849,11 @@ var _ = Describe("Controllers/Scheduler", func() {
 					workplacements := &v1alpha1.WorkPlacementList{}
 					Expect(fakeK8sClient.List(context.Background(), workplacements)).To(Succeed())
 
-					Eventually(schedulerRecorder.Events).Should(Receive(
+					Expect(aggregateEvents(schedulerRecorder.Events)).To(SatisfyAll(
 						ContainSubstring(
-							"workplacement reconciled: %s, operation: created",
-							workplacements.Items[0].GetName(),
-						),
-					))
+							"Normal WorkplacementReconciled workplacement reconciled: %s, operation: created",
+							workplacements.Items[0].GetName()),
+						ContainSubstring("Normal AllWorkplacementsScheduled All workplacements scheduled successfully")))
 				})
 
 				When("multiple destination matches the scheduling rules", func() {


### PR DESCRIPTION
## Context

1. publish a overall successful work events
```

```
2. correct a bug where workgroupIDs show as empty in the work event
```
Events:
  Type     Reason                       Age              From       Message
  ----     ------                       ----             ----       -------
  Normal   WorkplacementReconciled      51s              Scheduler  workplacement reconciled: jenkins-example-instance-configure-b09aa.worker-1-5058f, operation: created
  Warning  DestinationSelectorMismatch  2s (x2 over 3s)  Scheduler  Target destination no longer matches destinationSelectors for workloadGroups: []
```