### PR TITLE
chore: remove failure output from skipped test

### DIFF
--- a/test/system/promise_revision_test.go
+++ b/test/system/promise_revision_test.go
@@ -23,6 +23,10 @@ var _ = Describe("Upgrade", func() {
 	})
 
 	AfterEach(func() {
+		if getEnvOrDefault("UPGRADE_ENABLED", "false") != "true" {
+			return
+		}
+
 		platform.EventuallyKubectlDelete("upgrades", rrTwoName)
 		platform.EventuallyKubectlDelete("promise", promiseName)
 	})


### PR DESCRIPTION
before you'd see a failure, thinking your tests have failed, when they haven't!
<img width="1281" height="494" alt="Screenshot 2026-02-12 at 17 22 18" src="https://github.com/user-attachments/assets/9cf4628d-dfa9-4e60-bd7d-a0aa112fd56f" />
<img width="935" height="352" alt="Screenshot 2026-02-12 at 17 22 24" src="https://github.com/user-attachments/assets/f96fabdf-d326-4c62-bb99-520950d116c7" />


after (I focussed tests to get quicker verification):
<img width="1595" height="534" alt="Screenshot 2026-02-12 at 17 23 40" src="https://github.com/user-attachments/assets/98a200b1-6d36-440f-91be-03f8e4b03cdc" />
<img width="674" height="265" alt="Screenshot 2026-02-12 at 17 24 55" src="https://github.com/user-attachments/assets/d91cc466-be80-4222-8000-eeb178451cc5" />
