### PR TITLE
fix: healthrecord fails to delete when service account cannot read the resource

### DIFF
--- a/internal/controller/healthrecord_controller.go
+++ b/internal/controller/healthrecord_controller.go
@@ -90,8 +90,8 @@ func (r *HealthRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	healthRecordIsBeingDeleted := !healthRecord.DeletionTimestamp.IsZero()
 
 	if err = r.getResourceRequest(ctx, promiseGVK, healthRecord, resReq); err != nil {
-		if errors.IsNotFound(err) && healthRecordIsBeingDeleted {
-			logging.Debug(r.Log, "resource not found during deletion; removing finalizer", "healthRecord", req.Name)
+		if healthRecordIsBeingDeleted && (errors.IsNotFound(err) || errors.IsForbidden(err)) {
+			logging.Debug(r.Log, "resource not found or inaccessible during deletion; removing finalizer", "healthRecord", req.Name)
 			return ctrl.Result{}, r.removeFinalizer(ctx, healthRecord)
 		}
 		logging.Error(logger, err, "failed getting resource")


### PR DESCRIPTION
Fixes #628

## Changes
- Handle Forbidden errors when deleting healthrecords with inaccessible resources
- Add test case for service account permission denial scenario