### PR TITLE
feat: Log clearly what resource request a reconciliation belongs to

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -389,6 +389,7 @@ func main() {
 		if err := (&controller.ResourceBindingReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
+			Log:    ctrl.Log.WithName("controllers").WithName("ResourceBindingController"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ResourceBinding")
 			os.Exit(1)

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -94,10 +94,10 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	baseLogger := r.Log.WithValues(
 		"controller", "dynamicResourceRequest",
 		"uid", r.UID,
-		"promise", r.PromiseIdentifier,
 		"name", req.Name,
 		"namespace", req.Namespace,
 	)
+	baseLogger = withPromiseAndResourceRequest(baseLogger, r.PromiseIdentifier, req.Namespace, req.Name)
 
 	rr := &unstructured.Unstructured{}
 	rr.SetGroupVersionKind(*r.GVK)
@@ -267,7 +267,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	}
 
 	if !promise.HasPipeline(v1alpha1.WorkflowTypeResource, v1alpha1.WorkflowActionConfigure) {
-		return r.nextReconciliation(logger), r.updateWorkflowStatusCountersToZero(rr, ctx)
+		return r.nextReconciliation(logger), r.updateWorkflowStatusCountersToZero(logger, rr, ctx)
 	}
 
 	rrNamespace := ""
@@ -276,7 +276,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	}
 	workLabels := resourceutil.GetWorkLabels(r.PromiseIdentifier, rr.GetName(), rrNamespace, "", v1alpha1.WorkTypeResource)
 
-	statusUpdate, err := r.generateResourceStatus(ctx, rr, int64(len(pipelineResources)), workLabels, bindingVersion, promiseRevisionUsed)
+	statusUpdate, err := r.generateResourceStatus(ctx, logger, rr, int64(len(pipelineResources)), workLabels, bindingVersion, promiseRevisionUsed)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -297,7 +297,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	}
 
 	if r.PromiseUpgrade {
-		if r.updatePromiseVersionStatus(rr, bindingVersion, promiseRevisionUsed) {
+		if r.updatePromiseVersionStatus(logger, rr, bindingVersion, promiseRevisionUsed) {
 			return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
 		}
 	}
@@ -353,16 +353,16 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 	return nil
 }
 
-func (r *DynamicResourceRequestController) generateResourceStatus(ctx context.Context, rr *unstructured.Unstructured,
+func (r *DynamicResourceRequestController) generateResourceStatus(ctx context.Context, logger logr.Logger, rr *unstructured.Unstructured,
 	numberOfPipelines int64, workLabels map[string]string, bindingVersion string, promiseRevision *v1alpha1.PromiseRevision) (bool, error) {
-	failed, misplaced, pending, ready, err := r.getWorksStatus(ctx, rr, workLabels)
+	failed, misplaced, pending, ready, err := r.getWorksStatus(ctx, logger, rr, workLabels)
 	if err != nil {
 		return false, err
 	}
 	worksSucceededUpdate := r.updateWorksSucceededCondition(rr, failed, pending, ready, misplaced)
 	reconciledUpdate := r.updateReconciledCondition(rr)
-	workflowsCounterStatusUpdate := r.generateWorkflowsCounterStatus(rr, numberOfPipelines)
-	promiseVersionUpdate := r.updatePromiseVersionStatus(rr, bindingVersion, promiseRevision)
+	workflowsCounterStatusUpdate := r.generateWorkflowsCounterStatus(logger, rr, numberOfPipelines)
+	promiseVersionUpdate := r.updatePromiseVersionStatus(logger, rr, bindingVersion, promiseRevision)
 
 	return worksSucceededUpdate || reconciledUpdate || workflowsCounterStatusUpdate || promiseVersionUpdate, nil
 }
@@ -443,17 +443,17 @@ func (r *DynamicResourceRequestController) updateWorksSucceededCondition(rr *uns
 	return false
 }
 
-func (r *DynamicResourceRequestController) updatePromiseVersionStatus(rr *unstructured.Unstructured, bindingVersion string, promiseRevision *v1alpha1.PromiseRevision) bool {
-	logging.Trace(r.Log, "Checking if we need to update the promise version in the status")
+func (r *DynamicResourceRequestController) updatePromiseVersionStatus(logger logr.Logger, rr *unstructured.Unstructured, bindingVersion string, promiseRevision *v1alpha1.PromiseRevision) bool {
+	logging.Trace(logger, "Checking if we need to update the promise version in the status")
 	if !r.PromiseUpgrade || promiseRevision == nil {
-		logging.Trace(r.Log, "Feature flag disabled or no PromiseRevision: we don't")
+		logging.Trace(logger, "Feature flag disabled or no PromiseRevision: we don't")
 		return false
 	}
 
 	versionUpdated := false
 	currentVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
 	if currentVersion != promiseRevision.Spec.Version {
-		resourceutil.SetStatus(rr, r.Log, resourcePromiseVersionStatus, promiseRevision.Spec.Version)
+		resourceutil.SetStatus(rr, logger, resourcePromiseVersionStatus, promiseRevision.Spec.Version)
 		r.EventRecorder.Eventf(rr, v1.EventTypeNormal, "ReconcileSucceeded",
 			"Resource request reconciled with promise %s version %s",
 			promiseRevision.Spec.PromiseRef.Name,
@@ -463,7 +463,7 @@ func (r *DynamicResourceRequestController) updatePromiseVersionStatus(rr *unstru
 
 	currentBindingVersion := resourceutil.GetStatus(rr, resourceBindingVersionStatus)
 	if currentBindingVersion != bindingVersion {
-		resourceutil.SetStatus(rr, r.Log, resourceBindingVersionStatus, bindingVersion)
+		resourceutil.SetStatus(rr, logger, resourceBindingVersionStatus, bindingVersion)
 		r.EventRecorder.Eventf(rr, v1.EventTypeNormal, "ResourceBindingVersionUpdated",
 			"Resource binding version updated to %s", bindingVersion)
 		versionUpdated = true
@@ -482,11 +482,11 @@ func (r *DynamicResourceRequestController) setPausedReconciliationStatusConditio
 	return nil
 }
 
-func (r *DynamicResourceRequestController) getWorksStatus(ctx context.Context, rr *unstructured.Unstructured, workLabels map[string]string) ([]string, []string, []string, []string, error) {
+func (r *DynamicResourceRequestController) getWorksStatus(ctx context.Context, logger logr.Logger, rr *unstructured.Unstructured, workLabels map[string]string) ([]string, []string, []string, []string, error) {
 	workSelectorLabel := labels.FormatLabels(workLabels)
 	selector, err := labels.Parse(workSelectorLabel)
 	if err != nil {
-		logging.Debug(r.Log, "failed parsing works selector label", "labels", workSelectorLabel)
+		logging.Debug(logger, "failed parsing works selector label", "labels", workSelectorLabel)
 		return nil, nil, nil, nil, err
 	}
 
@@ -497,7 +497,7 @@ func (r *DynamicResourceRequestController) getWorksStatus(ctx context.Context, r
 	})
 
 	if err != nil {
-		logging.Error(r.Log, err, "failed listing works", "namespace", rr.GetNamespace(), "labelSelector", workSelectorLabel)
+		logging.Error(logger, err, "failed listing works", "namespace", rr.GetNamespace(), "labelSelector", workSelectorLabel)
 		return nil, nil, nil, nil, err
 	}
 
@@ -522,7 +522,7 @@ func (r *DynamicResourceRequestController) getWorksStatus(ctx context.Context, r
 	return failed, misplaced, pending, ready, nil
 }
 
-func (r *DynamicResourceRequestController) generateWorkflowsCounterStatus(rr *unstructured.Unstructured, numOfPipelines int64) bool {
+func (r *DynamicResourceRequestController) generateWorkflowsCounterStatus(logger logr.Logger, rr *unstructured.Unstructured, numOfPipelines int64) bool {
 	completedCond := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
 
 	desiredWorkflows := numOfPipelines
@@ -535,7 +535,7 @@ func (r *DynamicResourceRequestController) generateWorkflowsCounterStatus(rr *un
 	if resourceutil.GetWorkflowsCounterStatus(rr, "workflows") != desiredWorkflows ||
 		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsSucceeded") != desiredWorkflowsSucceeded {
 
-		resourceutil.SetStatus(rr, r.Log,
+		resourceutil.SetStatus(rr, logger,
 			"workflows", desiredWorkflows,
 			"workflowsSucceeded", desiredWorkflowsSucceeded,
 			"workflowsFailed", int64(0),
@@ -546,12 +546,12 @@ func (r *DynamicResourceRequestController) generateWorkflowsCounterStatus(rr *un
 	return false
 }
 
-func (r *DynamicResourceRequestController) updateWorkflowStatusCountersToZero(rr *unstructured.Unstructured, ctx context.Context) error {
+func (r *DynamicResourceRequestController) updateWorkflowStatusCountersToZero(logger logr.Logger, rr *unstructured.Unstructured, ctx context.Context) error {
 	if resourceutil.GetWorkflowsCounterStatus(rr, "workflows") != 0 ||
 		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsSucceeded") != 0 ||
 		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsFailed") != 0 {
 
-		resourceutil.SetStatus(rr, r.Log, "workflows", int64(0), "workflowsSucceeded", int64(0), "workflowsFailed", int64(0))
+		resourceutil.SetStatus(rr, logger, "workflows", int64(0), "workflowsSucceeded", int64(0), "workflowsFailed", int64(0))
 		return r.Client.Status().Update(ctx, rr)
 	}
 	return nil
@@ -639,7 +639,7 @@ func (r *DynamicResourceRequestController) deleteResourceBinding(o opts, rr *uns
 		if apierrors.IsNotFound(err) {
 			controllerutil.RemoveFinalizer(rr, finalizer)
 			if err := r.Client.Update(o.ctx, rr); err != nil {
-				r.Log.Info(err.Error())
+				logging.Error(o.logger, err, "failed updating resource request while removing finalizer")
 				return err
 			}
 			return nil

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -49,6 +49,7 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	logger := r.Log.WithValues(
 		"controller", "resourceBinding",
 		"name", req.Name,
+		"namespace", req.Namespace,
 	)
 
 	resourceBinding := &v1alpha1.ResourceBinding{}
@@ -60,6 +61,13 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logging.Warn(logger, "failed to get resourceBinding; requeueing")
 		return defaultRequeue, nil
 	}
+
+	logger = withPromiseAndResourceRequest(
+		logger,
+		resourceBinding.Spec.PromiseRef.Name,
+		resourceBinding.Spec.ResourceRef.Namespace,
+		resourceBinding.Spec.ResourceRef.Name,
+	)
 
 	promiseNamespacedName := types.NamespacedName{
 		Name: resourceBinding.Spec.PromiseRef.Name,

--- a/internal/controller/shared.go
+++ b/internal/controller/shared.go
@@ -27,6 +27,8 @@ const (
 	promiseReleaseNameLabel        = v1alpha1.KratixPrefix + "promise-release-name"
 	removeAllWorkflowJobsFinalizer = v1alpha1.KratixPrefix + "workflows-cleanup"
 	runDeleteWorkflowsFinalizer    = v1alpha1.KratixPrefix + "delete-workflows"
+	promiseLogKey                  = "promise"
+	resourceRequestLogKey          = "resourceRequest"
 	// DefaultReconciliationInterval is the interval on which the workflows will be re-run.
 	DefaultReconciliationInterval                       = time.Hour * 10
 	secretRefFieldName                                  = "secretRef"
@@ -53,6 +55,10 @@ type opts struct {
 	ctx    context.Context
 	client client.Client
 	logger logr.Logger
+}
+
+func withPromiseAndResourceRequest(logger logr.Logger, promiseName, resourceNamespace, resourceName string) logr.Logger {
+	return logger.WithValues(promiseLogKey, promiseName, resourceRequestLogKey, fmt.Sprintf("%s/%s/%s", promiseName, resourceNamespace, resourceName))
 }
 
 // pass in nil resourceLabels to delete all resources of the GVK

--- a/internal/controller/work_controller.go
+++ b/internal/controller/work_controller.go
@@ -84,12 +84,13 @@ func (r *WorkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	}
 
 	promiseName := work.Spec.PromiseName
+	resourceName := work.Spec.ResourceName
+	resourceNamespace := work.GetNamespace()
 	baseLogger := logger.WithValues(
-		"promise", promiseName,
 		"generation", work.GetGeneration(),
 	)
+	baseLogger = withPromiseAndResourceRequest(baseLogger, promiseName, resourceNamespace, resourceName)
 	spanName := fmt.Sprintf("%s/WorkReconcile", promiseName)
-	resourceName := work.Spec.ResourceName
 	if resourceName != "" {
 		spanName = fmt.Sprintf("%s/%s", resourceName, spanName)
 	}
@@ -107,7 +108,7 @@ func (r *WorkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	}
 
 	if !work.DeletionTimestamp.IsZero() {
-		if err := r.deleteWork(ctx, work); err != nil {
+		if err := r.deleteWork(ctx, logger, work); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -204,14 +205,14 @@ func (r *WorkReconciler) updateWorkStatus(ctx context.Context, logger logr.Logge
 	return nil
 }
 
-func (r *WorkReconciler) deleteWork(ctx context.Context, work *v1alpha1.Work) error {
+func (r *WorkReconciler) deleteWork(ctx context.Context, logger logr.Logger, work *v1alpha1.Work) error {
 	workplacementGVK := schema.GroupVersionKind{
 		Group:   v1alpha1.GroupVersion.Group,
 		Version: v1alpha1.GroupVersion.Version,
 		Kind:    "WorkPlacement",
 	}
 
-	logging.Debug(r.Log, "deleting workplacements")
+	logging.Debug(logger, "deleting workplacements")
 
 	wpList := &unstructured.UnstructuredList{}
 	wpList.SetGroupVersionKind(workplacementGVK)
@@ -227,7 +228,7 @@ func (r *WorkReconciler) deleteWork(ctx context.Context, work *v1alpha1.Work) er
 	for i := range wpList.Items {
 		wp := &wpList.Items[i]
 		if err := ensureTraceAnnotations(ctx, r.Client, wp, parentAnnotations); err != nil {
-			logging.Debug(r.Log, "Failed to ensure trace annotations are propagated, ignoring the error...", "error", err)
+			logging.Debug(logger, "Failed to ensure trace annotations are propagated, ignoring the error...", "error", err)
 		}
 		if err := r.Client.Delete(ctx, wp, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 			if errors.IsNotFound(err) {
@@ -245,12 +246,12 @@ func (r *WorkReconciler) deleteWork(ctx context.Context, work *v1alpha1.Work) er
 
 	if controllerutil.RemoveFinalizer(work, workCleanUpFinalizer) {
 		if err := r.Client.Update(ctx, work); err != nil {
-			logging.Debug(r.Log, "Failed to remove finalizer, requeuing...", "error", err)
+			logging.Debug(logger, "Failed to remove finalizer, requeuing...", "error", err)
 			return err
 		}
 	}
 
-	logging.Debug(r.Log, "workplacements deleted")
+	logging.Debug(logger, "workplacements deleted")
 	return nil
 }
 

--- a/internal/controller/workplacement_controller.go
+++ b/internal/controller/workplacement_controller.go
@@ -93,10 +93,11 @@ func (r *WorkPlacementReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	promiseName := workPlacement.Spec.PromiseName
 	resourceName := workPlacement.Spec.ResourceName
+	resourceNamespace := workPlacement.GetNamespace()
 	baseLogger := logger.WithValues(
-		"promise", promiseName,
 		"generation", workPlacement.GetGeneration(),
 	)
+	baseLogger = withPromiseAndResourceRequest(baseLogger, promiseName, resourceNamespace, resourceName)
 	spanName := fmt.Sprintf("%s/WorkPlacementReconcile", promiseName)
 	if resourceName != "" {
 		spanName = fmt.Sprintf("%s/%s", resourceName, spanName)
@@ -146,7 +147,7 @@ func (r *WorkPlacementReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return requeue, err
 	}
 
-	if err := r.updateResourceStatus(ctx, workPlacement, versionID); err != nil {
+	if err := r.updateResourceStatus(ctx, logger, workPlacement, versionID); err != nil {
 		if kerrors.IsConflict(err) {
 			return fastRequeue, nil
 		}
@@ -156,7 +157,7 @@ func (r *WorkPlacementReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return ctrl.Result{}, nil
 }
 
-func (r *WorkPlacementReconciler) updateResourceStatus(ctx context.Context, workPlacement *v1alpha1.WorkPlacement, versionID string) error {
+func (r *WorkPlacementReconciler) updateResourceStatus(ctx context.Context, logger logr.Logger, workPlacement *v1alpha1.WorkPlacement, versionID string) error {
 	versionID = r.getCachedVersionID(workPlacement, versionID)
 
 	versionChanged := versionID != "" && workPlacement.Status.VersionID != versionID
@@ -167,7 +168,7 @@ func (r *WorkPlacementReconciler) updateResourceStatus(ctx context.Context, work
 	condChanged := r.setWorkplacementReady(workPlacement)
 
 	if versionChanged || condChanged || writeSucceededCondChanged {
-		logging.Debug(r.Log, "updating workplacement status", "versionChanged", versionChanged, "condChanged", condChanged, "writeSucceededCondChanged", writeSucceededCondChanged)
+		logging.Debug(logger, "updating workplacement status", "versionChanged", versionChanged, "condChanged", condChanged, "writeSucceededCondChanged", writeSucceededCondChanged)
 		if err := r.Client.Status().Update(ctx, workPlacement); err != nil {
 			return err
 		}


### PR DESCRIPTION
this is only for work/workplacement/dynamic/resource-binding controllers. Introduces a new `<promise-name>/<resource-namespace>/<resource-name>` log key, that makes filtering easier, particularly across controllers 