### PR TITLE
Fix promise revision deletion when more than one version exists

### DIFF
--- a/internal/controller/assets/redis-request-other.yaml
+++ b/internal/controller/assets/redis-request-other.yaml
@@ -1,0 +1,9 @@
+apiVersion: marketplace.kratix.io/v1alpha1
+kind: redis
+metadata:
+  name: example-other
+  namespace: default
+  labels:
+    non-kratix-label: "true"
+spec:
+  size: small

--- a/internal/controller/shared_test.go
+++ b/internal/controller/shared_test.go
@@ -27,6 +27,7 @@ const (
 	promiseWithOnlyDepsUpdatedPath = "assets/promise-with-deps-only-updated.yaml"
 	promiseWithRequirements        = "assets/promise-with-requirements.yaml"
 	resourceRequestPath            = "assets/redis-request.yaml"
+	resourceRequestOtherPath       = "assets/redis-request-other.yaml"
 	updatedPromisePath             = "assets/redis-simple-promise-updated.yaml"
 )
 


### PR DESCRIPTION
There was a bug in the promise revision deletion where it wouldn't finalize the deletion if there was more than a single revision. The [bug](https://github.com/syntasso/kratix/compare/main...MMartyn:kratix:fix/delete-promiserevision?expand=1#diff-d15e8bddbcd5bd9c9626277dd0812d73ad936b23644c27da8ed8c6b39cea87c6L214) was due to it checking if there were any resource bindings but not taking into account the version that they were tied to. Feel free to change whatever.