### PR TITLE
fix: handle no resource configure pipelines gracefully

### DIFF
--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -149,6 +149,11 @@ type workflowState struct {
 // resources are updated (for example workflow Jobs or the parent object status),
 // rather than by issuing an explicit direct requeue from this function.
 func ReconcileConfigure(opts Opts) (passiveRequeue bool, err error) {
+	if len(opts.Resources) == 0 {
+		logging.Debug(opts.logger, "no pipeline resources to reconcile")
+		return false, nil
+	}
+
 	state, err := determineWorkflowState(opts)
 	if err != nil {
 		return false, err

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -99,6 +99,18 @@ var _ = Describe("Workflow Reconciler", func() {
 			workflowPipelines, uPromise = setupTest(promise, pipelines)
 		})
 
+		When("list of pipeline resources are empty", func() {
+			It("does not panic", func() {
+				opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, nil, "promise", 5, namespace)
+
+				Expect(func() {
+					passiveRequeue, err := workflow.ReconcileConfigure(opts)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(passiveRequeue).To(BeFalse())
+				}).NotTo(Panic())
+			})
+		})
+
 		When("no pipeline for the workflow was executed", func() {
 			var opts workflow.Opts
 			BeforeEach(func() {


### PR DESCRIPTION
# Context

Install a promise with no resource configure workflow and make a request:

Panic:
```
  {"level":"error","ts":"2026-03-16T15:32:17Z","msg":"Observed a panic","controller":"localkey","controllerGroup":"platform.kratix.io","controllerKind":"LocalKey","LocalKey":{"name":"test-resource","namespace":"default"},"namespace":"
  default","name":"test-resource","reconcileID":"67a89bf3-ef23-46a1-942e-8601028c098b","panic":"runtime error: index out of range [0] with length 0","panicGoValue":"runtime.boundsError{x:0, y:0, signed:true, code:0x0}","stacktrace":"g
  oroutine 917 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x1f3aa08, 0x20036cec90b0}, {0x1bf9260, 0x20036c1f6030})\n\t/go/pkg/mod/k8s.io/apimachinery@v0.32.1/pkg/util/runtime/runtime.go:107 +0x94\nsigs.k8s.io/controlle
  r-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:108 +0xd4\npanic({0x1bf9260?, 0x20036c1f6030?})\n\t/usr/local/go/src/
  runtime/panic.go:860 +0x12c\ngithub.com/syntasso/kratix/lib/workflow.ReconcileConfigure({{0x1f3aa08, 0x20036cef6c30}, {0x1f515a0, 0x20036c804e10}, {{0x1f445a0, 0x20036cef6270}, 0x0}, 0x20036c5831d8, {0x0, 0x0, ...}, ...})\n\t/worksp
  ace/lib/workflow/reconciler.go:169 +0x340\ngithub.com/syntasso/kratix/internal/controller.(*DynamicResourceRequestController).Reconcile(0x20036c853810, {0x1f3aa08, 0x20036cec90b0}, {{{0x20036c1ad709?, 0x0?}, {0x20036c1ad6f0?, 0x5?}}
  })\n\t/workspace/internal/controller/dynamic_resource_request_controller.go:270 +0x11fc\nsigs.k8s.io/controller
  ```

This is because there used to be this check in ReconcileConfigure:
```
	if pipelineIndex >= len(opts.Resources) {
		pipelineIndex = len(opts.Resources) - 1
	}

	if pipelineIndex < 0 {
		logging.Debug(opts.logger, "no pipeline to reconcile", "index", pipelineIndex)
		return false, nil
	}
```

which is removed with this commit: https://github.com/syntasso/kratix/commit/10b9a792106008dd5898351e838a98264cc66bc8#diff-a3e8b465de8cc1c0035d46ecc992121734603e0975e67028989ac49223ed5ed8