### PR TITLE
fix: reset reconcile condition correct when running from suspended

### DIFF
--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -346,6 +346,25 @@ func MarkCurrentPipelineAsRunning(rr *unstructured.Unstructured, logger logr.Log
 	return MarkCurrentPipelineAs(v1alpha1.WorkflowPhaseRunning, rr, logger, job)
 }
 
+func GetCurrentPipelinePhase(rr *unstructured.Unstructured, job *batchv1.Job) string {
+	workflows, found, err := unstructured.NestedSlice(rr.Object, "status", "kratix", "workflows", "pipelines")
+	if err != nil || !found {
+		return ""
+	}
+	pipelineName := job.GetLabels()[v1alpha1.PipelineNameLabel]
+	for _, pipeline := range workflows {
+		pipelineMap, ok := pipeline.(map[string]any)
+		if !ok {
+			continue
+		}
+		if pipelineMap["name"] == pipelineName {
+			phase, _ := pipelineMap["phase"].(string)
+			return phase
+		}
+	}
+	return ""
+}
+
 func MarkCurrentPipelineAs(status string, rr *unstructured.Unstructured, logger logr.Logger, job *batchv1.Job) error {
 	workflows, found, err := unstructured.NestedSlice(rr.Object, "status", "kratix", "workflows", "pipelines")
 	if err != nil {

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -619,17 +619,9 @@ func createConfigurePipeline(opts Opts, state *workflowState, resources v1alpha1
 
 	opts.eventRecorder.Eventf(opts.parentObject, "Normal", "PipelineStarted", "Configure Pipeline started: %s", resources.Name)
 
-	updated, err := setConfigureWorkflowCompletedConditionStatus(opts, state.pipelineIndex, opts.parentObject)
-	if err != nil || updated {
-		return updated, err
+	if err = setPipelineStartingStatus(opts, state.pipelineIndex, opts.parentObject, resources.Job); err != nil {
+		return false, err
 	}
-
-	state.desiredPipelinePhase = v1alpha1.WorkflowPhaseRunning
-	state.desiredPipelineJob = resources.Job
-	if updated, err = reconcileWorkflowStatus(opts, state); err != nil || updated {
-		return updated, err
-	}
-
 	return true, nil
 }
 
@@ -654,34 +646,53 @@ func removeLabel(opts Opts, labelKey string) error {
 	return nil
 }
 
-func setConfigureWorkflowCompletedConditionStatus(opts Opts, pipelineIndex int, obj *unstructured.Unstructured) (bool, error) {
+func setPipelineStartingStatus(opts Opts, pipelineIndex int, obj *unstructured.Unstructured, job *batchv1.Job) error {
 	if opts.SkipConditions {
-		return false, nil
+		return nil
 	}
+
 	var updated bool
+
+	currentMessage := resourceutil.GetStatus(obj, "message")
+	if currentMessage != "Pending" {
+		logging.Debug(opts.logger, "updating status message to Pending", "previousMessage", currentMessage)
+		resourceutil.SetStatus(obj, opts.logger, "message", "Pending")
+		updated = true
+	}
+
+	reconciled := resourceutil.GetCondition(obj, resourceutil.ReconciledCondition)
+	if reconciled == nil || reconciled.Status != v1.ConditionUnknown || reconciled.Reason != "WorkflowPending" {
+		logging.Debug(opts.logger, "updating Reconciled condition to WorkflowPending")
+		resourceutil.MarkReconciledPending(obj, "WorkflowPending")
+		updated = true
+	}
+
 	switch resourceutil.GetConfigureWorkflowCompletedConditionStatus(obj) {
 	case v1.ConditionTrue:
 		fallthrough
 	case v1.ConditionUnknown:
-		currentMessage := resourceutil.GetStatus(obj, "message")
-		if pipelineIndex == 0 || currentMessage == "" || currentMessage == "Resource requested" {
-			resourceutil.SetStatus(obj, opts.logger, "message", "Pending")
-		}
+		logging.Debug(opts.logger, "marking ConfigureWorkflowCompleted as running")
 		resourceutil.MarkConfigureWorkflowAsRunning(opts.logger, obj)
-		resourceutil.MarkReconciledPending(obj, "WorkflowPending")
 		updated = true
 	default:
-		updated = false
+		// The Condition is false (running); no need to update anything
+	}
+
+	if resourceutil.GetCurrentPipelinePhase(obj, job) != v1alpha1.WorkflowPhaseRunning {
+		logging.Debug(opts.logger, "marking pipeline phase as Running", "pipelineIndex", pipelineIndex)
+		if err := resourceutil.MarkCurrentPipelineAs(v1alpha1.WorkflowPhaseRunning, obj, opts.logger, job); err != nil {
+			return err
+		}
+		updated = true
 	}
 
 	if updated {
-		logging.Info(opts.logger, "setting pipeline execution status", "pipelineIndex", pipelineIndex, "phase", v1alpha1.WorkflowPhaseRunning)
 		if err := opts.client.Status().Update(opts.ctx, obj); err != nil {
 			logging.Error(opts.logger, err, "failed to update object status")
-			return false, err
+			return err
 		}
 	}
-	return updated, nil
+	return nil
 }
 
 func getMostRecentDeletePipelineJob(opts Opts, namespace string, pipeline v1alpha1.PipelineJobResources) (*batchv1.Job, error) {

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -729,7 +729,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				Expect(resourceutil.GetWorkflowsCounterStatus(updatedResource, "workflowsSucceeded")).To(Equal(int64((0))))
 				Expect(resourceutil.GetWorkflowsCounterStatus(updatedResource, "workflowsFailed")).To(Equal(int64(0)))
 
-				//second reconciliation updates the status to pending with the correct conditions
+				//second reconciliation creates the pipeline and updates the status to pending with the correct conditions
 				passiveRequeue, err = workflow.ReconcileConfigure(opts)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(passiveRequeue).To(BeTrue())
@@ -737,7 +737,6 @@ var _ = Describe("Workflow Reconciler", func() {
 				updatedResource = &unstructured.Unstructured{}
 				updatedResource.SetGroupVersionKind(resource.GroupVersionKind())
 				Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(resource), updatedResource)).To(Succeed())
-				//first reconciliation sets the workflow counters to 0
 
 				Expect(updatedResource.Object["status"]).To(SatisfyAll(
 					HaveKeyWithValue("message", "Pending"),
@@ -765,6 +764,32 @@ var _ = Describe("Workflow Reconciler", func() {
 
 				Eventually(eventRecorder.Events).Should(Receive(ContainSubstring(
 					"Normal PipelineStarted Configure Pipeline started: pipeline-1")))
+			})
+
+			When("a suspended resource pipeline is resumed", func() {
+				It("resets status.message and Reconciled condition", func() {
+					updatedResource := &unstructured.Unstructured{}
+					updatedResource.SetGroupVersionKind(resource.GroupVersionKind())
+					Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(resource), updatedResource)).To(Succeed())
+
+					resourceutil.MarkConfigureWorkflowAsRunning(logger, updatedResource)
+					resourceutil.MarkReconciledSuspended(updatedResource)
+					resourceutil.SetStatus(updatedResource, logger, "message", "To-be-updated")
+					Expect(fakeK8sClient.Status().Update(ctx, updatedResource)).To(Succeed())
+
+					Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(resource), updatedResource)).To(Succeed())
+					opts = workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, updatedResource, workflowPipelines, "resource", 5, namespace)
+					passiveRequeue, err := workflow.ReconcileConfigure(opts)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(passiveRequeue).To(BeTrue())
+
+					Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(resource), updatedResource)).To(Succeed())
+					Expect(resourceutil.GetStatus(updatedResource, "message")).To(Equal("Pending"))
+					reconciled := resourceutil.GetCondition(updatedResource, resourceutil.ReconciledCondition)
+					Expect(reconciled).NotTo(BeNil())
+					Expect(reconciled.Message).To(Equal("Pending"))
+					Expect(reconciled.Reason).To(Equal("WorkflowPending"))
+				})
 			})
 		})
 


### PR DESCRIPTION
# Context

closes #761 

```
status:
  conditions:
  - lastTransitionTime: "2026-04-14T14:17:10Z"
    message: Pipelines are still in progress
    reason: PipelinesInProgress
    status: "False"
    type: ConfigureWorkflowCompleted
  - lastTransitionTime: "2026-04-14T14:17:25Z"
    message: Pending
    reason: WorkflowPending
    status: Unknown
    type: Reconciled
  kratix:
    workflows:
      pipelines:
      - lastTransitionTime: "2026-04-14T14:17:25Z"
        name: resource-pipe-0
        phase: Running
      suspendedGeneration: 1
```

Reconciled condition is being reset to `Pending` and `WorkflowPending`.