### PR TITLE
Add webhook startup readiness check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -328,6 +328,10 @@ func main() {
 			setupLog.Error(err, "unable to set up ready check")
 			os.Exit(1)
 		}
+		if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+			setupLog.Error(err, "unable to set up webhook ready check")
+			os.Exit(1)
+		}
 
 		setupLog.Info("starting manager")
 		err = mgr.Start(ctx)


### PR DESCRIPTION
## Summary
- ensure manager only ready once webhook server is running

## Testing
- `make fmt vet`
- `make test` *(fails: controller package compilation failure)*

------
https://chatgpt.com/codex/tasks/task_b_6877c2b9c60c83219b35f7584492fc4b