### PR TITLE
wip: replacing deprecated minio with rustfs for quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,8 @@ minio-cli:
 	mkdir -p bin
 	$(call get-mc-cli)
 
+rustfs-cli: minio-cli
+
 .PHONY: list
 list:
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'

--- a/config/samples/minio-install.yaml
+++ b/config/samples/minio-install.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null
-  name: minio
+  name: rustfs
   namespace: kratix-platform-system
 spec:
   ports:
@@ -17,7 +17,7 @@ spec:
       targetPort: 9000
       nodePort: 31337
   selector:
-    run: minio
+    run: rustfs
   type: NodePort
 ---
 apiVersion: apps/v1
@@ -25,31 +25,62 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    run: minio
-  name: minio
+    run: rustfs
+  name: rustfs
   namespace: kratix-platform-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      run: minio
+      run: rustfs
   template:
     metadata:
       labels:
-        run: minio
+        run: rustfs
     spec:
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
       initContainers:
-        - name: make-buckets
-          image: docker.io/minio/minio:RELEASE.2022-06-30T20-58-09Z
+        - name: init-rustfs-data
+          image: busybox:1.36
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command:
+            [
+              "sh",
+              "-c",
+              "mkdir -p /data/rustfs0 /data/rustfs1 /data/rustfs2 /data/rustfs3 && chown -R 10001:10001 /data",
+            ]
           volumeMounts:
             - mountPath: /data
               name: data-volume
       containers:
-        - image: docker.io/minio/minio:RELEASE.2022-06-30T20-58-09Z
-          name: minio
-          args: ["server", "/data"]
+        - image: rustfs/rustfs:latest
+          name: rustfs
           ports:
             - containerPort: 9000
+          env:
+            - name: RUSTFS_VOLUMES
+              value: /data/rustfs{0..3}
+            - name: RUSTFS_ADDRESS
+              value: 0.0.0.0:9000
+            - name: RUSTFS_CONSOLE_ADDRESS
+              value: 0.0.0.0:9001
+            - name: RUSTFS_CONSOLE_ENABLE
+              value: "true"
+            - name: RUSTFS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-credentials
+                  key: accessKeyID
+            - name: RUSTFS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-credentials
+                  key: secretAccessKey
           volumeMounts:
             - mountPath: /data
               name: data-volume
@@ -60,8 +91,8 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-credentials
-  namespace: default
+  name: rustfs-credentials
+  namespace: kratix-platform-system
 stringData:
   accessKeyID: minioadmin
   secretAccessKey: minioadmin
@@ -69,39 +100,39 @@ stringData:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: minio-create-bucket
-  namespace: default
+  name: rustfs-create-bucket
+  namespace: kratix-platform-system
 spec:
   template:
     spec:
-      serviceAccountName: minio-create-bucket
+      serviceAccountName: rustfs-create-bucket
       initContainers:
-        - name: wait-for-minio
+        - name: wait-for-rustfs
           image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
           command:
             [
               "sh",
               "-c",
-              "kubectl wait --for=condition=Ready --timeout=120s -n kratix-platform-system pod -l run=minio",
+              "kubectl wait --for=condition=Ready --timeout=120s -n kratix-platform-system pod -l run=rustfs",
             ]
       containers:
-        - name: minio-event-configuration
+        - name: rustfs-bucket-configuration
           image: docker.io/minio/mc:RELEASE.2023-06-06T13-48-56Z
-          command: ["mc", "mb", "--ignore-existing", "minio/kratix"]
+          command: ["mc", "mb", "--ignore-existing", "rustfs/kratix"]
           env:
             - name: MC_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: minio-credentials
+                  name: rustfs-credentials
                   key: accessKeyID
             - name: MC_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: minio-credentials
+                  name: rustfs-credentials
                   key: secretAccessKey
             - name: MC_ENDPOINT
-              value: minio.kratix-platform-system.svc.cluster.local
-            - name: MC_HOST_minio
+              value: rustfs.kratix-platform-system.svc.cluster.local
+            - name: MC_HOST_rustfs
               value: "http://$(MC_ACCESS_KEY):$(MC_SECRET_KEY)@$(MC_ENDPOINT)"
       restartPolicy: Never
   backoffLimit: 4
@@ -109,7 +140,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: minio-create-bucket
+  name: rustfs-create-bucket
 rules:
   - apiGroups:
       - ""
@@ -123,18 +154,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: minio-create-bucket
+  name: rustfs-create-bucket
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: minio-create-bucket
+  name: rustfs-create-bucket
 subjects:
   - kind: ServiceAccount
-    name: minio-create-bucket
-    namespace: default
+    name: rustfs-create-bucket
+    namespace: kratix-platform-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: minio-create-bucket
-  namespace: default
+  name: rustfs-create-bucket
+  namespace: kratix-platform-system

--- a/config/samples/platform_v1alpha1_bucketstatestore.yaml
+++ b/config/samples/platform_v1alpha1_bucketstatestore.yaml
@@ -3,10 +3,10 @@ kind: BucketStateStore
 metadata:
   name: default
 spec:
-  endpoint: minio.kratix-platform-system.svc.cluster.local
+  endpoint: rustfs.kratix-platform-system.svc.cluster.local
   insecure: true
   bucketName: kratix
   authMethod: accessKey
   secretRef:
-    name: minio-credentials
-    namespace: default
+    name: rustfs-credentials
+    namespace: kratix-platform-system

--- a/hack/destination/gitops-tk-resources-single-cluster.yaml
+++ b/hack/destination/gitops-tk-resources-single-cluster.yaml
@@ -8,15 +8,15 @@ spec:
   interval: 10s
   provider: generic
   bucketName: kratix
-  endpoint: minio.kratix-platform-system.svc.cluster.local
+  endpoint: rustfs.kratix-platform-system.svc.cluster.local
   insecure: true
   secretRef:
-    name: minio-credentials
+    name: rustfs-credentials
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-credentials
+  name: rustfs-credentials
   namespace: flux-system
 type: Opaque
 data:

--- a/hack/destination/gitops-tk-resources.yaml
+++ b/hack/destination/gitops-tk-resources.yaml
@@ -11,12 +11,12 @@ spec:
   endpoint: 172.18.0.2:31337
   insecure: true
   secretRef:
-    name: minio-credentials
+    name: rustfs-credentials
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-credentials
+  name: rustfs-credentials
   namespace: flux-system
 type: Opaque
 data:

--- a/hack/destination/helm-values-minio.yaml
+++ b/hack/destination/helm-values-minio.yaml
@@ -2,7 +2,7 @@ config:
   path: worker-1
   namespace: kratix-worker-config
   secretRef:
-    name: minio-credentials
+    name: rustfs-credentials
     values:
       accesskey: bWluaW9hZG1pbg==
       secretkey: bWluaW9hZG1pbg==

--- a/hack/platform/helm-values-minio.yaml
+++ b/hack/platform/helm-values-minio.yaml
@@ -1,12 +1,12 @@
 stateStores:
 - kind: BucketStateStore
   name: default
-  namespace: default
+  namespace: kratix-platform-system
   secretRef:
-    name: minio-credentials
+    name: rustfs-credentials
     values:
       accesskey: bWluaW9hZG1pbg==
       secretkey: bWluaW9hZG1pbg==
   insecure: true
-  endpoint: minio.kratix-platform-system.svc.cluster.local
+  endpoint: rustfs.kratix-platform-system.svc.cluster.local
   bucket: kratix

--- a/hack/templates/gitops-tk-resources-template.yaml
+++ b/hack/templates/gitops-tk-resources-template.yaml
@@ -11,7 +11,7 @@ spec:
   endpoint: ENDPOINT
   insecure: true
   secretRef:
-    name: minio-credentials
+    name: rustfs-credentials
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: Bucket
@@ -25,12 +25,12 @@ spec:
   endpoint: ENDPOINT
   insecure: true
   secretRef:
-    name: minio-credentials
+    name: rustfs-credentials
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-credentials
+  name: rustfs-credentials
   namespace: flux-system
 type: Opaque
 data:

--- a/lib/writers/s3.go
+++ b/lib/writers/s3.go
@@ -196,6 +196,9 @@ func (b *S3Writer) deleteObjects(ctx context.Context, oldObjectsToDelete map[str
 	for objectName, objectInfo := range oldObjectsToDelete {
 		err := b.RepoClient.RemoveObject(ctx, b.BucketName, objectInfo.Key, minio.RemoveObjectOptions{})
 		if err != nil {
+			if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+				continue
+			}
 			logging.Error(logger, err, "failed to remove object", "objectName", objectName)
 			errCount++
 		}
@@ -266,6 +269,9 @@ func (b *S3Writer) RemoveObject(objectName string) error {
 			minio.RemoveObjectOptions{},
 		)
 		if err != nil {
+			if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+				return nil
+			}
 			logging.Error(b.Log, err, "could not delete object", "bucketName", b.BucketName, "objectName", objectName)
 			return err
 		}

--- a/scripts/helm-e2e-test.sh
+++ b/scripts/helm-e2e-test.sh
@@ -13,7 +13,7 @@ elif [ "$STATE_STORE" == "bucket" ]; then
     platform_helm_values_path="hack/platform/helm-values-minio.yaml"
     state_store_install_path="hack/platform/minio-install.yaml"
     job_pod_namespace="kratix-platform-system"
-    job_pod_labels="run=minio"
+    job_pod_labels="run=rustfs"
 else
     echo "No supported State Store specified"
     exit 1

--- a/test/system/assets/destination/destination-test-store.yaml
+++ b/test/system/assets/destination/destination-test-store.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   authMethod: accessKey
   bucketName: kratix
-  endpoint: minio.kratix-platform-system.svc.cluster.local
+  endpoint: rustfs.kratix-platform-system.svc.cluster.local
   insecure: true
   secretRef:
-    name: minio-credentials
-    namespace: default
+    name: rustfs-credentials
+    namespace: kratix-platform-system

--- a/test/system/destination_test.go
+++ b/test/system/destination_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Destinations", Label("destination"), Serial, func() {
 				platform.Kubectl("patch", "bucketstatestore", "destination-test-store", "--type=merge", "-p", `{"spec":{"secretRef":{"name":"aws-s3-credentials"}}}`)
 			} else {
 				// update the state store secret with the valid credentials when running in KinD
-				platform.Kubectl("patch", "secret", "minio-credentials", "--type=merge", "-p", `{"stringData":{"accessKeyID":"minioadmin"}}`)
+				platform.Kubectl("patch", "secret", "rustfs-credentials", "--type=merge", "-p", `{"stringData":{"accessKeyID":"minioadmin"}}`, "-n", "kratix-platform-system")
 			}
 			platform.Kubectl("delete", "-f", "assets/destination/destination-worker-3.yaml")
 			platform.Kubectl("delete", "secret", "new-state-store-secret", "--ignore-not-found")
@@ -121,7 +121,7 @@ var _ = Describe("Destinations", Label("destination"), Serial, func() {
 				Eventually(func() string {
 					describeOutput := strings.Split(platform.Kubectl("describe", "bucketstatestores", "destination-test-store"), "\n")
 					return describeOutput[len(describeOutput)-2]
-				}).Should(ContainSubstring("Error initialising writer: secret \"non-existent-secret\" not found in namespace \"default\""))
+				}).Should(ContainSubstring("Error initialising writer: secret \"non-existent-secret\" not found in namespace \"kratix-platform-system\""))
 			})
 
 			By("showing `Ready` as False in the Destination when the State Store secret does not exist", func() {
@@ -172,7 +172,7 @@ var _ = Describe("Destinations", Label("destination"), Serial, func() {
 
 			if os.Getenv("LRE") != "true" {
 				// update the underlying state store secret with invalid credentials (non-LRE only)
-				platform.Kubectl("patch", "secret", "minio-credentials", "--type=merge", "-p", `{"stringData":{"accessKeyID":"invalid"}}`)
+				platform.Kubectl("patch", "secret", "rustfs-credentials", "--type=merge", "-p", `{"stringData":{"accessKeyID":"invalid"}}`, "-n", "kratix-platform-system")
 
 				By("showing `Ready` as False in the State Store", func() {
 					Eventually(func() string {


### PR DESCRIPTION
  ## What this change does

  - Replaces the MinIO dev statestore used by scripts/quick-start.sh with RustFS (S3‑compatible) while keeping the same statestore flow.
  - Updates the quick‑start wiring, sample BucketStateStore, and install manifest to point at the RustFS service/credentials.
  - Renames Kubernetes resources from minio* to rustfs* for clarity.

## Why we moved namespaces

  - RustFS reads credentials from a Kubernetes Secret mounted into the Deployment. Since the RustFS pod runs in kratix-platform-system, the secret must live in the same namespace (Kubernetes secrets are namespace‑scoped).
  - MinIO worked with the secret in default because the MinIO pod did not consume that secret; only the bucket‑creation job did. With RustFS, the pod itself needs the secret.

 ## Testing

  - Ran ./scripts/quick-start.sh --recreate.
  - Installed the namespace and redis promises from kratix-marketplace, submitted resource requests, and verified:
      - Resources reconciled to the worker cluster.
      - Flux kratix-worker-dependencies and kratix-worker-resources are Ready.
      - RustFS bucket contains expected artifacts under worker-1/….
  - Confirmed no MinIO resources exist after quick‑start.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace deprecated MinIO with RustFS as the default S3-compatible storage backend for the quickstart environment to improve maintainability and modernize infrastructure dependencies.

Main changes:
- Replaced all MinIO references with RustFS across configuration files, scripts, and Kubernetes manifests including deployment specs and credentials
- Updated quick-start.sh script flags from --git-and-minio to --git-and-rustfs with corresponding variable and function name changes
- Added NoSuchKey error handling in S3Writer deleteObjects and RemoveObject methods to gracefully skip non-existent objects

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
