### PR TITLE
chore: bump kratix operator deployment memory request and limit

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,10 +56,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 256Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 256Mi
         env:
           - name: PIPELINE_ADAPTER_IMG
             valueFrom:


### PR DESCRIPTION
## Context

relates to https://github.com/syntasso/enterprise-kratix/issues/465