### PR TITLE
feat: set pipeline execution status for resources

### DIFF
--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -233,8 +233,21 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
+	statusChanged := false
 	if resourceutil.GetWorkflowsCounterStatus(rr, "workflows") != int64(len(pipelineResources)) {
 		resourceutil.SetStatus(rr, logger, "workflows", int64(len(pipelineResources)))
+		statusChanged = true
+	}
+
+	workflowStatusChanged, err := ensureRRKratixWorkflowStatusIsSetup(rr, pipelineResources)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if workflowStatusChanged {
+		statusChanged = true
+	}
+
+	if statusChanged {
 		return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
 	}
 
@@ -268,7 +281,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	}
 
 	if !promise.HasPipeline(v1alpha1.WorkflowTypeResource, v1alpha1.WorkflowActionConfigure) {
-		return r.nextReconciliation(logger), r.updateWorkflowStatusCountersToZero(logger, rr, ctx)
+		return r.nextReconciliation(logger), r.cleanupWorkflowCountersAndExecution(ctx, logger, rr)
 	}
 
 	rrNamespace := ""
@@ -547,15 +560,37 @@ func (r *DynamicResourceRequestController) generateWorkflowsCounterStatus(logger
 	return false
 }
 
-func (r *DynamicResourceRequestController) updateWorkflowStatusCountersToZero(logger logr.Logger, rr *unstructured.Unstructured, ctx context.Context) error {
+func (r *DynamicResourceRequestController) cleanupWorkflowCountersAndExecution(ctx context.Context, logger logr.Logger,
+	rr *unstructured.Unstructured) error {
 	if resourceutil.GetWorkflowsCounterStatus(rr, "workflows") != 0 ||
 		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsSucceeded") != 0 ||
 		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsFailed") != 0 {
 
 		resourceutil.SetStatus(rr, logger, "workflows", int64(0), "workflowsSucceeded", int64(0), "workflowsFailed", int64(0))
+		unstructured.RemoveNestedField(rr.Object, "status", "kratix", "workflows", "pipelines")
 		return r.Client.Status().Update(ctx, rr)
 	}
 	return nil
+}
+
+func ensureRRKratixWorkflowStatusIsSetup(rr *unstructured.Unstructured, pipelines []v1alpha1.PipelineJobResources) (bool, error) {
+	existingPipelines, found, err := unstructured.NestedSlice(rr.Object, "status", "kratix", "workflows", "pipelines")
+	if err != nil {
+		return false, err
+	}
+
+	if !found || len(existingPipelines) != len(pipelines) {
+		return true, resourceutil.ResetPipelineStatusToPending(rr, pipelines)
+	}
+
+	for i, pipeline := range pipelines {
+		pipelineStatus, ok := existingPipelines[i].(map[string]any)
+		if !ok || pipelineStatus["name"] != pipeline.Name {
+			return true, resourceutil.ResetPipelineStatusToPending(rr, pipelines)
+		}
+	}
+
+	return false, nil
 }
 
 func (r *DynamicResourceRequestController) deleteResources(o opts, promise *v1alpha1.Promise, resourceRequest *unstructured.Unstructured) (ctrl.Result, error) {

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -335,6 +335,11 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				observedGeneration := resourceutil.GetObservedGeneration(resReq)
 				setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
 				setReconcileConfigureWorkflowToReturnFinished()
+				// Reconcile until the reconciliation loop reaches observed generation update
+				// first reconcile will return at updating workflow execution phases to 'pending'
+				result, err = reconciler.Reconcile(ctx, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
 				result, err = reconciler.Reconcile(ctx, request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
@@ -769,6 +774,24 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflowsSucceeded")).To(Equal(int64(0)))
 					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflowsFailed")).To(Equal(int64(0)))
 				})
+			})
+
+			It("initialises kratix workflow pipelines to pending before workflow reconciliation", func() {
+				request := ctrl.Request{NamespacedName: resReqNameNamespace}
+				result, err := reconciler.Reconcile(ctx, request)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+				workflows, found, err := unstructured.NestedSlice(resReq.Object, "status", "kratix", "workflows", "pipelines")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(workflows).To(HaveLen(1))
+				Expect(workflows[0]).To(SatisfyAll(
+					HaveKeyWithValue("name", "first-pipeline"),
+					HaveKeyWithValue("phase", v1alpha1.WorkflowPhasePending),
+					HaveKeyWithValue("lastTransitionTime", Not(BeEmpty())),
+				))
 			})
 
 			When("all configure pipelines are successful", func() {

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1671,6 +1671,26 @@ func setStatusFieldsOnCRD(rrCRD *apiextensionsv1.CustomResourceDefinition) {
 								"lastSuccessfulConfigureWorkflowTime": {
 									Type: "string",
 								},
+								"pipelines": {
+									Type: "array",
+									Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+										Schema: &apiextensionsv1.JSONSchemaProps{
+											Type: "object",
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"name": {
+													Type: "string",
+												},
+												"phase": {
+													Type: "string",
+												},
+												"lastTransitionTime": {
+													Type:   "string",
+													Format: "datetime",
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -139,6 +139,19 @@ var _ = Describe("PromiseController", func() {
 						lastSuccessfulConfigureWorkflowTime, ok := kratixWorkflows.Properties["lastSuccessfulConfigureWorkflowTime"]
 						Expect(ok).To(BeTrue(), ".status.kratix.workflows.lastSuccessfulConfigureWorkflowTime did not exist. Spec %v", kratixWorkflows)
 						Expect(lastSuccessfulConfigureWorkflowTime.Type).To(Equal("string"))
+						pipelines, ok := kratixWorkflows.Properties["pipelines"]
+						Expect(ok).To(BeTrue(), ".status.kratix.workflows.pipelines did not exist. Spec %v", kratixWorkflows)
+						Expect(pipelines.Type).To(Equal("array"))
+						Expect(pipelines.Items).NotTo(BeNil())
+						Expect(pipelines.Items.Schema).NotTo(BeNil())
+						Expect(pipelines.Items.Schema.Type).To(Equal("object"))
+						Expect(pipelines.Items.Schema.Properties).To(
+							SatisfyAll(HaveKey("name"),
+								HaveKey("phase"),
+								HaveKey("lastTransitionTime")))
+						Expect(pipelines.Items.Schema.Properties["name"].Type).To(Equal("string"))
+						Expect(pipelines.Items.Schema.Properties["phase"].Type).To(Equal("string"))
+						Expect(pipelines.Items.Schema.Properties["lastTransitionTime"].Type).To(Equal("string"))
 
 						observedGeneration, ok := status.Properties["observedGeneration"]
 						Expect(ok).To(BeTrue(), ".status.observedGeneration did not exist. Spec %v", status)

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -14,7 +14,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -336,19 +335,22 @@ func MarkCurrentPipelineAsRunning(rr *unstructured.Unstructured, logger logr.Log
 }
 
 func MarkCurrentPipelineAs(status string, rr *unstructured.Unstructured, logger logr.Logger, job *batchv1.Job) error {
-	if rr.GetKind() != "Promise" {
-		return nil
-	}
-	promise := &v1alpha1.Promise{}
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(rr.Object, promise)
+	workflows, found, err := unstructured.NestedSlice(rr.Object, "status", "kratix", "workflows", "pipelines")
 	if err != nil {
-		logging.Warn(logger, "failed to convert to promise", "error", err)
+		logging.Warn(logger, "failed to get workflow pipeline status", "error", err)
 		return err
+	}
+	if !found {
+		return nil
 	}
 
 	pipelineIndex := -1
-	for i, pipeline := range promise.Status.Kratix.Workflows.Pipelines {
-		if pipeline.Name == job.GetLabels()[v1alpha1.PipelineNameLabel] {
+	for i, pipeline := range workflows {
+		pipelineMap, ok := pipeline.(map[string]any)
+		if !ok {
+			continue
+		}
+		if pipelineMap["name"] == job.GetLabels()[v1alpha1.PipelineNameLabel] {
 			pipelineIndex = i
 			break
 		}
@@ -358,39 +360,28 @@ func MarkCurrentPipelineAs(status string, rr *unstructured.Unstructured, logger 
 		return fmt.Errorf("no pipeline found for job %s", job.GetName())
 	}
 
-	previousPhase := promise.Status.Kratix.Workflows.Pipelines[pipelineIndex].Phase
-	changed := previousPhase != status
-	if changed {
-		promise.Status.Kratix.Workflows.Pipelines[pipelineIndex].Phase = status
-		promise.Status.Kratix.Workflows.Pipelines[pipelineIndex].LastTransitionTime = metav1.Now()
-	}
-
-	rr.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(promise)
-	return err
-}
-
-func ResetPipelineStatusToPending(obj *unstructured.Unstructured) error {
-	if obj.GetKind() != "Promise" {
+	pipeline := workflows[pipelineIndex].(map[string]any)
+	if previousPhase, ok := pipeline["phase"].(string); ok && previousPhase == status {
 		return nil
 	}
-	promise := &v1alpha1.Promise{}
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, promise)
-	if err != nil {
-		return err
-	}
-	workflows := []v1alpha1.WorkflowPipelineStatus{}
 
-	for _, pipeline := range promise.Spec.Workflows.Promise.Configure {
-		workflows = append(workflows, v1alpha1.WorkflowPipelineStatus{
-			Name:               pipeline.GetName(),
-			Phase:              v1alpha1.WorkflowPhasePending,
-			LastTransitionTime: metav1.NewTime(time.Now()),
+	pipeline["phase"] = status
+	pipeline["lastTransitionTime"] = metav1.Now().Format(time.RFC3339)
+	workflows[pipelineIndex] = pipeline
+	return unstructured.SetNestedSlice(rr.Object, workflows, "status", "kratix", "workflows", "pipelines")
+}
+
+func ResetPipelineStatusToPending(obj *unstructured.Unstructured, pipelines []v1alpha1.PipelineJobResources) error {
+	workflows := make([]any, 0, len(pipelines))
+	for _, pipeline := range pipelines {
+		workflows = append(workflows, map[string]any{
+			"name":               pipeline.Name,
+			"phase":              v1alpha1.WorkflowPhasePending,
+			"lastTransitionTime": metav1.Now().Format(time.RFC3339),
 		})
 	}
 
-	promise.Status.Kratix.Workflows.Pipelines = workflows
-	obj.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(promise)
-	return err
+	return unstructured.SetNestedSlice(obj.Object, workflows, "status", "kratix", "workflows", "pipelines")
 }
 
 // GetObservedGeneration returns 0 when either status or status.observedGeneration is nil

--- a/lib/resourceutil/util_test.go
+++ b/lib/resourceutil/util_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/syntasso/kratix/api/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -404,6 +405,90 @@ var _ = Describe("Conditions", func() {
 		Context("GetKratixWorkflowsStatus", func() {
 			It("returns empty string for missing keys", func() {
 				Expect(resourceutil.GetKratixWorkflowsStatus(rr, "lastSuccessfulConfigureWorkflowTime")).To(BeEmpty())
+			})
+		})
+
+		Describe("pipeline execution status", func() {
+			var job *batchv1.Job
+			var pipelines []v1alpha1.PipelineJobResources
+
+			BeforeEach(func() {
+				rr.SetAPIVersion("test.kratix.io/v1alpha1")
+				rr.SetKind("Redis")
+				rr.Object["status"] = map[string]interface{}{
+					"kratix": map[string]interface{}{
+						"workflows": map[string]interface{}{
+							"pipelines": []interface{}{
+								map[string]interface{}{
+									"name":  "first-pipeline",
+									"phase": v1alpha1.WorkflowPhasePending,
+								},
+							},
+						},
+					},
+				}
+
+				pipelines = []v1alpha1.PipelineJobResources{
+					{Name: "first-pipeline"},
+					{Name: "second-pipeline"},
+				}
+
+				job = &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job-1",
+						Labels: map[string]string{
+							v1alpha1.PipelineNameLabel: "first-pipeline",
+						},
+					},
+				}
+			})
+
+			It("marks the current pipeline as succeeded for a resource request", func() {
+				err := resourceutil.MarkCurrentPipelineAsSucceeded(rr, logger, job)
+				Expect(err).NotTo(HaveOccurred())
+
+				workflows, found, err := unstructured.NestedSlice(rr.Object, "status", "kratix", "workflows", "pipelines")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(workflows).To(HaveLen(1))
+
+				pipeline := workflows[0].(map[string]interface{})
+				Expect(pipeline["phase"]).To(Equal(v1alpha1.WorkflowPhaseSucceeded))
+				Expect(pipeline["lastTransitionTime"]).NotTo(BeNil())
+			})
+
+			It("marks the current pipeline with an explicit phase for a resource request", func() {
+				err := resourceutil.MarkCurrentPipelineAs(v1alpha1.WorkflowPhaseFailed, rr, logger, job)
+				Expect(err).NotTo(HaveOccurred())
+
+				workflows, found, err := unstructured.NestedSlice(rr.Object, "status", "kratix", "workflows", "pipelines")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(workflows).To(HaveLen(1))
+
+				pipeline := workflows[0].(map[string]interface{})
+				Expect(pipeline["phase"]).To(Equal(v1alpha1.WorkflowPhaseFailed))
+				Expect(pipeline["lastTransitionTime"]).NotTo(BeNil())
+			})
+
+			It("resets resource request pipelines to pending", func() {
+				err := resourceutil.ResetPipelineStatusToPending(rr, pipelines)
+				Expect(err).NotTo(HaveOccurred())
+
+				workflows, found, err := unstructured.NestedSlice(rr.Object, "status", "kratix", "workflows", "pipelines")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(workflows).To(HaveLen(2))
+				Expect(workflows[0]).To(SatisfyAll(
+					HaveKeyWithValue("name", "first-pipeline"),
+					HaveKeyWithValue("phase", v1alpha1.WorkflowPhasePending),
+					HaveKeyWithValue("lastTransitionTime", Not(BeNil())),
+				))
+				Expect(workflows[1]).To(SatisfyAll(
+					HaveKeyWithValue("name", "second-pipeline"),
+					HaveKeyWithValue("phase", v1alpha1.WorkflowPhasePending),
+					HaveKeyWithValue("lastTransitionTime", Not(BeNil())),
+				))
 			})
 		})
 

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -231,7 +231,7 @@ func reconcileWorkflowStatus(opts Opts, state *workflowState) (passiveRequeue bo
 	}
 
 	succeededCountDrifted := currentSucceededCount != state.completedCount
-	shouldResetForManualRetry := state.manualReconcile && currentFailedCount != 0
+	shouldResetForManualRetry := state.manualReconcile && (currentFailedCount != 0 || currentSucceededCount != 0)
 	failedCountDrifted := state.desiredFailedCount != nil && currentFailedCount != *state.desiredFailedCount
 	pipelinePhaseDrifted := state.desiredPipelineJob != nil && state.desiredPipelinePhase != ""
 
@@ -251,7 +251,7 @@ func reconcileWorkflowStatus(opts Opts, state *workflowState) (passiveRequeue bo
 
 	if shouldResetForManualRetry || (succeededCountDrifted && state.completedCount == 0) {
 		resourceutil.SetStatus(opts.parentObject, opts.logger, "workflowsFailed", int64(0))
-		if err = resourceutil.ResetPipelineStatusToPending(opts.parentObject); err != nil {
+		if err = resourceutil.ResetPipelineStatusToPending(opts.parentObject, opts.Resources); err != nil {
 			return false, err
 		}
 	}

--- a/test/core/core_test.go
+++ b/test/core/core_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Core Tests", Ordered, func() {
 
 		It("should deliver xaas to users", func() {
 			var originalPromiseConfigMapTimestamp1 string
+			pipelinesExecutionStatusPath := ".status.kratix.workflows.pipelines"
 			By("successfully installing a Promise", func() {
 				Expect(platform.Kubectl("apply", "-f", "assets/promise.yaml")).To(ContainSubstring("testbundle created"))
 
@@ -178,7 +179,6 @@ var _ = Describe("Core Tests", Ordered, func() {
 						promiseWorkflows := ".status.workflows"
 						promiseWorkflowsSucceeded := ".status.workflowsSucceeded"
 						promiseWorkflowsFailed := ".status.workflowsFailed"
-						promiseWorkflowPipelines := ".status.kratix.workflows.pipelines"
 
 						Eventually(func(g Gomega) {
 							g.Expect(
@@ -204,7 +204,7 @@ var _ = Describe("Core Tests", Ordered, func() {
 							).To(ContainSubstring("1"))
 
 							var parsedOutput [][]v1alpha1.WorkflowPipelineStatus // jsonpath-as-json returns a nested array of the target objects
-							jsonOutput := platform.Kubectl(append(promiseArgs, fmt.Sprintf(`-o=jsonpath-as-json={%s}`, promiseWorkflowPipelines))...)
+							jsonOutput := platform.Kubectl(append(promiseArgs, fmt.Sprintf(`-o=jsonpath-as-json={%s}`, pipelinesExecutionStatusPath))...)
 							json.Unmarshal([]byte(jsonOutput), &parsedOutput)
 							// TODO: remove after releasing: only assert if '.kratix.workflows.pipelines' is set
 							if len(parsedOutput) != 0 {
@@ -248,6 +248,21 @@ var _ = Describe("Core Tests", Ordered, func() {
 						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.workflows}'")...)).To(ContainSubstring("2"))
 						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.workflowsSucceeded}'")...)).To(ContainSubstring("2"))
 						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.workflowsFailed}'")...)).To(ContainSubstring("0"))
+
+						if platform.Kubectl(append(rrArgs, `-o=jsonpath={.status.kratix.workflows}`)...) != "" {
+							var parsedOutput [][]v1alpha1.WorkflowPipelineStatus
+							jsonOutput := platform.Kubectl(append(rrArgs, fmt.Sprintf(`-o=jsonpath-as-json={%s}`, pipelinesExecutionStatusPath))...)
+							json.Unmarshal([]byte(jsonOutput), &parsedOutput)
+							g.Expect(parsedOutput).To(HaveLen(1))
+							workflowPipelines := parsedOutput[0]
+							g.Expect(workflowPipelines).To(HaveLen(2))
+							g.Expect(workflowPipelines[0].Name).To(Equal("resource-pipeline0"))
+							g.Expect(workflowPipelines[0].Phase).To(Equal(v1alpha1.WorkflowPhaseSucceeded))
+							g.Expect(workflowPipelines[0].LastTransitionTime).To(Not(BeZero()))
+							g.Expect(workflowPipelines[1].Name).To(Equal("resource-pipeline1"))
+							g.Expect(workflowPipelines[1].Phase).To(Equal(v1alpha1.WorkflowPhaseSucceeded))
+							g.Expect(workflowPipelines[1].LastTransitionTime).To(Not(BeZero()))
+						}
 					}, timeout, interval).Should(Succeed())
 
 					Eventually(func() bool {
@@ -320,6 +335,7 @@ var _ = Describe("Core Tests", Ordered, func() {
 				})
 
 				By("rerunning pipelines when updating a resource request", func() {
+					rrArgs := []string{"-n", "default", "get", "testbundle", resourceRequestName}
 					originalTimeStampW1 := worker.Kubectl(append(cmArgs, rrConfigMapName+"-1", "-o=jsonpath={.data.timestamp}")...)
 					originalTimeStampW2 := worker.Kubectl(append(cmArgs, rrConfigMapName+"-2", "-o=jsonpath={.data.timestamp}")...)
 					Expect(
@@ -335,6 +351,36 @@ var _ = Describe("Core Tests", Ordered, func() {
 							worker.Kubectl(append(cmArgs, rrConfigMapName+"-2", "-o=jsonpath={.data.timestamp}")...),
 						).ToNot(Equal(originalTimeStampW2))
 					}, longerTimeout, interval).Should(Succeed())
+
+					if platform.Kubectl(append(rrArgs, `-o=jsonpath={.status.kratix.workflows}`)...) != "" {
+						Eventually(func(g Gomega) {
+							var parsedOutput [][]v1alpha1.WorkflowPipelineStatus
+							jsonOutput := platform.Kubectl(append(rrArgs, fmt.Sprintf(`-o=jsonpath-as-json={%s}`, pipelinesExecutionStatusPath))...)
+							json.Unmarshal([]byte(jsonOutput), &parsedOutput)
+							g.Expect(parsedOutput).To(HaveLen(1))
+							workflowPipelines := parsedOutput[0]
+							g.Expect(workflowPipelines).To(HaveLen(2))
+							for _, pipeline := range workflowPipelines {
+								g.Expect(pipeline.Phase).To(Or(
+									Equal(v1alpha1.WorkflowPhasePending),
+									Equal(v1alpha1.WorkflowPhaseRunning),
+									Equal(v1alpha1.WorkflowPhaseSucceeded),
+								))
+								g.Expect(pipeline.LastTransitionTime).To(Not(BeZero()))
+							}
+						}, timeout, interval).Should(Succeed())
+
+						Eventually(func(g Gomega) {
+							var parsedOutput [][]v1alpha1.WorkflowPipelineStatus
+							jsonOutput := platform.Kubectl(append(rrArgs, fmt.Sprintf(`-o=jsonpath-as-json={%s}`, pipelinesExecutionStatusPath))...)
+							json.Unmarshal([]byte(jsonOutput), &parsedOutput)
+							g.Expect(parsedOutput).To(HaveLen(1))
+							workflowPipelines := parsedOutput[0]
+							g.Expect(workflowPipelines).To(HaveLen(2))
+							g.Expect(workflowPipelines[0].Phase).To(Equal(v1alpha1.WorkflowPhaseSucceeded))
+							g.Expect(workflowPipelines[1].Phase).To(Equal(v1alpha1.WorkflowPhaseSucceeded))
+						}, longerTimeout, interval).Should(Succeed())
+					}
 				})
 			})
 


### PR DESCRIPTION
## Context

closes #677 

Looks like:
```yaml
status:
  kratix:
    workflows:
      lastSuccessfulConfigureWorkflowTime: "2026-03-16T11:52:06Z"
      pipelines:
      - lastTransitionTime: "2026-03-16T11:53:04Z"
        name: resource-pipeline0
        phase: Succeeded
      - lastTransitionTime: "2026-03-16T11:58:53Z"
        name: resource-pipeline1
        phase: Failed
      - lastTransitionTime: "2026-03-16T11:52:57Z"
        name: resource-pipeline2
        phase: Pending
```