### PR TITLE
feature: make DefaultResourceRequirements configurable

### DIFF
--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -84,6 +84,18 @@ var _ = Describe("Pipeline", func() {
 		}
 		v1alpha1.DefaultUserProvidedContainersSecurityContext = globalDefaultSecurityContext
 		v1alpha1.DefaultImagePullPolicy = ""
+		v1alpha1.DefaultResourceRequirements = &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{ //nolint:exhaustive
+				corev1.ResourceCPU:              resource.MustParse("100m"),
+				corev1.ResourceMemory:           resource.MustParse("128Mi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{ //nolint:exhaustive
+				corev1.ResourceCPU:              resource.MustParse("200m"),
+				corev1.ResourceMemory:           resource.MustParse("256Mi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("256Mi"),
+			},
+		}
 		promiseCrd = &apiextensionsv1.CustomResourceDefinition{
 			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 				Group: "promise.crd.group",
@@ -1096,6 +1108,47 @@ var _ = Describe("Pipeline", func() {
 						Expect(err).ToNot(HaveOccurred())
 						statusContainer := resources.Job.Spec.Template.Spec.Containers[0]
 						Expect(string(statusContainer.ImagePullPolicy)).To(Equal("Never"))
+					})
+				})
+
+				When("DefaultResourceRequirements is overridden", func() {
+					BeforeEach(func() {
+						v1alpha1.DefaultResourceRequirements = &corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{ //nolint:exhaustive
+								corev1.ResourceCPU:              resource.MustParse("100m"),
+								corev1.ResourceMemory:           resource.MustParse("128Mi"),
+								corev1.ResourceEphemeralStorage: resource.MustParse("512Mi"),
+							},
+							Limits: corev1.ResourceList{ //nolint:exhaustive
+								corev1.ResourceCPU:              resource.MustParse("200m"),
+								corev1.ResourceMemory:           resource.MustParse("256Mi"),
+								corev1.ResourceEphemeralStorage: resource.MustParse("512Mi"),
+							},
+						}
+					})
+
+					It("applies the overridden ephemeral-storage requests and limits to the status-writer container", func() {
+						resources, err := factory.Resources(nil)
+						Expect(err).ToNot(HaveOccurred())
+						container := resources.Job.Spec.Template.Spec.Containers[0]
+						Expect(container.Name).To(Equal("status-writer"))
+						Expect(container.Resources.Requests.StorageEphemeral().String()).To(Equal("512Mi"))
+						Expect(container.Resources.Limits.StorageEphemeral().String()).To(Equal("512Mi"))
+					})
+
+					It("does not affect the default ephemeral-storage values after reset", func() {
+						Expect(v1alpha1.DefaultResourceRequirements.Requests.StorageEphemeral().String()).To(Equal("512Mi"))
+					})
+				})
+
+				When("DefaultResourceRequirements is not overridden", func() {
+					It("uses the hardcoded default ephemeral-storage values on the status-writer container", func() {
+						resources, err := factory.Resources(nil)
+						Expect(err).ToNot(HaveOccurred())
+						container := resources.Job.Spec.Template.Spec.Containers[0]
+						Expect(container.Name).To(Equal("status-writer"))
+						Expect(container.Resources.Requests.StorageEphemeral().String()).To(Equal("128Mi"))
+						Expect(container.Resources.Limits.StorageEphemeral().String()).To(Equal("256Mi"))
 					})
 				})
 			})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,9 +95,10 @@ type LoggingConfig struct {
 }
 
 type Workflows struct {
-	DefaultContainerSecurityContext corev1.SecurityContext `json:"defaultContainerSecurityContext"`
-	DefaultImagePullPolicy          corev1.PullPolicy      `json:"defaultImagePullPolicy,omitempty"`
-	JobOptions                      JobOptions             `json:"jobOptions,omitempty"`
+	DefaultContainerSecurityContext corev1.SecurityContext       `json:"defaultContainerSecurityContext"`
+	DefaultImagePullPolicy          corev1.PullPolicy            `json:"defaultImagePullPolicy,omitempty"`
+	DefaultContainerResources       *corev1.ResourceRequirements `json:"defaultContainerResources,omitempty"`
+	JobOptions                      JobOptions                   `json:"jobOptions,omitempty"`
 }
 
 type JobOptions struct {
@@ -180,13 +181,16 @@ func main() {
 	setupLog = ctrl.Log.WithName("setup")
 	setupLog.Info("logging configured from Kratix config", "structured", !opts.Development, "developmentMode", opts.Development, "level", opts.Level)
 
-	if kratixConfig != nil {
-		v1alpha1.DefaultUserProvidedContainersSecurityContext = &kratixConfig.Workflows.DefaultContainerSecurityContext
-		v1alpha1.DefaultImagePullPolicy = kratixConfig.Workflows.DefaultImagePullPolicy
-		if kratixConfig.Workflows.JobOptions.DefaultBackoffLimit != nil {
-			v1alpha1.DefaultJobBackoffLimit = kratixConfig.Workflows.JobOptions.DefaultBackoffLimit
-		}
-	}
+    if kratixConfig != nil {
+        v1alpha1.DefaultUserProvidedContainersSecurityContext = &kratixConfig.Workflows.DefaultContainerSecurityContext
+        v1alpha1.DefaultImagePullPolicy = kratixConfig.Workflows.DefaultImagePullPolicy
+        if kratixConfig.Workflows.JobOptions.DefaultBackoffLimit != nil {
+            v1alpha1.DefaultJobBackoffLimit = kratixConfig.Workflows.JobOptions.DefaultBackoffLimit
+        }
+        if kratixConfig.Workflows.DefaultContainerResources != nil {
+            v1alpha1.DefaultResourceRequirements = kratixConfig.Workflows.DefaultContainerResources
+        }
+    }
 
 	podTTLAfterFinished := getPodTTLAfterFinished(kratixConfig)
 


### PR DESCRIPTION
### Problem

Kratix-injected containers (`status-writer` on Configure, `work-creator` on Delete) hardcode
`Resources: *DefaultResourceRequirements` and are not accessible from the Promise spec.

### Solution

Add `defaultContainerResources` to the `workflows` section of the `kratix` ConfigMap, following
the same pattern as `defaultImagePullPolicy` and `defaultContainerSecurityContext`.
When set, it overwrites `DefaultResourceRequirements` at startup.

```yaml
data:
  config: |
    workflows:
      defaultContainerResources:
        requests:
          cpu: "100m"
          memory: "128Mi"
          ephemeral-storage: "256Mi"
        limits:
          cpu: "200m"
          memory: "256Mi"
          ephemeral-storage: "256Mi"
```

### Changes

| File | Change |
|------|--------|
| `cmd/main.go` | Added `DefaultContainerResources *corev1.ResourceRequirements` to the `Workflows` struct; wired it to `v1alpha1.DefaultResourceRequirements` at startup if set |
| `api/v1alpha1/pipeline_types_test.go` | Reset `DefaultResourceRequirements` in global `BeforeEach` to prevent test pollution; added tests verifying the override is applied to the `status-writer` container |

