### PR TITLE
fix: match on workflow type and action

### DIFF
--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -305,7 +305,7 @@ func legacyLabelsForJobs(opts Opts) map[string]string {
 	return l
 }
 
-func labelsForAllPipelineJobs(pipeline v1alpha1.PipelineJobResources) map[string]string {
+func labelsForAllWorkflowJobs(pipeline v1alpha1.PipelineJobResources) map[string]string {
 	pipelineLabels := pipeline.Job.GetLabels()
 	labels := map[string]string{
 		v1alpha1.PromiseNameLabel: pipelineLabels[v1alpha1.PromiseNameLabel],
@@ -315,6 +315,12 @@ func labelsForAllPipelineJobs(pipeline v1alpha1.PipelineJobResources) map[string
 	}
 	if pipelineLabels[v1alpha1.ResourceNamespaceLabel] != "" {
 		labels[v1alpha1.ResourceNamespaceLabel] = pipelineLabels[v1alpha1.ResourceNamespaceLabel]
+	}
+	if pipelineLabels[v1alpha1.WorkflowActionLabel] != "" {
+		labels[v1alpha1.WorkflowActionLabel] = pipelineLabels[v1alpha1.WorkflowActionLabel]
+	}
+	if pipelineLabels[v1alpha1.WorkflowTypeLabel] != "" {
+		labels[v1alpha1.WorkflowTypeLabel] = pipelineLabels[v1alpha1.WorkflowTypeLabel]
 	}
 	return labels
 }
@@ -402,7 +408,7 @@ func isRunning(job *batchv1.Job) bool {
 func cleanup(opts Opts, namespace string) error {
 	pipelineNames := map[string]bool{}
 	for _, pipeline := range opts.Resources {
-		l := labelsForAllPipelineJobs(pipeline)
+		l := labelsForAllWorkflowJobs(pipeline)
 		l[v1alpha1.PipelineNameLabel] = pipeline.Name
 		pipelineNames[pipeline.Name] = true
 		jobsForPipeline, _ := getJobsWithLabels(opts, l, namespace)


### PR DESCRIPTION
## Context

This PR fixes an issue when the workflow reconciler is listing all jobs for a pipeline.

Before this change, when the ReconcileConfigure is working on a promise configure workflow, it will match on promise name and the pipeline name only. If the name of a pipeline in the promise configure workflow is the same of a pipeline name in the resource configure workflow, we will ended up matching more jobs which leads to kratix deleting the promise configure workflow job even though the number of jobs has not exceeded the number of jobs to keep configuration.

Matching on workflow type and action labels fixes this issue.

This is related to: https://github.com/syntasso/kratix-private/issues/171#issue-3900531251