### PR TITLE
chore: wait for kratix deployment in quickstart

### DIFF
--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -285,6 +285,10 @@ setup_worker_2_destination() {
     kubectl wait destination worker-2 --for=condition=Ready
 }
 
+wait_for_kratix_deployment() {
+    kubectl wait deployment --context kind-${PLATFORM_CLUSTER_NAME} -n kratix-platform-system kratix-platform-controller-manager --for=condition=Available --timeout=300s
+}
+
 wait_for_gitea() {
     wait_opts=$1
     kubectl wait pod --context kind-${PLATFORM_CLUSTER_NAME} -n gitea --selector app=gitea --for=condition=ready ${wait_opts}
@@ -516,6 +520,13 @@ install_kratix() {
     fi
 
     step_register_destinations
+    log -n "Waiting for kratix deployment to be ready..."
+    if ! SUPPRESS_OUTPUT=true run wait_for_kratix_deployment; then
+        run wait_for_kratix_deployment
+    else
+        success_mark
+    fi
+
     step_setup_worker_cluster
 
     log -n "Waiting for local repository to be running..."


### PR DESCRIPTION
## Context

In slow environment, kratix deployment might take a long time to get ready and you might get error such as:
```
Error from server (InternalError): error when creating "/home/runner/work/enterprise-kratix/enterprise-kratix/read-only-kratix/config/samples/platform_v1alpha1_bucketstatestore.yaml": Internal error occurred: failed calling webhook "vbucketstatestore-v1alpha1.kb.io": failed to call webhook: Post "[https://kratix-platform-webhook-service.kratix-platform-system.svc:443/validate-platform-kratix-io-v1alpha1-bucketstatestore?timeout=10s](https://kratix-platform-webhook-service.kratix-platform-system.svc/validate-platform-kratix-io-v1alpha1-bucketstatestore?timeout=10s)": dial tcp 10.96.140.67:443: connect: connection refused
Error from server (NotFound): bucketstatestores.platform.kratix.io "default" not found
Warning: v1beta2 Bucket is deprecated, upgrade to v1
error: timed out waiting for the condition on destinations/platform-cluster
```