### PR TITLE
fix: handle empty condition when getting work status

### DIFF
--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -320,7 +320,11 @@ func (r *DynamicResourceRequestController) getWorksStatus(ctx context.Context, r
 	var failed, misplaced, ready, pending []string
 	for _, work := range works.Items {
 		readyCond := apiMeta.FindStatusCondition(work.Status.Conditions, "Ready")
-		switch readyCond.Message {
+		message := "Pending"
+		if readyCond != nil && readyCond.Message != "" {
+			message = readyCond.Message
+		}
+		switch message {
 		case "Failing":
 			failed = append(failed, work.Name)
 		case "Misplaced":

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -437,7 +437,11 @@ func (r *PromiseReconciler) getWorksStatus(ctx context.Context,
 	var failed, misplaced, ready, pending []string
 	for _, work := range works.Items {
 		readyCond := apiMeta.FindStatusCondition(work.Status.Conditions, "Ready")
-		switch readyCond.Message {
+		message := "Pending"
+		if readyCond != nil && readyCond.Message != "" {
+			message = readyCond.Message
+		}
+		switch message {
 		case "Failing":
 			failed = append(failed, work.Name)
 		case "Misplaced":


### PR DESCRIPTION
## Context

 Fix for both promise and dynamic controller.

closes #575 