### PR TITLE
fix: skip workflow control file handling for non promise and resource

### DIFF
--- a/work-creator/cmd/update_status.go
+++ b/work-creator/cmd/update_status.go
@@ -92,28 +92,30 @@ func updateStatus(ctx context.Context, baseDir string, params *helpers.Parameter
 		mergedStatus = lib.MarkAsCompleted(mergedStatus, params.WorkflowType)
 	}
 
-	control, err := readWorkflowControlFile(controlFile)
-	if err != nil {
-		return err
-	}
-
-	if control != nil && control.Suspend {
-		fmt.Fprintln(
-			os.Stdout,
-			"Info: workflow-control.yaml file found with suspend set to true; will label the object and update its pipeline execution status.")
-		existingObj, err = addWorkflowSuspendLabel(ctx, objectClient, existingObj)
+	if params.WorkflowType == v1alpha1.WorkflowTypePromise || params.WorkflowType == v1alpha1.WorkflowTypeResource {
+		control, err := readWorkflowControlFile(controlFile)
 		if err != nil {
 			return err
 		}
 
-		mergedStatus, err = lib.MarkPipelineAsSuspended(mergedStatus, params.PipelineName, control.Message, existingObj.GetGeneration())
-		if err != nil {
-			return err
-		}
-	} else {
-		mergedStatus, err = lib.ClearPipelineSuspension(mergedStatus, params.PipelineName)
-		if err != nil {
-			return err
+		if control != nil && control.Suspend {
+			fmt.Fprintln(
+				os.Stdout,
+				"Info: workflow-control.yaml file found with suspend set to true; will label the object and update its pipeline execution status.")
+			existingObj, err = addWorkflowSuspendLabel(ctx, objectClient, existingObj)
+			if err != nil {
+				return err
+			}
+
+			mergedStatus, err = lib.MarkPipelineAsSuspended(mergedStatus, params.PipelineName, control.Message, existingObj.GetGeneration())
+			if err != nil {
+				return err
+			}
+		} else {
+			mergedStatus, err = lib.ClearPipelineSuspension(mergedStatus, params.PipelineName)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Context

Some types of pipelines won't be supporting workflow control file.

Or else when we are using the workflow reconciler to execute other workflow types and includes pipeline names that are not in the list of configure pipelines, we can get error like:
```
❯ k -n kratix-platform-system logs kratix-map-backstage-gen-1de7a-pw7v6 -c status-writer
Error: pipeline "backstage-gen" not found in status.kratix.workflows.pipelines
Usage:
  pipeline-adapter update-status [flags]

Flags:
  -h, --help   help for update-status

Error: pipeline "backstage-gen" not found in status.kratix.workflows.pipelines
```