### PR TITLE
chore: limit workplacement parallel reconciliation

### DIFF
--- a/internal/controller/workplacement_controller.go
+++ b/internal/controller/workplacement_controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -506,6 +507,9 @@ func getDir(workPlacement v1alpha1.WorkPlacement) string {
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkPlacementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 2,
+		}).
 		For(&v1alpha1.WorkPlacement{}).
 		Complete(r)
 }


### PR DESCRIPTION
over load, kratix git clones too much, and that causes memory spikes and
eventually system failure. This changes limits the number of parallel
reconciliations in the workplacement controller, which shouldn't
slow the system down too much, but would reduce the chance of exhausting
the pod resources
