### PR TITLE
fix: Don't set workplacement ready=true if it hasn't been written yet

### DIFF
--- a/internal/controller/scheduler.go
+++ b/internal/controller/scheduler.go
@@ -429,7 +429,7 @@ func (s *Scheduler) updateWorkPlacementStatus(ctx context.Context, workPlacement
 		return err
 	}
 
-	var desiredScheduleCond, desiredReadyCond v1.Condition
+	var desiredScheduleCond v1.Condition
 	if misplaced {
 		desiredScheduleCond = v1.Condition{
 			Message:            scheduleSucceededConditionMismatchMsg,
@@ -438,32 +438,41 @@ func (s *Scheduler) updateWorkPlacementStatus(ctx context.Context, workPlacement
 			Status:             v1.ConditionFalse,
 			LastTransitionTime: v1.NewTime(time.Now()),
 		}
-		desiredReadyCond = metav1.Condition{
+		readyUpdated := apimeta.SetStatusCondition(&updatedwp.Status.Conditions, metav1.Condition{
 			Type:    "Ready",
 			Status:  v1.ConditionFalse,
 			Reason:  "Misplaced",
 			Message: "Misplaced",
-		}
+		})
+		scheduleUpdated := apimeta.SetStatusCondition(&updatedwp.Status.Conditions, desiredScheduleCond)
 		s.EventRecorder.Eventf(updatedwp, corev1.EventTypeWarning, scheduleSucceededConditionMismatchReason,
 			"labels for destination: %s no longer match the expected labels, marking this workplacement as misplaced", updatedwp.Spec.TargetDestinationName)
-	} else {
-		desiredScheduleCond = v1.Condition{
-			Message:            "Scheduled to correct Destination",
-			Reason:             "ScheduledToDestination",
-			Type:               scheduleSucceededConditionType,
-			Status:             v1.ConditionTrue,
-			LastTransitionTime: v1.NewTime(time.Now()),
+		if scheduleUpdated || readyUpdated {
+			return s.Client.Status().Update(ctx, updatedwp)
 		}
-		desiredReadyCond = metav1.Condition{
-			Type:    "Ready",
-			Status:  v1.ConditionTrue,
-			Reason:  "Ready",
-			Message: "Ready",
-		}
+		return nil
 	}
 
-	if apimeta.SetStatusCondition(&updatedwp.Status.Conditions, desiredScheduleCond) {
-		apimeta.SetStatusCondition(&updatedwp.Status.Conditions, desiredReadyCond)
+	desiredScheduleCond = v1.Condition{
+		Message:            "Scheduled to correct Destination",
+		Reason:             "ScheduledToDestination",
+		Type:               scheduleSucceededConditionType,
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: v1.NewTime(time.Now()),
+	}
+	scheduleUpdated := apimeta.SetStatusCondition(&updatedwp.Status.Conditions, desiredScheduleCond)
+
+	readyUpdated := false
+	if scheduleUpdated {
+		readyUpdated = apimeta.SetStatusCondition(&updatedwp.Status.Conditions, metav1.Condition{
+			Type:    "Ready",
+			Status:  v1.ConditionFalse,
+			Reason:  "ScheduledToDestination",
+			Message: "Pending",
+		})
+	}
+
+	if scheduleUpdated || readyUpdated {
 		return s.Client.Status().Update(ctx, updatedwp)
 	}
 	return nil

--- a/internal/controller/scheduler_test.go
+++ b/internal/controller/scheduler_test.go
@@ -109,6 +109,12 @@ var _ = Describe("Controllers/Scheduler", func() {
 						HaveKeyWithValue("kratix.io/pipeline-name", resourceWork.Labels["kratix.io/pipeline-name"]),
 					))
 					Expect(workPlacement.GetAnnotations()).To(Equal(resourceWork.GetAnnotations()))
+
+					Expect(workPlacement.Status.Conditions).To(HaveLen(2))
+					for i := range workPlacement.Status.Conditions {
+						workPlacement.Status.Conditions[i].LastTransitionTime = metav1.Time{}
+					}
+					Expect(workPlacement.Status.Conditions).To(ConsistOf(scheduledWorkPlacementPendingConditions()))
 				})
 
 				It("records a scheduled outcome metric", func() {
@@ -1073,6 +1079,23 @@ func misplacedWorkPlacementConditions() []metav1.Condition {
 			Reason:  "Misplaced",
 			Type:    "Ready",
 			Status:  metav1.ConditionFalse},
+	}
+}
+
+func scheduledWorkPlacementPendingConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:    "ScheduleSucceeded",
+			Status:  metav1.ConditionTrue,
+			Reason:  "ScheduledToDestination",
+			Message: "Scheduled to correct Destination",
+		},
+		{
+			Type:    "Ready",
+			Status:  metav1.ConditionFalse,
+			Reason:  "ScheduledToDestination",
+			Message: "Pending",
+		},
 	}
 }
 


### PR DESCRIPTION
Before this PR, if a workplacement failed to get written, e.g. the workplacement controller was stuck in its Git flow, you could get the status as follows:
```
k get workplacements.platform.kratix.io wp | yq .status
conditions:
  - lastTransitionTime: "2026-02-24T13:31:32Z"
    message: Scheduled to correct Destination
    reason: ScheduledToDestination
    status: "True"
    type: ScheduleSucceeded
  - lastTransitionTime: "2026-02-24T13:31:32Z"
    message: Ready
    reason: Ready
    status: "True"
    type: Ready
```

This was confusing, `Ready: true` is incorrect since the file hasn't been written, which you can observe from no `versionID` or condition to indicate its success.

This PR changes it so that the Work (Scheduler) controller sets the Ready status to False by default, it can then be updated by the WorkPlacement controller to `True` once the files are written.