### PR TITLE
feat: ability to set resource labels from a workflow

### DIFF
--- a/sdk/contract.md
+++ b/sdk/contract.md
@@ -26,6 +26,10 @@ WriteOutput writes the content to the specifies file at the path /kratix/output/
 
 WriteStatus writes the specified status to the `/kratix/metadata/status.yaml`
 
+**`WriteLabels(map[string]string) error`**
+
+WriteLabels writes the specified labels to the `/kratix/metadata/labels.yaml`. These labels will be merged with the existing resource labels after the pipeline completes.
+
 **`WriteDestinationSelectors([]DestinationSelector) error`**
 
 WriteDestinationSelectors writes the specified Destination Selectors to the `/kratix/metadata/destination_selectors.yaml`
@@ -69,6 +73,10 @@ PublishStatus updates the status of the provided resource with the provided stat
 **`ReadStatus() (Status, error)`**
 
 ReadStatus reads the /kratix/metadata/status.yaml
+
+**`ReadLabels() (map[string]string, error)`**
+
+ReadLabels reads the /kratix/metadata/labels.yaml
 
 ## Promise Interface
 

--- a/work-creator/lib/status_updater.go
+++ b/work-creator/lib/status_updater.go
@@ -19,6 +19,25 @@ func MergeStatuses(existing map[string]any, incoming map[string]any) map[string]
 	return mergeRecursive(existing, incoming)
 }
 
+// MergeLabels takes two label maps and returns a new label map that is a
+// merge of the two. If a key exists in both maps, the value from the incoming
+// map will be used.
+func MergeLabels(existing map[string]string, incoming map[string]string) map[string]string {
+	result := make(map[string]string)
+
+	// First, copy all keys from existing
+	for k, v := range existing {
+		result[k] = v
+	}
+
+	// Then merge or overwrite with incoming
+	for k, v := range incoming {
+		result[k] = v
+	}
+
+	return result
+}
+
 // MarkAsCompleted takes a status map and returns a new status map with the
 // "ConfigureWorkflowCompleted" condition set to true. It will also update the
 // "message" field to "Resource requested" if the message is currently

--- a/work-creator/lib/status_updater_test.go
+++ b/work-creator/lib/status_updater_test.go
@@ -9,6 +9,53 @@ import (
 
 var _ = Describe("StatusUpdater", func() {
 
+	Describe("MergeLabels", func() {
+		It("merges the two maps", func() {
+			existing := map[string]string{
+				"existing-key": "existing-value",
+				"shared-key":   "old-value",
+			}
+			incoming := map[string]string{
+				"incoming-key": "incoming-value",
+				"shared-key":   "new-value",
+			}
+			result := lib.MergeLabels(existing, incoming)
+			Expect(result).To(SatisfyAll(
+				HaveKeyWithValue("existing-key", "existing-value"),
+				HaveKeyWithValue("incoming-key", "incoming-value"),
+				HaveKeyWithValue("shared-key", "new-value"),
+			))
+			Expect(result).To(HaveLen(3))
+		})
+
+		It("returns incoming labels when existing is empty", func() {
+			existing := map[string]string{}
+			incoming := map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}
+			result := lib.MergeLabels(existing, incoming)
+			Expect(result).To(Equal(incoming))
+		})
+
+		It("returns existing labels when incoming is empty", func() {
+			existing := map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}
+			incoming := map[string]string{}
+			result := lib.MergeLabels(existing, incoming)
+			Expect(result).To(Equal(existing))
+		})
+
+		It("returns empty map when both are empty", func() {
+			existing := map[string]string{}
+			incoming := map[string]string{}
+			result := lib.MergeLabels(existing, incoming)
+			Expect(result).To(BeEmpty())
+		})
+	})
+
 	Describe("MergeStatuses", func() {
 		It("merges the two maps", func() {
 			existing := map[string]any{


### PR DESCRIPTION
Fixes #617

## Changes
- Add MergeLabels function to merge incoming labels with existing resource labels
- Modify update-status command to read and apply labels from /kratix/metadata/labels.yaml
- Update SDK contract with WriteLabels and ReadLabels function specifications
- Add tests for label merging functionality