### PR TITLE
fix(#543): wrap kubectl on utility image

### DIFF
--- a/hack/kratix-pipeline-utility-image/Dockerfile
+++ b/hack/kratix-pipeline-utility-image/Dockerfile
@@ -1,22 +1,30 @@
-FROM --platform=$TARGETPLATFORM "alpine"
+FROM alpine
 
-LABEL org.opencontainers.image.authors "kratix@syntasso.io"
-LABEL org.opencontainers.image.source https://github.com/syntasso/kratix
+LABEL org.opencontainers.image.authors="kratix@syntasso.io"
+LABEL org.opencontainers.image.source=https://github.com/syntasso/kratix
 
 RUN [ "mkdir", "/tmp/transfer" ]
 RUN apk update && apk add --no-cache \
 	bash yq curl git \
 	pwgen bash openssl wget bind-tools \
-	github-cli unzip fortune ruby
+	github-cli unzip fortune ruby file
 
 RUN curl https://releases.hashicorp.com/terraform/1.7.1/terraform_1.7.1_linux_amd64.zip -o terraform.zip && \
     unzip terraform.zip && \
     mv terraform /usr/local/bin/terraform && \
     rm terraform.zip
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/amd64/kubectl
-RUN chmod u+x kubectl && mv kubectl /bin/kubectl
+ARG TARGETOS
+ARG TARGETARCH
+RUN curl -LO https://dl.k8s.io/v1.33.2/kubernetes-client-${TARGETOS}-${TARGETARCH}.tar.gz && \
+    tar -xzf kubernetes-client-${TARGETOS}-${TARGETARCH}.tar.gz && \
+    mv kubernetes/client/bin/kubectl /bin/kubectl-cli && \
+    chmod 755 /bin/kubectl-cli && \
+    rm -rf kubernetes-client-linux-amd64.tar.gz kubernetes
+COPY kubectl-wrapper.sh /bin/kubectl
+RUN chmod 755 /bin/kubectl
+
+RUN file /bin/kubectl && /bin/kubectl version --client
 
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \
     && chmod +x get_helm.sh && ./get_helm.sh
-

--- a/hack/kratix-pipeline-utility-image/kubectl-wrapper.sh
+++ b/hack/kratix-pipeline-utility-image/kubectl-wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ ! -f /tmp/kubectl-cli ]; then
+	cp /bin/kubectl-cli /tmp/kubectl-cli
+	chmod +x /tmp/kubectl-cli
+fi
+exec /tmp/kubectl-cli "$@"


### PR DESCRIPTION
Work around a Go runtime crash (lfstack.push invalid packing) in
OpenShift Jobs by copying kubectl to /tmp before execution.

The issue occurs when Go binaries are run directly from image layers
(e.g. OverlayFS), which under some conditions in OpenShift Jobs can lead
to pointer alignment violations during startup.

Copying the binary to /tmp (tmpfs) ensures correct memory alignment and
avoids this crash.

closes #543
