### PR TITLE
fix: better handling of VersionID cache

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -62,9 +62,6 @@ var _ = BeforeSuite(func(_ SpecContext) {
 
 }, NodeTimeout(time.Minute))
 
-var _ = AfterSuite(func() {
-})
-
 var reconcileConfigureOptsArg workflow.Opts
 var reconcileDeleteOptsArg workflow.Opts
 
@@ -107,6 +104,10 @@ var _ = BeforeEach(func() {
 		reconcileDeleteOptsArg = w
 		return true, nil
 	})
+})
+
+var _ = AfterEach(func() {
+	errSubResourceUpdate = nil
 })
 
 func TestControllers(t *testing.T) {

--- a/internal/controller/workplacement_controller.go
+++ b/internal/controller/workplacement_controller.go
@@ -613,7 +613,6 @@ func (r *WorkPlacementReconciler) setVersionID(workPlacement *v1alpha1.WorkPlace
 }
 
 func (r *WorkPlacementReconciler) getVersionID(workPlacement *v1alpha1.WorkPlacement, versionID string) string {
-
 	if versionID != "" {
 		return versionID
 	}


### PR DESCRIPTION
Once the files are written successfully to the state store, we
immediately update a condition on the resource to reflect that. In rare
occasions, that status update can fail. When that happens, the version
id could be lost, since we were not storing it anywhere for the next
reconciliation

This commit fixes that behaviour. The Version ID is stored in the cache
immediately after it becomes available. It is only removed from the
cache when it's successfully persisted in the resource status.
