### PR TITLE
fix: Don't run resource workflows when Promise is unavailable

### DIFF
--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -191,7 +191,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return r.deleteResources(opts, promise, rr)
 	}
 
-	if !*r.CanCreateResources || promiseAvailableConditionIsFalse(promise) {
+	if r.promiseCannotFulfilResourceRequests(promise) {
 		return r.ensurePromiseIsUnavailable(ctx, rr, logger)
 	}
 
@@ -918,7 +918,10 @@ func (r *DynamicResourceRequestController) updateManualReconcileToTrue(ctx conte
 	return r.Client.Update(ctx, rr)
 }
 
-func promiseAvailableConditionIsFalse(promise *v1alpha1.Promise) bool {
+func (r *DynamicResourceRequestController) promiseCannotFulfilResourceRequests(promise *v1alpha1.Promise) bool {
+	if !*r.CanCreateResources {
+		return true
+	}
 	condition := promise.GetCondition(v1alpha1.PromiseAvailableConditionType)
 	return condition != nil && condition.Status == metav1.ConditionFalse
 }

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -191,7 +191,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return r.deleteResources(opts, promise, rr)
 	}
 
-	if !*r.CanCreateResources {
+	if !*r.CanCreateResources || promiseAvailableConditionIsFalse(promise) {
 		return r.ensurePromiseIsUnavailable(ctx, rr, logger)
 	}
 
@@ -916,6 +916,14 @@ func (r *DynamicResourceRequestController) updateManualReconcileToTrue(ctx conte
 	rr.SetLabels(resourceLabels)
 
 	return r.Client.Update(ctx, rr)
+}
+
+func promiseAvailableConditionIsFalse(promise *v1alpha1.Promise) bool {
+	condition := promise.GetCondition(v1alpha1.PromiseAvailableConditionType)
+	if condition == nil {
+		return false
+	}
+	return condition.Status == metav1.ConditionFalse
 }
 
 func (r *DynamicResourceRequestController) ensurePromiseIsUnavailable(ctx context.Context,

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -920,10 +920,7 @@ func (r *DynamicResourceRequestController) updateManualReconcileToTrue(ctx conte
 
 func promiseAvailableConditionIsFalse(promise *v1alpha1.Promise) bool {
 	condition := promise.GetCondition(v1alpha1.PromiseAvailableConditionType)
-	if condition == nil {
-		return false
-	}
-	return condition.Status == metav1.ConditionFalse
+	return condition != nil && condition.Status == metav1.ConditionFalse
 }
 
 func (r *DynamicResourceRequestController) ensurePromiseIsUnavailable(ctx context.Context,

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -250,19 +250,16 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				_, err := t.reconcileUntilCompletion(reconciler, resReq)
 				Expect(err).To(MatchError("reconcile loop detected"))
 				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
-				status := resReq.Object["status"]
-				statusMap := status.(map[string]interface{})
-				Expect(statusMap["message"].(string)).To(Equal("Pending"))
-
-				By("not triggering any configure workflows", func() {
-					Expect(reconcileConfigureOptsArg.Resources).To(BeEmpty())
-				})
+				Expect(resourceutil.IsPromiseMarkedAsUnavailable(resReq)).To(BeTrue())
+				Expect(reconcileConfigureOptsArg.Resources).To(BeEmpty())
 			})
 
 			When("the promise becomes available again", func() {
 				BeforeEach(func() {
 					_, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).To(MatchError("reconcile loop detected"))
+
+					reconcileConfigureOptsArg = workflow.Opts{}
 
 					Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(promise), promise)).To(Succeed())
 					promise.Status.Conditions = []metav1.Condition{
@@ -278,17 +275,12 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				})
 
 				It("clears the pending status on the resource request and triggers the configure workflow", func() {
-					reconcileConfigureOptsArg = workflow.Opts{}
-
 					_, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
 					Expect(resourceutil.IsPromiseMarkedAsUnavailable(resReq)).To(BeFalse())
-
-					By("triggering the configure workflow", func() {
-						Expect(reconcileConfigureOptsArg.Resources).NotTo(BeEmpty())
-					})
+					Expect(reconcileConfigureOptsArg.Resources).NotTo(BeEmpty())
 				})
 			})
 		})

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -231,6 +231,67 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				Expect(statusMap["message"].(string)).To(Equal("Pending"))
 			})
 		})
+
+		When("the promise Available condition is False", func() {
+			BeforeEach(func() {
+				reconcileConfigureOptsArg = workflow.Opts{}
+				Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(promise), promise)).To(Succeed())
+				promise.Status.Conditions = append(promise.Status.Conditions, metav1.Condition{
+					Type:               v1alpha1.PromiseAvailableConditionType,
+					Status:             metav1.ConditionFalse,
+					Reason:             "PromiseUnavailable",
+					Message:            "Cannot fulfil resource requests",
+					LastTransitionTime: metav1.Now(),
+				})
+				Expect(fakeK8sClient.Status().Update(ctx, promise)).To(Succeed())
+			})
+
+			It("sets the resource request status to pending without triggering workflows", func() {
+				_, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).To(MatchError("reconcile loop detected"))
+				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+				status := resReq.Object["status"]
+				statusMap := status.(map[string]interface{})
+				Expect(statusMap["message"].(string)).To(Equal("Pending"))
+
+				By("not triggering any configure workflows", func() {
+					Expect(reconcileConfigureOptsArg.Resources).To(BeEmpty())
+				})
+			})
+
+			When("the promise becomes available again", func() {
+				BeforeEach(func() {
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).To(MatchError("reconcile loop detected"))
+
+					Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(promise), promise)).To(Succeed())
+					promise.Status.Conditions = []metav1.Condition{
+						{
+							Type:               v1alpha1.PromiseAvailableConditionType,
+							Status:             metav1.ConditionTrue,
+							Reason:             "PromiseAvailable",
+							Message:            "Ready to fulfil resource requests",
+							LastTransitionTime: metav1.Now(),
+						},
+					}
+					Expect(fakeK8sClient.Status().Update(ctx, promise)).To(Succeed())
+				})
+
+				It("clears the pending status on the resource request and triggers the configure workflow", func() {
+					reconcileConfigureOptsArg = workflow.Opts{}
+
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+					Expect(resourceutil.IsPromiseMarkedAsUnavailable(resReq)).To(BeFalse())
+
+					By("triggering the configure workflow", func() {
+						Expect(reconcileConfigureOptsArg.Resources).NotTo(BeEmpty())
+					})
+				})
+			})
+		})
 	})
 
 	When("resource is being deleted", func() {

--- a/test/system/reconciliation_test.go
+++ b/test/system/reconciliation_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Reconciliation", func() {
 			By("resuming reconciliation for resource requests after unpaused")
 			Eventually(func() string {
 				return platform.Kubectl("get", "pods", "-l", podLabels, "-o", goTemplate)
-			}, 30*time.Second).Should(ContainSubstring("3"))
+			}, 90*time.Second).Should(ContainSubstring("3"))
 
 			Eventually(func() string {
 				return platform.Kubectl("get", promiseName, "one")


### PR DESCRIPTION
Before:
```
-> % k get promises
NAME    STATUS        KIND    API VERSION                      VERSION   MESSAGE
redis   Unavailable   redis   marketplace.kratix.io/v1alpha1   v0.1.0    Pending

-> % k -n kratix-platform-system get pod
NAME                                                  READY   STATUS       RESTARTS      AGE
kratix-platform-controller-manager-55fdbcfbd8-m4gls   1/1     Running      0             13m
kratix-redis-promise-configure-8431d-x5lm2            0/1     Init:Error   1 (11s ago)   18s
minio-6c6bdc6456-44vnx                                1/1     Running      0             13m

-> % k get promises
NAME    STATUS        KIND    API VERSION                      VERSION   MESSAGE
redis   Unavailable   redis   marketplace.kratix.io/v1alpha1   v0.1.0    Pending

-> % kaf resource-request.yaml
redis.marketplace.kratix.io/example created

-> % k get pods
NAME                                                  READY   STATUS            RESTARTS   AGE
kratix-redis-example-instance-configure-d0c94-2vbvt   0/1     PodInitializing   0          3s
```

After:
```
-> % k get promise
  NAME    STATUS        KIND    API VERSION                      VERSION   MESSAGE
  redis   Unavailable   redis   marketplace.kratix.io/v1alpha1   v0.1.0    Pending

  -> % k get pods -n kratix-platform-system
  NAME                                                  READY   STATUS       RESTARTS     AGE
  kratix-platform-controller-manager-58899df945-28fqw   1/1     Running      0            3m3s
  kratix-redis-promise-configure-07894-8sz62            0/1     Completed    0            38s
  kratix-redis-promise-configure-17fd5-7qjk2            0/1     Init:Error   1 (3s ago)   7s
  minio-6c6bdc6456-wj2cc                                1/1     Running      0            44m

  -> % kaf resource-request.yaml
  redis.marketplace.kratix.io/example created

  -> % k get pods -w
  ^C # nothing created
```