### PR TITLE
Make images run with arbitrary UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,12 @@ RUN --mount=target=. \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/cc:nonroot
+# Use a distroless base image that supports arbitrary UIDs
+FROM gcr.io/distroless/cc
 WORKDIR /
 COPY --from=builder /out/manager .
 COPY --from=alpine/git /usr/bin/git /usr/bin/git
-USER 65532:65532
+
+# Do not specify a user so OpenShift can assign a project-specific UID
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.pipeline-adapter
+++ b/Dockerfile.pipeline-adapter
@@ -21,7 +21,7 @@ RUN --mount=target=. \
 
 FROM busybox AS busybox
 
-FROM gcr.io/distroless/cc:nonroot
+FROM gcr.io/distroless/cc
 
 COPY --chown=nonroot:nonroot --from=busybox /usr/bin/env /usr/bin/env
 COPY --chown=nonroot:nonroot --from=busybox /bin/sh /bin/sh
@@ -29,6 +29,6 @@ COPY --chown=nonroot:nonroot --from=builder /out/work-creator /bin/work-creator
 COPY --chown=nonroot:nonroot --from=builder /out/update-status /bin/update-status
 COPY --chown=nonroot:nonroot --from=builder /out/reader /bin/reader
 
-USER 65532:65532
+# Do not specify a user so OpenShift can assign a project-specific UID
 ENTRYPOINT []
 CMD []

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Follow our [quick start](https://docs.kratix.io/main/quick-start) to get up-and-
 For documentation about how to use Kratix, visit [docs.kratix.io](https://docs.kratix.io/).
 For case studies, guides, and more checkout [syntasso.io](https://syntasso.io?utm_source=github&utm_medium=readme&utm_id=kratix).
 
+## Running on OpenShift
+
+The container images built from this repository now use a base image that
+supports running with an arbitrary user ID. This allows Kratix to run on Red Hat
+OpenShift without requiring custom SecurityContextConstraints.
+
 ## Community
 
 Kratix is apache 2.0 licensed and open for both contribution and feedback.

--- a/hack/kratix-quick-start-installer/Dockerfile
+++ b/hack/kratix-quick-start-installer/Dockerfile
@@ -16,10 +16,10 @@ RUN --mount=target=. \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/cc:nonroot
+FROM gcr.io/distroless/cc
 
 COPY --chown=nonroot:nonroot --from=builder /out/quick-start-installer /bin/quick-start-installer
 COPY --chown=nonroot:nonroot --from=bitnami/kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
 
-USER 65532:65532
+# Do not specify a user so OpenShift can assign a project-specific UID
 ENTRYPOINT ["/bin/quick-start-installer"]


### PR DESCRIPTION
## Summary
- switch Dockerfiles to `distroless/cc` base image
- remove hardcoded user directives so OpenShift can assign UIDs
- document OpenShift compatibility

## Testing
- `make fmt`
- ⚠️ `make vet` *(failed: timeout)*
- ⚠️ `go test ./...` *(failed: timeout)*

------
https://chatgpt.com/codex/tasks/task_b_687c0c76a10c832185365ea5758cd559