### PR TITLE
fix: remove the actual git temp directory and not its parent

### DIFF
--- a/lib/writers/git.go
+++ b/lib/writers/git.go
@@ -114,7 +114,7 @@ func (g *GitWriter) update(subDir, workPlacementName string, workloadsToCreate [
 		"branch", g.GitServer.Branch,
 	)
 
-	defer os.RemoveAll(filepath.Dir(localDir)) //nolint:errcheck
+	defer os.RemoveAll(localDir) //nolint:errcheck
 
 	err = g.deleteExistingFiles(subDir != "", dirInGitRepo, workloadsToDelete, logger)
 	if err != nil {
@@ -205,7 +205,7 @@ func (g *GitWriter) ReadFile(filePath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(filepath.Dir(localDir)) //nolint:errcheck
+	defer os.RemoveAll(localDir) //nolint:errcheck
 
 	fullPath := filepath.Join(g.Runner.Root(), filePath)
 	logger := g.Log.WithValues(


### PR DESCRIPTION
The `localDir` in both code paths points to the temporary directory hosting the files checked out from Git (e.g. `/tmp/kratix-repo123`). In both cases, the call to `filePath.Dir()` will return the parent directory (`/tmp`). This causes the entire `/tmp` location to be removed instead of just the Git temporary directory.

This causes errors such as:

* No rights for current repository

```text
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 2026-02-10T11:17:38Z	ERROR	controllers.GitStateStoreController.writers.GitStateStoreWriter	command failed	{"controller": "gitStateStore", "name": "terraform-demo", "generation": 1, "execID": "3f115", "dir": "/tmp/kratix-repo3317009446", "severity": "error", "args": "git fetch origin main --depth 1 --force --prune", "duration": "105.416417ms", "error": "`git fetch origin main --depth 1 --force --prune` failed exit status 128: No user exists for uid 65532\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists."}
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/internal/logging.Error
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/internal/logging/logger.go:36
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/util/git.RunCommandExt
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/util/git/exec.go:210
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/util/git.RunWithExecRunOpts
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/util/git/exec.go:53
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/util/git.(*nativeGitClient).runCmdOutput
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/util/git/exec.go:273
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/util/git.(*nativeGitClient).runCredentialedCmd
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/util/git/exec.go:310
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/util/git.(*nativeGitClient).fetch
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/util/git/git.go:368
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/util/git.(*nativeGitClient).Fetch
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/util/git/git.go:454
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/util/git.(*nativeGitClient).Clone
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/util/git/git.go:514
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/lib/writers.(*GitWriter).ValidatePermissions
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/lib/writers/git.go:233
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/internal/controller.reconcileStateStoreCommon
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/internal/controller/state_store.go:83
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/internal/controller.(*GitStateStoreReconciler).Reconcile
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/internal/controller/gitstatestore_controller.go:75
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255

```

* File not found

```text
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 2026-02-10T11:17:30Z	ERROR	controllers.WorkPlacementController	failed to read .kratix state file	{"controller": "workPlacement", "name": "bucket-tf-bug-test-bucket-configure-7fa30.tfe-5058f", "namespace": "team-backend", "promise": "bucket", "generation": 2, "severity": "error", "filePath": ".kratix/team-backend-bucket-tf-bug-test-bucket-configure-7fa30.tfe-5058f.yaml", "error": "file not found"}
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/internal/logging.Error
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/internal/logging/logger.go:36
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/internal/controller.(*WorkPlacementReconciler).deleteWorkPlacement
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/internal/controller/workplacement_controller.go:281
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/internal/controller.(*WorkPlacementReconciler).handleDeletion
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/internal/controller/workplacement_controller.go:577
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager github.com/syntasso/kratix/internal/controller.(*WorkPlacementReconciler).Reconcile
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/workspace/internal/controller/workplacement_controller.go:127
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
kratix-platform-controller-manager-7fdd849c8d-ssf9v manager 	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
```

This PR fixes the code to cleanup only the target directory and not its parent, thus removing errors related to the Git directory being absent.
