### PR TITLE
Add OpenTelemetry tracing across Kratix flows

### DIFF
--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/syntasso/kratix/api/v1alpha1"
 	"github.com/syntasso/kratix/internal/ptr"
+	"github.com/syntasso/kratix/internal/telemetry"
 	"github.com/syntasso/kratix/lib/hash"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -814,6 +815,20 @@ var _ = Describe("Pipeline", func() {
 							corev1.VolumeMount{Name: "shared-metadata", MountPath: "/work-creator-files/metadata"},
 							corev1.VolumeMount{Name: "promise-scheduling", MountPath: "/work-creator-files/kratix-system"},
 						))
+						Expect(container.Env).To(ConsistOf(
+							corev1.EnvVar{
+								Name: telemetry.TraceParentEnvVar,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{FieldPath: fmt.Sprintf("metadata.annotations['%s']", telemetry.TraceParentAnnotation)},
+								},
+							},
+							corev1.EnvVar{
+								Name: telemetry.TraceStateEnvVar,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{FieldPath: fmt.Sprintf("metadata.annotations['%s']", telemetry.TraceStateAnnotation)},
+								},
+							},
+						))
 					})
 
 					When("default image pull policy is set ", func() {
@@ -862,6 +877,20 @@ var _ = Describe("Pipeline", func() {
 							corev1.VolumeMount{Name: "shared-output", MountPath: "/work-creator-files/input"},
 							corev1.VolumeMount{Name: "shared-metadata", MountPath: "/work-creator-files/metadata"},
 							corev1.VolumeMount{Name: "promise-scheduling", MountPath: "/work-creator-files/kratix-system"},
+						))
+						Expect(container.Env).To(ConsistOf(
+							corev1.EnvVar{
+								Name: telemetry.TraceParentEnvVar,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{FieldPath: fmt.Sprintf("metadata.annotations['%s']", telemetry.TraceParentAnnotation)},
+								},
+							},
+							corev1.EnvVar{
+								Name: telemetry.TraceStateEnvVar,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{FieldPath: fmt.Sprintf("metadata.annotations['%s']", telemetry.TraceStateAnnotation)},
+								},
+							},
 						))
 					})
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,10 @@ require (
 	github.com/minio/minio-go/v7 v7.0.68
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
+	github.com/spf13/cobra v1.8.1
+	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/sdk v1.28.0
+	go.opentelemetry.io/otel/trace v1.28.0
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.1
@@ -85,18 +89,14 @@ require (
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
-	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.28.0 // indirect
-	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect

--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -1,0 +1,264 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kratixPrefix              = "kratix.io/"
+	TraceParentAnnotation     = kratixPrefix + "trace-parent"
+	TraceStateAnnotation      = kratixPrefix + "trace-state"
+	TraceTimestampAnnotation  = kratixPrefix + "trace-timestamp"
+	TraceGenerationAnnotation = kratixPrefix + "trace-generation"
+	TraceParentEnvVar         = "KRATIX_TRACE_PARENT"
+	TraceStateEnvVar          = "KRATIX_TRACE_STATE"
+
+	traceparentKey = "traceparent"
+	tracestateKey  = "tracestate"
+)
+
+var (
+	tracePropagator = propagation.TraceContext{}
+	traceMaxAge     = 24 * time.Hour
+	nowFunc         = time.Now
+)
+
+// StartSpanForObject ensures trace annotations are present on obj and starts a span whose
+// parent is derived from those annotations. The returned boolean indicates whether the
+// caller should persist obj because its annotations were updated.
+func StartSpanForObject(ctx context.Context, tracer trace.Tracer, obj metav1.Object, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span, bool, error) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	needNewTrace, err := needsNewTrace(obj, annotations)
+	if err != nil {
+		return ctx, trace.SpanFromContext(ctx), false, err
+	}
+
+	if needNewTrace {
+		startOpts := append([]trace.SpanStartOption{trace.WithNewRoot()}, opts...)
+		ctx, span := tracer.Start(ctx, spanName, startOpts...)
+		storeSpanContext(annotations, span.SpanContext())
+		annotations[TraceTimestampAnnotation] = nowFunc().UTC().Format(time.RFC3339Nano)
+		if gen := obj.GetGeneration(); gen > 0 {
+			annotations[TraceGenerationAnnotation] = strconv.FormatInt(gen, 10)
+		} else {
+			delete(annotations, TraceGenerationAnnotation)
+		}
+		obj.SetAnnotations(annotations)
+		return ctx, span, true, nil
+	}
+
+	carrier := propagation.MapCarrier{}
+	parent := annotations[TraceParentAnnotation]
+	carrier.Set(traceparentKey, parent)
+	if state := annotations[TraceStateAnnotation]; state != "" {
+		carrier.Set(tracestateKey, state)
+	}
+
+	extracted := tracePropagator.Extract(ctx, carrier)
+	spanCtx := trace.SpanContextFromContext(extracted)
+	if !spanCtx.IsValid() {
+		startOpts := append([]trace.SpanStartOption{trace.WithNewRoot()}, opts...)
+		ctx, span := tracer.Start(ctx, spanName, startOpts...)
+		storeSpanContext(annotations, span.SpanContext())
+		annotations[TraceTimestampAnnotation] = nowFunc().UTC().Format(time.RFC3339Nano)
+		if gen := obj.GetGeneration(); gen > 0 {
+			annotations[TraceGenerationAnnotation] = strconv.FormatInt(gen, 10)
+		} else {
+			delete(annotations, TraceGenerationAnnotation)
+		}
+		obj.SetAnnotations(annotations)
+		return ctx, span, true, nil
+	}
+
+	ctx, span := tracer.Start(extracted, spanName, opts...)
+	mutated := false
+	if annotations[TraceTimestampAnnotation] == "" {
+		annotations[TraceTimestampAnnotation] = nowFunc().UTC().Format(time.RFC3339Nano)
+		mutated = true
+	}
+	if gen := obj.GetGeneration(); gen > 0 {
+		if annotations[TraceGenerationAnnotation] == "" {
+			annotations[TraceGenerationAnnotation] = strconv.FormatInt(gen, 10)
+			mutated = true
+		}
+	}
+	if mutated {
+		obj.SetAnnotations(annotations)
+	}
+	return ctx, span, mutated, nil
+}
+
+func needsNewTrace(obj metav1.Object, annotations map[string]string) (bool, error) {
+	parent := annotations[TraceParentAnnotation]
+	if parent == "" {
+		return true, nil
+	}
+
+	carrier := propagation.MapCarrier{}
+	carrier.Set(traceparentKey, parent)
+	if state := annotations[TraceStateAnnotation]; state != "" {
+		carrier.Set(tracestateKey, state)
+	}
+	extracted := tracePropagator.Extract(context.Background(), carrier)
+	if !trace.SpanContextFromContext(extracted).IsValid() {
+		return true, nil
+	}
+
+	if tsStr := annotations[TraceTimestampAnnotation]; tsStr != "" {
+		ts, err := time.Parse(time.RFC3339Nano, tsStr)
+		if err != nil {
+			return true, nil
+		}
+		if nowFunc().Sub(ts) > traceMaxAge {
+			return true, nil
+		}
+	}
+
+	if gen := obj.GetGeneration(); gen > 0 {
+		if genStr := annotations[TraceGenerationAnnotation]; genStr != "" {
+			val, err := strconv.ParseInt(genStr, 10, 64)
+			if err != nil {
+				return true, nil
+			}
+			if val != gen {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func storeSpanContext(annotations map[string]string, spanCtx trace.SpanContext) {
+	carrier := propagation.MapCarrier{}
+	ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+	tracePropagator.Inject(ctx, carrier)
+	if tp := carrier.Get(traceparentKey); tp != "" {
+		annotations[TraceParentAnnotation] = tp
+	}
+	if ts := carrier.Get(tracestateKey); ts != "" {
+		annotations[TraceStateAnnotation] = ts
+	} else {
+		delete(annotations, TraceStateAnnotation)
+	}
+}
+
+// CopyTraceAnnotations copies trace annotations from src to dst.
+func CopyTraceAnnotations(dst map[string]string, src map[string]string) map[string]string {
+	if dst == nil {
+		dst = map[string]string{}
+	}
+	if src == nil {
+		return dst
+	}
+	for _, key := range []string{TraceParentAnnotation, TraceStateAnnotation, TraceTimestampAnnotation, TraceGenerationAnnotation} {
+		if val, ok := src[key]; ok && val != "" {
+			dst[key] = val
+		}
+	}
+	return dst
+}
+
+// ApplyTraceAnnotations ensures the provided annotations map contains the supplied
+// traceparent and tracestate values.
+func ApplyTraceAnnotations(annotations map[string]string, traceParent, traceState string) map[string]string {
+	if traceParent == "" {
+		return annotations
+	}
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[TraceParentAnnotation] = traceParent
+	if traceState != "" {
+		annotations[TraceStateAnnotation] = traceState
+	} else {
+		delete(annotations, TraceStateAnnotation)
+	}
+	return annotations
+}
+
+// ContextWithTraceparent returns a context containing the provided trace parent values.
+func ContextWithTraceparent(ctx context.Context, traceParent, traceState string) (context.Context, bool) {
+	if traceParent == "" {
+		return ctx, false
+	}
+	carrier := propagation.MapCarrier{}
+	carrier.Set(traceparentKey, traceParent)
+	if traceState != "" {
+		carrier.Set(tracestateKey, traceState)
+	}
+	extracted := tracePropagator.Extract(ctx, carrier)
+	spanCtx := trace.SpanContextFromContext(extracted)
+	if !spanCtx.IsValid() {
+		return ctx, false
+	}
+	return extracted, true
+}
+
+// LoggerWithTrace enriches the logger with the trace id if available.
+func LoggerWithTrace(logger logr.Logger, span trace.Span) logr.Logger {
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		return logger
+	}
+	return logger.WithValues("trace_id", sc.TraceID().String())
+}
+
+// RecordError annotates the span status with the provided error if non-nil.
+func RecordError(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+// SetCommonAttributes attaches common flow attributes to the span.
+func SetCommonAttributes(span trace.Span, attrs ...attribute.KeyValue) {
+	if span == nil {
+		return
+	}
+	span.SetAttributes(attrs...)
+}
+
+// TraceParentFromEnv reads the trace parent information from the environment.
+func TraceParentFromEnv() (string, string) {
+	return os.Getenv(TraceParentEnvVar), os.Getenv(TraceStateEnvVar)
+}
+
+// SetTraceMaxAge is used in tests to override the default duration.
+func SetTraceMaxAge(d time.Duration) {
+	traceMaxAge = d
+}
+
+// ResetTimeNow is used in tests to reset the injected time function.
+func ResetTimeNow() {
+	nowFunc = time.Now
+}
+
+// SetTimeNow overrides the now function, primarily for testing.
+func SetTimeNow(f func() time.Time) {
+	nowFunc = f
+}
+
+// TraceInfoString returns a formatted representation of the stored trace annotations.
+func TraceInfoString(annotations map[string]string) string {
+	if annotations == nil {
+		return ""
+	}
+	return fmt.Sprintf("traceparent=%s tracestate=%s", annotations[TraceParentAnnotation], annotations[TraceStateAnnotation])
+}

--- a/internal/telemetry/tracing_test.go
+++ b/internal/telemetry/tracing_test.go
@@ -1,0 +1,90 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/syntasso/kratix/api/v1alpha1"
+	"github.com/syntasso/kratix/internal/telemetry"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestTracer(t *testing.T) trace.Tracer {
+	t.Helper()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+	return provider.Tracer("test")
+}
+
+func TestStartSpanForObjectCreatesAnnotations(t *testing.T) {
+	g := gomega.NewWithT(t)
+	tracer := newTestTracer(t)
+
+	promise := &v1alpha1.Promise{ObjectMeta: metav1.ObjectMeta{Name: "test", Generation: 1}}
+
+	ctx, span, mutated, err := telemetry.StartSpanForObject(context.Background(), tracer, promise, "promise-flow")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(mutated).To(gomega.BeTrue())
+	annotations := promise.GetAnnotations()
+	g.Expect(annotations).NotTo(gomega.BeNil())
+	g.Expect(annotations[telemetry.TraceParentAnnotation]).NotTo(gomega.BeEmpty())
+	g.Expect(annotations[telemetry.TraceTimestampAnnotation]).NotTo(gomega.BeEmpty())
+	g.Expect(annotations[telemetry.TraceGenerationAnnotation]).To(gomega.Equal("1"))
+	span.End()
+
+	// Reuse the existing trace.
+	_, span2, mutatedSecond, err := telemetry.StartSpanForObject(ctx, tracer, promise, "promise-flow")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(mutatedSecond).To(gomega.BeFalse())
+	g.Expect(promise.GetAnnotations()[telemetry.TraceParentAnnotation]).To(gomega.Equal(annotations[telemetry.TraceParentAnnotation]))
+	span2.End()
+}
+
+func TestStartSpanForObjectDetectsExpiredTrace(t *testing.T) {
+	g := gomega.NewWithT(t)
+	tracer := newTestTracer(t)
+	telemetry.SetTraceMaxAge(time.Second)
+	telemetry.SetTimeNow(func() time.Time { return time.Unix(0, 0) })
+	t.Cleanup(func() {
+		telemetry.SetTraceMaxAge(24 * time.Hour)
+		telemetry.ResetTimeNow()
+	})
+
+	work := &v1alpha1.Work{ObjectMeta: metav1.ObjectMeta{Name: "work", Namespace: "default", Generation: 1}}
+
+	_, span, mutated, err := telemetry.StartSpanForObject(context.Background(), tracer, work, "work-flow")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(mutated).To(gomega.BeTrue())
+	span.End()
+
+	telemetry.SetTimeNow(func() time.Time { return time.Unix(5, 0) })
+
+	_, span2, mutatedSecond, err := telemetry.StartSpanForObject(context.Background(), tracer, work, "work-flow")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(mutatedSecond).To(gomega.BeTrue())
+	span2.End()
+}
+
+func TestContextWithTraceparent(t *testing.T) {
+	g := gomega.NewWithT(t)
+	tracer := newTestTracer(t)
+
+	promise := &v1alpha1.Promise{ObjectMeta: metav1.ObjectMeta{Name: "trace", Generation: 1}}
+	_, span, mutated, err := telemetry.StartSpanForObject(context.Background(), tracer, promise, "promise-flow")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(mutated).To(gomega.BeTrue())
+	span.End()
+
+	parent := promise.GetAnnotations()[telemetry.TraceParentAnnotation]
+	state := promise.GetAnnotations()[telemetry.TraceStateAnnotation]
+
+	ctx, ok := telemetry.ContextWithTraceparent(context.Background(), parent, state)
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(trace.SpanContextFromContext(ctx).IsValid()).To(gomega.BeTrue())
+}


### PR DESCRIPTION
## Summary
- add a telemetry helper package to manage trace context annotations
- instrument controllers, pipeline jobs, and work creator to propagate spans end-to-end
- extend existing unit tests to cover trace propagation for jobs and work objects

## Testing
- go test ./internal/telemetry
- go test ./work-creator/lib
- go test ./api/v1alpha1 -run Test

------
https://chatgpt.com/codex/tasks/task_b_68dafecce9908321979a96d8a7f3154a