### PR TITLE
fix: use system namespace for dry-run resources

### DIFF
--- a/internal/webhook/v1alpha1/promise_webhook.go
+++ b/internal/webhook/v1alpha1/promise_webhook.go
@@ -182,7 +182,7 @@ func exampleResourceRequest(p *v1alpha1.Promise) *unstructured.Unstructured {
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"name":      "webhook-dry-run",
-				"namespace": "default",
+				"namespace": "kratix-platform-system",
 				"uid":       uuid.New().String(),
 			},
 		},


### PR DESCRIPTION
instead of using the default namespace, which is a few platforms are
blocked from getting resources created by default

closes #564
