### PR TITLE
chore: use latest k8s in quick-start

### DIFF
--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -20,7 +20,7 @@ VERSION=${VERSION:-"$(cd $ROOT; git branch --show-current)"}
 DOCKER_BUILDKIT="${DOCKER_BUILDKIT:-1}"
 
 WAIT_TIMEOUT="180s"
-KIND_IMAGE="${KIND_IMAGE:-"kindest/node:v1.31.2"}"
+KIND_IMAGE="${KIND_IMAGE:-"kindest/node:v1.33.1"}"
 
 WITH_CERT_MANAGER=true
 CERT_MANAGER_DIST=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml


### PR DESCRIPTION
## Context

part of https://github.com/syntasso/enterprise-kratix/issues/406