### PR TITLE
chore: Duplicate upgrade-related information into resource bindings from RR

### DIFF
--- a/api/v1alpha1/resourcebinding_types.go
+++ b/api/v1alpha1/resourcebinding_types.go
@@ -64,6 +64,9 @@ type ResourceBindingStatus struct {
 	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// Reference to the Resource Request version
+	// +optional
+	ResourceRequestVersion string `json:"resourceRequestVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/resourcebinding_types.go
+++ b/api/v1alpha1/resourcebinding_types.go
@@ -66,7 +66,7 @@ type ResourceBindingStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// Reference to the Resource Request version
 	// +optional
-	ResourceRequestVersion string `json:"resourceRequestVersion,omitempty"`
+	LastAppiedVersion string `json:"lastAppiedVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/resourcebinding_types.go
+++ b/api/v1alpha1/resourcebinding_types.go
@@ -66,7 +66,7 @@ type ResourceBindingStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// Reference to the Resource Request version
 	// +optional
-	LastAppiedVersion string `json:"lastAppiedVersion,omitempty"`
+	LastAppliedVersion string `json:"lastAppliedVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/platform.kratix.io_resourcebindings.yaml
+++ b/config/crd/bases/platform.kratix.io_resourcebindings.yaml
@@ -151,7 +151,7 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              lastAppiedVersion:
+              lastAppliedVersion:
                 description: Reference to the Resource Request version
                 type: string
             type: object

--- a/config/crd/bases/platform.kratix.io_resourcebindings.yaml
+++ b/config/crd/bases/platform.kratix.io_resourcebindings.yaml
@@ -151,6 +151,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              resourceRequestVersion:
+                description: Reference to the Resource Request version
+                type: string
             type: object
         required:
         - spec

--- a/config/crd/bases/platform.kratix.io_resourcebindings.yaml
+++ b/config/crd/bases/platform.kratix.io_resourcebindings.yaml
@@ -151,7 +151,7 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              resourceRequestVersion:
+              lastAppiedVersion:
                 description: Reference to the Resource Request version
                 type: string
             type: object

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -62,6 +63,7 @@ const (
 	resourceBindingVersionStatus      = "resourceBindingVersion"
 	promiseRevisionLookupFailedReason = "FailedPromiseRevisionLookup"
 	UnversionedPromiseVersion         = "not-set"
+	LatestVersion                     = "latest"
 )
 
 type DynamicResourceRequestController struct {
@@ -380,12 +382,18 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 		},
 	}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, resourceBinding, func() error {
-		resourceBinding.SetLabels(rrLabelsWithoutEphemeralTriggers(rr.GetLabels()))
-		for k, v := range resourceBindingLabels(rr, promise) {
-			resourceBinding.Labels[k] = v
+		// Exclude one-shot trigger labels — propagating them would cause the
+		// ResourceBinding controller to re-trigger reconciliation in an infinite loop.
+		mergedLabels := rr.GetLabels()
+		delete(mergedLabels, resourceutil.ManualReconciliationLabel)
+		delete(mergedLabels, resourceutil.WorkflowRunFromStartLabel)
+		if mergedLabels == nil {
+			mergedLabels = make(map[string]string)
 		}
+		maps.Copy(mergedLabels, resourceBindingLabels(rr, promise))
+		resourceBinding.SetLabels(mergedLabels)
 		if resourceBinding.Spec.Version == "" {
-			resourceBinding.Spec.Version = "latest"
+			resourceBinding.Spec.Version = LatestVersion
 			// if the resource binding got deleted, when we recreate the resource binding we infer what the resource binding
 			// version used to be from the resource request `status.resourceBindingVersion`
 			existingPromiseVersion := resourceutil.GetStatus(rr, resourceBindingVersionStatus)
@@ -1064,19 +1072,6 @@ func getPromiseRevisionToUse(ctx context.Context, rr *unstructured.Unstructured,
 	}
 
 	return promiseRevisionToUse, bindingVersion, nil
-}
-
-// rrLabelsWithoutEphemeralTriggers returns the RR labels without one-shot trigger
-// labels. Propagating these to the ResourceBinding would cause the ResourceBinding
-// controller to re-trigger reconciliation in an infinite loop.
-func rrLabelsWithoutEphemeralTriggers(rrLabels map[string]string) map[string]string {
-	result := make(map[string]string, len(rrLabels))
-	for k, v := range rrLabels {
-		result[k] = v
-	}
-	delete(result, resourceutil.ManualReconciliationLabel)
-	delete(result, resourceutil.WorkflowRunFromStartLabel)
-	return result
 }
 
 func resourceBindingLabels(rr *unstructured.Unstructured, promise *v1alpha1.Promise) map[string]string {

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -61,7 +61,7 @@ const (
 	resourcePromiseVersionStatus      = "promiseVersion"
 	resourceBindingVersionStatus      = "resourceBindingVersion"
 	promiseRevisionLookupFailedReason = "FailedPromiseRevisionLookup"
-	unversionedPromiseVersion         = "not-set"
+	UnversionedPromiseVersion         = "not-set"
 )
 
 type DynamicResourceRequestController struct {
@@ -292,13 +292,19 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return r.nextReconciliation(logger), r.cleanupWorkflowCountersAndExecution(ctx, logger, rr)
 	}
 
-	if updated, err := r.ensureResourceStatus(ctx, logger, rr, promise, pipelineResources, bindingVersion, promiseRevisionUsed); updated || err != nil {
+	statusUpdated, err := r.ensureResourceStatus(ctx, logger, rr, promise, pipelineResources, bindingVersion, promiseRevisionUsed)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
+	if statusUpdated {
+		return ctrl.Result{}, nil
+	}
 
-	if err := r.updateResourceBindingVersionStatus(ctx, logger, promise.GetName(), rr); err != nil {
-		logging.Error(logger, err, "failed to update resource binding version status")
-		return ctrl.Result{}, err
+	if r.PromiseUpgrade {
+		if err := r.updateResourceBindingVersionStatus(ctx, logger, promise.GetName(), rr); err != nil {
+			logging.Error(logger, err, "failed to update resource binding version status")
+			return ctrl.Result{}, err
+		}
 	}
 
 	workflowCompletedCondition := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
@@ -345,14 +351,9 @@ func (r *DynamicResourceRequestController) ensureResourceStatus(
 		return true, r.Client.Status().Update(ctx, rr)
 	}
 	return false, nil
-
 }
 
 func (r *DynamicResourceRequestController) updateResourceBindingVersionStatus(ctx context.Context, logger logr.Logger, promiseName string, rr *unstructured.Unstructured) error {
-	if !r.PromiseUpgrade {
-		return nil
-	}
-
 	resourceBindingName := objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promiseName))
 	resourceBinding := &v1alpha1.ResourceBinding{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: rr.GetNamespace()}, resourceBinding)
@@ -361,12 +362,12 @@ func (r *DynamicResourceRequestController) updateResourceBindingVersionStatus(ct
 	}
 
 	desiredVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
-	if resourceBinding.Status.LastAppiedVersion == desiredVersion {
+	if resourceBinding.Status.LastAppliedVersion == desiredVersion {
 		return nil
 	}
 
-	logging.Info(logger, "updating the resource binding status.ResourceRequestVersion", "oldVersion", resourceBinding.Spec.Version, "newVersion", desiredVersion)
-	resourceBinding.Status.LastAppiedVersion = desiredVersion
+	logging.Info(logger, "updating resource binding Status.LastAppliedVersion", "oldVersion", resourceBinding.Status.LastAppliedVersion, "newVersion", desiredVersion)
+	resourceBinding.Status.LastAppliedVersion = desiredVersion
 	if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
 		return fmt.Errorf("failed to update resource binding status: %w", err)
 	}

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -217,6 +217,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	if r.PromiseUpgrade {
 		err := r.updateResourceBinding(ctx, logger, rr, promise)
 		if err != nil {
+			logging.Error(logger, err, "failed to update resource binding for resource request")
 			return ctrl.Result{}, err
 		}
 	}
@@ -306,26 +307,9 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	}
 
 	if r.PromiseUpgrade {
-		resourceBinding := &v1alpha1.ResourceBinding{}
-		if err := r.Client.Get(ctx, types.NamespacedName{
-			Name:      objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promise.GetName())),
-			Namespace: rr.GetNamespace(),
-		}, resourceBinding); err != nil {
-			if !apierrors.IsNotFound(err) {
-				logging.Warn(logger, "failed to get resourceBinding, requeueing..")
-				return ctrl.Result{}, err
-			}
-			logging.Warn(logger, "resourceBinding not found; skipping status update")
-		} else {
-			desiredVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
-			if resourceBinding.Status.ResourceRequestVersion != desiredVersion {
-				logging.Info(logger, "attempting to update the resource binding status.ResourceRequestVersion")
-				resourceBinding.Status.ResourceRequestVersion = desiredVersion
-				if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
-					logging.Error(logger, err, "failed to update resource binding status.ResourceRequestVersion")
-					return ctrl.Result{}, err
-				}
-			}
+		if err := r.updateResourceBindingVersionStatus(ctx, logger, promise.GetName(), rr, bindingVersion); err != nil {
+			logging.Error(logger, err, "failed to update resource binding version status")
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -349,6 +333,27 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	return ctrl.Result{}, nil
 }
 
+func (r *DynamicResourceRequestController) updateResourceBindingVersionStatus(ctx context.Context, logger logr.Logger, promiseName string, rr *unstructured.Unstructured, bindingVersion string) error {
+	resourceBindingName := objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promiseName))
+	resourceBinding := &v1alpha1.ResourceBinding{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: rr.GetNamespace()}, resourceBinding)
+	if err != nil {
+		return fmt.Errorf("failed to get resourceBinding: %w", err)
+	}
+
+	desiredVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
+	if resourceBinding.Spec.Version == desiredVersion {
+		return nil
+	}
+
+	logging.Info(logger, "updating the resource binding status.ResourceRequestVersion", "oldVersion", resourceBinding.Spec.Version, "newVersion", desiredVersion)
+	resourceBinding.Status.ResourceRequestVersion = desiredVersion
+	if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
+		return fmt.Errorf("failed to update resource binding status: %w", err)
+	}
+	return nil
+}
+
 func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Context, logger logr.Logger, rr *unstructured.Unstructured, promise *v1alpha1.Promise) error {
 	resourceBinding := &v1alpha1.ResourceBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -357,14 +362,10 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 		},
 	}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, resourceBinding, func() error {
-		mergedLabels := make(map[string]string)
-		for k, v := range rr.GetLabels() {
-			mergedLabels[k] = v
-		}
+		resourceBinding.SetLabels(rr.GetLabels())
 		for k, v := range resourceBindingLabels(rr, promise) {
-			mergedLabels[k] = v
+			resourceBinding.Labels[k] = v
 		}
-		resourceBinding.SetLabels(mergedLabels)
 		if resourceBinding.Spec.Version == "" {
 			resourceBinding.Spec.Version = "latest"
 			// if the resource binding got deleted, when we recreate the resource binding we infer what the resource binding
@@ -388,6 +389,7 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 	}
 
 	logging.Debug(logger, "ResourceBinding reconciled for Resource",
+		"resourceBindingName", resourceBinding.GetName(),
 		"operation", op,
 		"promiseName", resourceBinding.Spec.PromiseRef.Name,
 		"promiseVersion", resourceBinding.Spec.Version,

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -342,7 +342,7 @@ func (r *DynamicResourceRequestController) updateResourceBindingVersionStatus(ct
 	}
 
 	desiredVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
-	if resourceBinding.Spec.Version == desiredVersion {
+	if resourceBinding.Status.ResourceRequestVersion == desiredVersion {
 		return nil
 	}
 

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -61,6 +61,7 @@ const (
 	resourcePromiseVersionStatus      = "promiseVersion"
 	resourceBindingVersionStatus      = "resourceBindingVersion"
 	promiseRevisionLookupFailedReason = "FailedPromiseRevisionLookup"
+	unversionedPromiseVersion         = "not-set"
 )
 
 type DynamicResourceRequestController struct {
@@ -380,7 +381,7 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 		},
 	}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, resourceBinding, func() error {
-		resourceBinding.SetLabels(rr.GetLabels())
+		resourceBinding.SetLabels(rrLabelsWithoutEphemeralTriggers(rr.GetLabels()))
 		for k, v := range resourceBindingLabels(rr, promise) {
 			resourceBinding.Labels[k] = v
 		}
@@ -1064,6 +1065,24 @@ func getPromiseRevisionToUse(ctx context.Context, rr *unstructured.Unstructured,
 	}
 
 	return promiseRevisionToUse, bindingVersion, nil
+}
+
+// rrLabelsWithoutEphemeralTriggers returns the RR labels without one-shot trigger
+// labels. Propagating these to the ResourceBinding would cause the ResourceBinding
+// controller to re-trigger reconciliation in an infinite loop.
+func rrLabelsWithoutEphemeralTriggers(rrLabels map[string]string) map[string]string {
+	ephemeralLabels := []string{
+		resourceutil.ManualReconciliationLabel,
+		resourceutil.WorkflowRunFromStartLabel,
+	}
+	result := make(map[string]string, len(rrLabels))
+	for k, v := range rrLabels {
+		result[k] = v
+	}
+	for _, key := range ephemeralLabels {
+		delete(result, key)
+	}
+	return result
 }
 
 func resourceBindingLabels(rr *unstructured.Unstructured, promise *v1alpha1.Promise) map[string]string {

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -291,26 +291,13 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return r.nextReconciliation(logger), r.cleanupWorkflowCountersAndExecution(ctx, logger, rr)
 	}
 
-	rrNamespace := ""
-	if promise.WorkflowPipelineNamespaceSet() {
-		rrNamespace = rr.GetNamespace()
-	}
-	workLabels := resourceutil.GetWorkLabels(r.PromiseIdentifier, rr.GetName(), rrNamespace, "", v1alpha1.WorkTypeResource)
-
-	statusUpdate, err := r.generateResourceStatus(ctx, logger, rr, int64(len(pipelineResources)), workLabels, bindingVersion, promiseRevisionUsed)
-	if err != nil {
+	if updated, err := r.ensureResourceStatus(ctx, logger, rr, promise, pipelineResources, bindingVersion, promiseRevisionUsed); updated || err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if statusUpdate {
-		return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
-	}
-
-	if r.PromiseUpgrade {
-		if err := r.updateResourceBindingVersionStatus(ctx, logger, promise.GetName(), rr, bindingVersion); err != nil {
-			logging.Error(logger, err, "failed to update resource binding version status")
-			return ctrl.Result{}, err
-		}
+	if err := r.updateResourceBindingVersionStatus(ctx, logger, promise.GetName(), rr); err != nil {
+		logging.Error(logger, err, "failed to update resource binding version status")
+		return ctrl.Result{}, err
 	}
 
 	workflowCompletedCondition := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
@@ -333,7 +320,38 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	return ctrl.Result{}, nil
 }
 
-func (r *DynamicResourceRequestController) updateResourceBindingVersionStatus(ctx context.Context, logger logr.Logger, promiseName string, rr *unstructured.Unstructured, bindingVersion string) error {
+func (r *DynamicResourceRequestController) ensureResourceStatus(
+	ctx context.Context,
+	logger logr.Logger,
+	rr *unstructured.Unstructured,
+	promise *v1alpha1.Promise,
+	pipelineResources []v1alpha1.PipelineJobResources,
+	bindingVersion string,
+	promiseRevisionUsed *v1alpha1.PromiseRevision,
+) (bool, error) {
+	rrNamespace := ""
+	if promise.WorkflowPipelineNamespaceSet() {
+		rrNamespace = rr.GetNamespace()
+	}
+	workLabels := resourceutil.GetWorkLabels(r.PromiseIdentifier, rr.GetName(), rrNamespace, "", v1alpha1.WorkTypeResource)
+
+	statusUpdate, err := r.generateResourceStatus(ctx, logger, rr, int64(len(pipelineResources)), workLabels, bindingVersion, promiseRevisionUsed)
+	if err != nil {
+		return false, err
+	}
+
+	if statusUpdate {
+		return true, r.Client.Status().Update(ctx, rr)
+	}
+	return false, nil
+
+}
+
+func (r *DynamicResourceRequestController) updateResourceBindingVersionStatus(ctx context.Context, logger logr.Logger, promiseName string, rr *unstructured.Unstructured) error {
+	if !r.PromiseUpgrade {
+		return nil
+	}
+
 	resourceBindingName := objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promiseName))
 	resourceBinding := &v1alpha1.ResourceBinding{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: rr.GetNamespace()}, resourceBinding)

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -82,7 +82,7 @@ type DynamicResourceRequestController struct {
 	NumberOfJobsToKeep          int
 	ReconciliationInterval      time.Duration
 	EventRecorder               record.EventRecorder
-	PromiseUpgrade              bool
+	PromiseUpgradeFeatFlag      bool
 }
 
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;list;watch;create;update;patch;delete
@@ -172,7 +172,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		promiseRevisionUsed *v1alpha1.PromiseRevision
 		bindingVersion      string
 	)
-	if r.PromiseUpgrade {
+	if r.PromiseUpgradeFeatFlag {
 		logging.Trace(baseLogger,
 			"PromiseUpgrade feature flag set to true; will reconcile with a PromiseRevision.")
 
@@ -215,7 +215,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	if r.PromiseUpgrade {
+	if r.PromiseUpgradeFeatFlag {
 		err := r.updateResourceBinding(ctx, logger, rr, promise)
 		if err != nil {
 			logging.Error(logger, err, "failed to update resource binding for resource request")
@@ -300,7 +300,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, nil
 	}
 
-	if r.PromiseUpgrade {
+	if r.PromiseUpgradeFeatFlag {
 		if err := r.updateResourceBindingVersionStatus(ctx, logger, promise.GetName(), rr); err != nil {
 			logging.Error(logger, err, "failed to update resource binding version status")
 			return ctrl.Result{}, err
@@ -318,7 +318,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return r.nextReconciliation(logger), nil
 	}
 
-	if r.PromiseUpgrade {
+	if r.PromiseUpgradeFeatFlag {
 		if r.updatePromiseVersionStatus(logger, rr, bindingVersion, promiseRevisionUsed) {
 			return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
 		}
@@ -620,7 +620,7 @@ func (r *DynamicResourceRequestController) updateReconciledCondition(rr *unstruc
 
 func (r *DynamicResourceRequestController) updatePromiseVersionStatus(logger logr.Logger, rr *unstructured.Unstructured, bindingVersion string, promiseRevision *v1alpha1.PromiseRevision) bool {
 	logging.Trace(logger, "Checking if we need to update the promise version in the status")
-	if !r.PromiseUpgrade || promiseRevision == nil {
+	if !r.PromiseUpgradeFeatFlag || promiseRevision == nil {
 		logging.Trace(logger, "Feature flag disabled or no PromiseRevision: no update promise version required")
 		return false
 	}
@@ -822,7 +822,7 @@ func (r *DynamicResourceRequestController) deleteResources(o opts, promise *v1al
 		return fastRequeue, nil
 	}
 
-	if r.PromiseUpgrade {
+	if r.PromiseUpgradeFeatFlag {
 		if controllerutil.ContainsFinalizer(resourceRequest, resourceBindingFinalizer) {
 			err := r.deleteResourceBinding(o, resourceRequest, promise, resourceBindingFinalizer)
 			if err != nil {
@@ -1164,7 +1164,7 @@ func (r *DynamicResourceRequestController) setPromiseLabels(ctx context.Context,
 
 func (r *DynamicResourceRequestController) getRRFinalizers() []string {
 	rrFinalizers := []string{workFinalizer, removeAllWorkflowJobsFinalizer, runDeleteWorkflowsFinalizer}
-	if r.PromiseUpgrade {
+	if r.PromiseUpgradeFeatFlag {
 		rrFinalizers = append(rrFinalizers, resourceBindingFinalizer)
 	}
 	return rrFinalizers

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -206,13 +206,11 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	if resourceutil.FinalizersAreMissing(
 		rr, []string{workFinalizer, removeAllWorkflowJobsFinalizer, runDeleteWorkflowsFinalizer},
 	) {
-		if err := addFinalizers(opts, rr, r.getRRFinalizers()); err != nil {
-			if apierrors.IsConflict(err) {
-				return fastRequeue, nil
-			}
-			return ctrl.Result{}, err
+		err := addFinalizers(opts, rr, r.getRRFinalizers())
+		if apierrors.IsConflict(err) {
+			return fastRequeue, nil
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	if r.PromiseUpgrade {

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -360,12 +360,12 @@ func (r *DynamicResourceRequestController) updateResourceBindingVersionStatus(ct
 	}
 
 	desiredVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
-	if resourceBinding.Status.ResourceRequestVersion == desiredVersion {
+	if resourceBinding.Status.LastAppiedVersion == desiredVersion {
 		return nil
 	}
 
 	logging.Info(logger, "updating the resource binding status.ResourceRequestVersion", "oldVersion", resourceBinding.Spec.Version, "newVersion", desiredVersion)
-	resourceBinding.Status.ResourceRequestVersion = desiredVersion
+	resourceBinding.Status.LastAppiedVersion = desiredVersion
 	if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
 		return fmt.Errorf("failed to update resource binding status: %w", err)
 	}

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -1070,17 +1070,12 @@ func getPromiseRevisionToUse(ctx context.Context, rr *unstructured.Unstructured,
 // labels. Propagating these to the ResourceBinding would cause the ResourceBinding
 // controller to re-trigger reconciliation in an infinite loop.
 func rrLabelsWithoutEphemeralTriggers(rrLabels map[string]string) map[string]string {
-	ephemeralLabels := []string{
-		resourceutil.ManualReconciliationLabel,
-		resourceutil.WorkflowRunFromStartLabel,
-	}
 	result := make(map[string]string, len(rrLabels))
 	for k, v := range rrLabels {
 		result[k] = v
 	}
-	for _, key := range ephemeralLabels {
-		delete(result, key)
-	}
+	delete(result, resourceutil.ManualReconciliationLabel)
+	delete(result, resourceutil.WorkflowRunFromStartLabel)
 	return result
 }
 

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -305,6 +305,30 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
 	}
 
+	if r.PromiseUpgrade {
+		resourceBinding := &v1alpha1.ResourceBinding{}
+		if err := r.Client.Get(ctx, types.NamespacedName{
+			Name:      objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promise.GetName())),
+			Namespace: rr.GetNamespace(),
+		}, resourceBinding); err != nil {
+			if !apierrors.IsNotFound(err) {
+				logging.Warn(logger, "failed to get resourceBinding, requeueing..")
+				return ctrl.Result{}, err
+			}
+			logging.Warn(logger, "resourceBinding not found; skipping status update")
+		} else {
+			desiredVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
+			if resourceBinding.Status.ResourceRequestVersion != desiredVersion {
+				logging.Info(logger, "attempting to update the resource binding status.ResourceRequestVersion")
+				resourceBinding.Status.ResourceRequestVersion = desiredVersion
+				if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
+					logging.Error(logger, err, "failed to update resource binding status.ResourceRequestVersion")
+					return ctrl.Result{}, err
+				}
+			}
+		}
+	}
+
 	workflowCompletedCondition := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
 	if workflowsCompletedSuccessfully(workflowCompletedCondition) {
 		if shouldUpdateLastSuccessfulConfigureWorkflowTime(workflowCompletedCondition, rr) {
@@ -333,9 +357,18 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 		},
 	}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, resourceBinding, func() error {
-		resourceBinding.SetLabels(resourceBindingLabels(rr, promise))
+		mergedLabels := make(map[string]string)
+		for k, v := range rr.GetLabels() {
+			mergedLabels[k] = v
+		}
+		for k, v := range resourceBindingLabels(rr, promise) {
+			mergedLabels[k] = v
+		}
+		resourceBinding.SetLabels(mergedLabels)
 		if resourceBinding.Spec.Version == "" {
 			resourceBinding.Spec.Version = "latest"
+			// if the resource binding got deleted, when we recreate the resource binding we infer what the resource binding
+			// version used to be from the resource request `status.resourceBindingVersion`
 			existingPromiseVersion := resourceutil.GetStatus(rr, resourceBindingVersionStatus)
 			if existingPromiseVersion != "" {
 				resourceBinding.Spec.Version = existingPromiseVersion
@@ -1041,6 +1074,11 @@ func latestRevision(ctx context.Context, c client.Client, promise *v1alpha1.Prom
 func fetchRevision(ctx context.Context, c client.Client, promise *v1alpha1.Promise,
 	binding *v1alpha1.ResourceBinding, promiseVersionFromRRStatus string) (*v1alpha1.PromiseRevision, error) {
 
+	// there is a scenario where the PromiseVersion from resource request status
+	//  is set, but no resource binding exists, which means the resource binding was
+	// deleted at some point.
+	//
+	// We infer what the resource binding version used to be from the resource request `status.resourceBindingVersion`
 	desiredVersion := promiseVersionFromRRStatus
 
 	if binding != nil {

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1494,7 +1494,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					// so it should be updated to the actual running promise version
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal("latest"))
-					Expect(binding.Status.ResourceRequestVersion).To(Equal(promiseVersion))
+					Expect(binding.Status.LastAppiedVersion).To(Equal(promiseVersion))
 				})
 			})
 
@@ -1513,7 +1513,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					// should be set — the skip condition checks Status, not Spec
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal(promiseVersion))
-					Expect(binding.Status.ResourceRequestVersion).To(Equal(promiseVersion))
+					Expect(binding.Status.LastAppiedVersion).To(Equal(promiseVersion))
 				})
 			})
 		})

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1483,18 +1483,18 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				createPromiseRevision(fakeK8sClient, promise, promiseVersion)
 			})
 
-			When("the resource binding Status.ResourceRequestVersion does not yet reflect the current promise version", func() {
-				It("updates Status.ResourceRequestVersion to track the current promise version", func() {
+			When("the resource binding Status.LastAppliedVersion does not yet reflect the current promise version", func() {
+				It("updates Status.LastAppliedVersion to track the current promise version", func() {
 					setReconcileConfigureWorkflowToReturnFinished()
 					result, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					// The binding starts with Status.ResourceRequestVersion="" (unset),
+					// The binding starts with Status.LastAppliedVersion="" (unset),
 					// so it should be updated to the actual running promise version
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal("latest"))
-					Expect(binding.Status.LastAppiedVersion).To(Equal(promiseVersion))
+					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))
 				})
 			})
 
@@ -1503,17 +1503,17 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					createResourceBinding(fakeK8sClient, promise, resReq, promiseVersion)
 				})
 
-				It("still updates Status.ResourceRequestVersion to reflect the current promise version", func() {
+				It("still updates Status.LastAppliedVersion to reflect the current promise version", func() {
 					setReconcileConfigureWorkflowToReturnFinished()
 					result, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					// Even when Spec.Version matches the running version, Status.ResourceRequestVersion
-					// should be set — the skip condition checks Status, not Spec
+					// Even when Spec.Version matches the running version, Status.LastAppliedVersion
+					// should be set — the ResourceBinding controller checks this to avoid re-triggering
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal(promiseVersion))
-					Expect(binding.Status.LastAppiedVersion).To(Equal(promiseVersion))
+					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))
 				})
 			})
 		})

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1585,7 +1585,7 @@ func createPromiseRevision(fakeK8sClient client.Client, promise *v1alpha1.Promis
 	Expect(fakeK8sClient.Status().Update(ctx, promiseRevision)).To(Succeed())
 }
 
-func createResourceBinding(client client.Client, promise *v1alpha1.Promise, rr *unstructured.Unstructured, version string) *v1alpha1.ResourceBinding {
+func createResourceBinding(client client.Client, promise *v1alpha1.Promise, rr *unstructured.Unstructured, version string) {
 	resourceBinding := &v1alpha1.ResourceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promise.GetName())),
@@ -1607,7 +1607,6 @@ func createResourceBinding(client client.Client, promise *v1alpha1.Promise, rr *
 		},
 	}
 	ExpectWithOffset(1, client.Create(ctx, resourceBinding)).To(Succeed())
-	return resourceBinding
 }
 
 func setConfigureWorkflowStatus(resReq *unstructured.Unstructured, status v1.ConditionStatus, lastTransitionTime ...time.Time) {

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1203,7 +1203,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 	When("promise upgrade feature is on", func() {
 		BeforeEach(func() {
 			Expect(fakeK8sClient.Delete(ctx, resReq)).To(Succeed())
-			reconciler.PromiseUpgrade = true
+			reconciler.PromiseUpgradeFeatFlag = true
 			resReq = createResourceRequest(resourceRequestPath)
 			resReqNameNamespace = client.ObjectKeyFromObject(resReq)
 		})
@@ -1490,8 +1490,6 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					// The binding starts with Status.LastAppliedVersion="" (unset),
-					// so it should be updated to the actual running promise version
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal("latest"))
 					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))
@@ -1503,14 +1501,12 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					createResourceBinding(fakeK8sClient, promise, resReq, promiseVersion)
 				})
 
-				It("still updates Status.LastAppliedVersion to reflect the current promise version", func() {
+				It("updates Status.LastAppliedVersion to reflect the current promise version", func() {
 					setReconcileConfigureWorkflowToReturnFinished()
 					result, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					// Even when Spec.Version matches the running version, Status.LastAppliedVersion
-					// should be set — the ResourceBinding controller checks this to avoid re-triggering
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal(promiseVersion))
 					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1536,6 +1536,24 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				Expect(binding.GetLabels()).To(HaveKeyWithValue("kratix.io/promise-name", promise.GetName()))
 				Expect(binding.GetLabels()).To(HaveKeyWithValue("kratix.io/resource-name", resReq.GetName()))
 			})
+
+			It("does not propagate ephemeral trigger labels from the resource request to the binding", func() {
+				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+				labels := resReq.GetLabels()
+				labels[resourceutil.ManualReconciliationLabel] = "true"
+				labels[resourceutil.WorkflowRunFromStartLabel] = "true"
+				resReq.SetLabels(labels)
+				Expect(fakeK8sClient.Update(ctx, resReq)).To(Succeed())
+
+				setReconcileConfigureWorkflowToReturnFinished()
+				result, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+				Expect(binding.GetLabels()).NotTo(HaveKey(resourceutil.ManualReconciliationLabel))
+				Expect(binding.GetLabels()).NotTo(HaveKey(resourceutil.WorkflowRunFromStartLabel))
+			})
 		})
 
 	})

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1556,6 +1556,48 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			})
 		})
 
+		When("updating the labels on an existing resource binding", func() {
+			BeforeEach(func() {
+				createPromiseRevision(fakeK8sClient, promise, "v1.1.0")
+				setReconcileConfigureWorkflowToReturnFinished()
+				_, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("reflects a changed label from the resource request on the binding", func() {
+				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+				updatedLabels := resReq.GetLabels()
+				updatedLabels["non-kratix-label"] = "updated-value"
+				resReq.SetLabels(updatedLabels)
+				Expect(fakeK8sClient.Update(ctx, resReq)).To(Succeed())
+
+				result, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+				Expect(binding.GetLabels()).To(HaveKeyWithValue("non-kratix-label", "updated-value"))
+			})
+
+			It("removes a label from the binding when it is removed from the resource request", func() {
+				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+				updatedLabels := resReq.GetLabels()
+				delete(updatedLabels, "non-kratix-label")
+				resReq.SetLabels(updatedLabels)
+				Expect(fakeK8sClient.Update(ctx, resReq)).To(Succeed())
+
+				result, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+				Expect(binding.GetLabels()).NotTo(HaveKey("non-kratix-label"))
+				// Binding-specific labels should remain untouched
+				Expect(binding.GetLabels()).To(HaveKeyWithValue("kratix.io/promise-name", promise.GetName()))
+				Expect(binding.GetLabels()).To(HaveKeyWithValue("kratix.io/resource-name", resReq.GetName()))
+			})
+		})
+
 	})
 })
 

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1476,6 +1476,67 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			})
 		})
 
+		When("updating the resource binding version status", func() {
+			const promiseVersion = "v1.1.0"
+
+			BeforeEach(func() {
+				createPromiseRevision(fakeK8sClient, promise, promiseVersion)
+			})
+
+			When("the resource binding Spec.Version differs from the resource request's current promise version", func() {
+				It("updates Status.ResourceRequestVersion to reflect the current promise version", func() {
+					setReconcileConfigureWorkflowToReturnFinished()
+					result, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					// The binding Spec.Version is "latest" but the RR is running on "v1.1.0",
+					// so Status.ResourceRequestVersion should be updated to track the actual version
+					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+					Expect(binding.Spec.Version).To(Equal("latest"))
+					Expect(binding.Status.ResourceRequestVersion).To(Equal(promiseVersion))
+				})
+			})
+
+			When("the resource binding Spec.Version matches the resource request's current promise version", func() {
+				BeforeEach(func() {
+					createResourceBinding(fakeK8sClient, promise, resReq, promiseVersion)
+				})
+
+				It("does not update Status.ResourceRequestVersion", func() {
+					setReconcileConfigureWorkflowToReturnFinished()
+					result, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					// Spec.Version matches the actual running version, so no update is needed
+					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+					Expect(binding.Spec.Version).To(Equal(promiseVersion))
+					Expect(binding.Status.ResourceRequestVersion).To(BeEmpty())
+				})
+			})
+		})
+
+		When("creating the resource binding", func() {
+			BeforeEach(func() {
+				createPromiseRevision(fakeK8sClient, promise, "v1.1.0")
+			})
+
+			It("merges the resource request's labels with the binding-specific labels", func() {
+				setReconcileConfigureWorkflowToReturnFinished()
+				result, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+				// Labels originating from the resource request itself
+				Expect(binding.GetLabels()).To(HaveKeyWithValue("non-kratix-label", "true"))
+				// Binding-specific labels added by resourceBindingLabels
+				Expect(binding.GetLabels()).To(HaveKeyWithValue("kratix.io/promise-name", promise.GetName()))
+				Expect(binding.GetLabels()).To(HaveKeyWithValue("kratix.io/resource-name", resReq.GetName()))
+			})
+		})
+
 	})
 })
 

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1483,36 +1483,37 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				createPromiseRevision(fakeK8sClient, promise, promiseVersion)
 			})
 
-			When("the resource binding Spec.Version differs from the resource request's current promise version", func() {
-				It("updates Status.ResourceRequestVersion to reflect the current promise version", func() {
+			When("the resource binding Status.ResourceRequestVersion does not yet reflect the current promise version", func() {
+				It("updates Status.ResourceRequestVersion to track the current promise version", func() {
 					setReconcileConfigureWorkflowToReturnFinished()
 					result, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					// The binding Spec.Version is "latest" but the RR is running on "v1.1.0",
-					// so Status.ResourceRequestVersion should be updated to track the actual version
+					// The binding starts with Status.ResourceRequestVersion="" (unset),
+					// so it should be updated to the actual running promise version
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal("latest"))
 					Expect(binding.Status.ResourceRequestVersion).To(Equal(promiseVersion))
 				})
 			})
 
-			When("the resource binding Spec.Version matches the resource request's current promise version", func() {
+			When("the resource binding is pinned to a specific promise version", func() {
 				BeforeEach(func() {
 					createResourceBinding(fakeK8sClient, promise, resReq, promiseVersion)
 				})
 
-				It("does not update Status.ResourceRequestVersion", func() {
+				It("still updates Status.ResourceRequestVersion to reflect the current promise version", func() {
 					setReconcileConfigureWorkflowToReturnFinished()
 					result, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{}))
 
-					// Spec.Version matches the actual running version, so no update is needed
+					// Even when Spec.Version matches the running version, Status.ResourceRequestVersion
+					// should be set — the skip condition checks Status, not Spec
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal(promiseVersion))
-					Expect(binding.Status.ResourceRequestVersion).To(BeEmpty())
+					Expect(binding.Status.ResourceRequestVersion).To(Equal(promiseVersion))
 				})
 			})
 		})

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1138,7 +1138,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		dynamicController.EventRecorder = r.Manager.GetEventRecorderFor("ResourceRequestController")
 		dynamicController.NumberOfJobsToKeep = r.NumberOfJobsToKeep
 		dynamicController.ReconciliationInterval = r.ReconciliationInterval
-		dynamicController.PromiseUpgrade = r.PromiseUpgrade
+		dynamicController.PromiseUpgradeFeatFlag = r.PromiseUpgrade
 		dynamicController.PromiseDestinationSelectors = promise.Spec.DestinationSelectors
 
 		if dynamicController.WatchStopped {
@@ -1168,7 +1168,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		NumberOfJobsToKeep:          r.NumberOfJobsToKeep,
 		ReconciliationInterval:      r.ReconciliationInterval,
 		EventRecorder:               r.Manager.GetEventRecorderFor("ResourceRequestController"),
-		PromiseUpgrade:              r.PromiseUpgrade,
+		PromiseUpgradeFeatFlag:      r.PromiseUpgrade,
 	}
 
 	unstructuredCRD := &unstructured.Unstructured{}

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -376,7 +376,7 @@ func (r *PromiseReconciler) handlePromiseVersion(ctx context.Context, promise *v
 	}
 
 	if promiseVersion == "" {
-		promiseVersion = "not-set"
+		promiseVersion = unversionedPromiseVersion
 	}
 
 	revision := v1alpha1.NewPromiseRevision(promise, promiseVersion)

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -376,7 +376,7 @@ func (r *PromiseReconciler) handlePromiseVersion(ctx context.Context, promise *v
 	}
 
 	if promiseVersion == "" {
-		promiseVersion = unversionedPromiseVersion
+		promiseVersion = UnversionedPromiseVersion
 	}
 
 	revision := v1alpha1.NewPromiseRevision(promise, promiseVersion)

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -102,7 +102,12 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	rrPromiseVersion := resourceutil.GetStatus(rr, "promiseVersion")
-	if rrPromiseVersion == "" || rrPromiseVersion == resourceBinding.Spec.Version {
+	if rrPromiseVersion == "" || rrPromiseVersion == unversionedPromiseVersion {
+		logging.Info(logger, "promise has no version; skipping version check")
+		return ctrl.Result{}, nil
+	}
+
+	if rrPromiseVersion == resourceBinding.Spec.Version {
 		logging.Info(logger, "resource request version is equal to the resource binding desired version", "resource binding version", resourceBinding.Spec.Version)
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -101,20 +101,22 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return defaultRequeue, nil
 	}
 
-	// The PromiseController will trigger a reconciliation of all requests every time a new
-	// Promise version is installed, so this controller doesn't need to trigger a reconciliation
-	// when the ResourceBinding version is set to "latest"
-	if resourceBinding.Spec.Version == LatestVersion {
-		return ctrl.Result{}, nil
-	}
-
 	rrPromiseVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
 	if rrPromiseVersion == "" || rrPromiseVersion == UnversionedPromiseVersion {
 		logging.Info(logger, "promise has no version; skipping version check")
 		return ctrl.Result{}, nil
 	}
 
-	if rrPromiseVersion == resourceBinding.Spec.Version {
+	desiredVersion := resourceBinding.Spec.Version
+	if desiredVersion == LatestVersion {
+		provisionRevisionMarkedWithLatest, err := latestRevision(ctx, r.Client, promise)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get latest provision revision for promise %s: %w", promiseNamespacedName.Name, err)
+		}
+		desiredVersion = provisionRevisionMarkedWithLatest.Spec.Version
+	}
+
+	if rrPromiseVersion == desiredVersion {
 		logging.Debug(logger, "resource request version is equal to the resource binding desired version", "resource binding version", resourceBinding.Spec.Version)
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -109,7 +109,7 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	logging.Info(
 		logger,
-		"resource request version mismatch to the resource binding desired version, triggering manual reconcilation",
+		"resource request version mismatch to the resource binding desired version, triggering manual reconciliation",
 		"resource request version", rrPromiseVersion,
 		"resource binding version", resourceBinding.Spec.Version,
 	)

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -101,6 +101,13 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return defaultRequeue, nil
 	}
 
+	// "latest" bindings are upgraded via the DRRC's periodic reconciliation, which
+	// re-reads the current PromiseRevision on every tick. There is nothing for this
+	// controller to do for them.
+	if resourceBinding.Spec.Version == "latest" {
+		return ctrl.Result{}, nil
+	}
+
 	rrPromiseVersion := resourceutil.GetStatus(rr, "promiseVersion")
 	if rrPromiseVersion == "" || rrPromiseVersion == UnversionedPromiseVersion {
 		logging.Info(logger, "promise has no version; skipping version check")
@@ -109,14 +116,6 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if rrPromiseVersion == resourceBinding.Spec.Version {
 		logging.Debug(logger, "resource request version is equal to the resource binding desired version", "resource binding version", resourceBinding.Spec.Version)
-		return ctrl.Result{}, nil
-	}
-
-	// For "latest" bindings Spec.Version is never equal to a concrete version string,
-	// so the check above can never match. We use LastAppliedVersion to detect that
-	// the RR has already been reconciled at its current version, breaking the loop.
-	if resourceBinding.Spec.Version == "latest" && rrPromiseVersion == resourceBinding.Status.LastAppliedVersion {
-		logging.Debug(logger, "resource request version has already been applied; skipping reconciliation", "version", rrPromiseVersion)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -103,8 +103,16 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	rrPromiseVersion := resourceutil.GetStatus(rr, "promiseVersion")
 	if rrPromiseVersion == "" || rrPromiseVersion == resourceBinding.Spec.Version {
+		logging.Info(logger, "resource request version is equal to the resource binding desired version", "resource binding version", resourceBinding.Spec.Version)
 		return ctrl.Result{}, nil
 	}
+
+	logging.Info(
+		logger,
+		"resource request version mismatch to the resource binding desired version, triggering manual reconcilation",
+		"resource request version", rrPromiseVersion,
+		"resource binding version", resourceBinding.Spec.Version,
+	)
 
 	labels := rr.GetLabels()
 	if labels == nil {
@@ -115,7 +123,6 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := r.Client.Update(ctx, rr); err != nil {
 		return ctrl.Result{}, err
 	}
-
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -101,9 +101,8 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return defaultRequeue, nil
 	}
 
-	// "latest" bindings are upgraded via the DRRC's periodic reconciliation, which
-	// re-reads the current PromiseRevision on every tick. There is nothing for this
-	// controller to do for them.
+	// The PromiseController will trigger a manual reconciliation of all requests every time a new
+	// Promise version is installed, so we don't need to trigger manual reconciliations here.
 	if resourceBinding.Spec.Version == "latest" {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -101,8 +101,9 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return defaultRequeue, nil
 	}
 
-	// The PromiseController will trigger a manual reconciliation of all requests every time a new
-	// Promise version is installed, so we don't need to trigger manual reconciliations here.
+	// The PromiseController will trigger a reconciliation of all requests every time a new
+	// Promise version is installed, so this controller doesn't need to trigger a reconciliation
+	// when the ResourceBinding version is set to "latest"
 	if resourceBinding.Spec.Version == LatestVersion {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -102,13 +102,21 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	rrPromiseVersion := resourceutil.GetStatus(rr, "promiseVersion")
-	if rrPromiseVersion == "" || rrPromiseVersion == unversionedPromiseVersion {
+	if rrPromiseVersion == "" || rrPromiseVersion == UnversionedPromiseVersion {
 		logging.Info(logger, "promise has no version; skipping version check")
 		return ctrl.Result{}, nil
 	}
 
 	if rrPromiseVersion == resourceBinding.Spec.Version {
-		logging.Info(logger, "resource request version is equal to the resource binding desired version", "resource binding version", resourceBinding.Spec.Version)
+		logging.Debug(logger, "resource request version is equal to the resource binding desired version", "resource binding version", resourceBinding.Spec.Version)
+		return ctrl.Result{}, nil
+	}
+
+	// For "latest" bindings Spec.Version is never equal to a concrete version string,
+	// so the check above can never match. We use LastAppliedVersion to detect that
+	// the RR has already been reconciled at its current version, breaking the loop.
+	if resourceBinding.Spec.Version == "latest" && rrPromiseVersion == resourceBinding.Status.LastAppliedVersion {
+		logging.Debug(logger, "resource request version has already been applied; skipping reconciliation", "version", rrPromiseVersion)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -103,11 +103,11 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// The PromiseController will trigger a manual reconciliation of all requests every time a new
 	// Promise version is installed, so we don't need to trigger manual reconciliations here.
-	if resourceBinding.Spec.Version == "latest" {
+	if resourceBinding.Spec.Version == LatestVersion {
 		return ctrl.Result{}, nil
 	}
 
-	rrPromiseVersion := resourceutil.GetStatus(rr, "promiseVersion")
+	rrPromiseVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
 	if rrPromiseVersion == "" || rrPromiseVersion == UnversionedPromiseVersion {
 		logging.Info(logger, "promise has no version; skipping version check")
 		return ctrl.Result{}, nil

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -171,10 +171,12 @@ var _ = Describe("ResourceBinding Controller", func() {
 				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal(""))
 			})
 
-			It("does not apply the manual reconciliation label when the binding tracks latest", func() {
+			It("does not apply the manual reconciliation label when the binding tracks latest and the RR is already on the latest revision", func() {
 				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
 				resourceBinding.Spec.Version = "latest"
 				Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())
+
+				createPromiseRevision(fakeK8sClient, promise, "v0.0.1")
 
 				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
 
@@ -187,6 +189,37 @@ var _ = Describe("ResourceBinding Controller", func() {
 					rr,
 				)
 				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal(""))
+			})
+
+			It("applies the manual reconciliation label when the binding tracks latest but the RR is behind the latest revision", func() {
+				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
+				resourceBinding.Spec.Version = "latest"
+				Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())
+
+				createPromiseRevision(fakeK8sClient, promise, "v0.0.2")
+
+				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+				result, err := reconciler.Reconcile(ctx, request)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				fakeK8sClient.Get(ctx,
+					types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()},
+					rr,
+				)
+				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal("true"))
+			})
+
+			It("returns an error when the binding tracks latest but no latest PromiseRevision exists", func() {
+				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
+				resourceBinding.Spec.Version = "latest"
+				Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())
+
+				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+				_, err := reconciler.Reconcile(ctx, request)
+				Expect(err).To(MatchError(ContainSubstring("failed to get latest provision revision for promise redis")))
 			})
 		})
 	})

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -171,35 +171,12 @@ var _ = Describe("ResourceBinding Controller", func() {
 				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal(""))
 			})
 
-			It("still applies the manual reconciliation label when Spec.Version differs and LastAppliedVersion matches rrPromiseVersion", func() {
-				// Spec.Version="v0.0.2" (desired), rrPromiseVersion="v0.0.1" (current), LastAppliedVersion="v0.0.1"
-				// LastAppliedVersion matching rrPromiseVersion does NOT mean we are done —
-				// the RR still needs upgrading to Spec.Version="v0.0.2"
-				resourceBinding.Status.LastAppliedVersion = "v0.0.1"
-				Expect(fakeK8sClient.Status().Update(ctx, &resourceBinding)).To(Succeed())
-
-				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
-
-				result, err := reconciler.Reconcile(ctx, request)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
-
-				fakeK8sClient.Get(ctx,
-					types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()},
-					rr,
-				)
-				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal("true"))
-			})
-
-			It("does not apply the manual reconciliation label when the binding tracks latest and the version has already been applied", func() {
-				// Spec.Version="latest" will never equal a concrete version like "v0.0.1",
-				// so we rely on LastAppliedVersion to detect the RR is already up to date
+			It("does not apply the manual reconciliation label when the binding tracks latest", func() {
+				// "latest" bindings are handled by the DRRC's periodic reconciliation,
+				// not by this controller — it must not interfere
 				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
 				resourceBinding.Spec.Version = "latest"
 				Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())
-
-				resourceBinding.Status.LastAppliedVersion = "v0.0.1"
-				Expect(fakeK8sClient.Status().Update(ctx, &resourceBinding)).To(Succeed())
 
 				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
 

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -139,7 +139,7 @@ var _ = Describe("ResourceBinding Controller", func() {
 				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
 
 				result, err := reconciler.Reconcile(ctx, request)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 
 				fakeK8sClient.Get(ctx,
@@ -155,13 +155,56 @@ var _ = Describe("ResourceBinding Controller", func() {
 					rr,
 				)
 
-				resourceutil.SetStatus(rr, logr.Discard(), "promiseVersion", "not-set")
+				resourceutil.SetStatus(rr, logr.Discard(), "promiseVersion", controller.UnversionedPromiseVersion)
 				Expect(fakeK8sClient.Status().Update(ctx, rr)).To(Succeed())
 
 				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
 
 				result, err := reconciler.Reconcile(ctx, request)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				fakeK8sClient.Get(ctx,
+					types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()},
+					rr,
+				)
+				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal(""))
+			})
+
+			It("still applies the manual reconciliation label when Spec.Version differs and LastAppliedVersion matches rrPromiseVersion", func() {
+				// Spec.Version="v0.0.2" (desired), rrPromiseVersion="v0.0.1" (current), LastAppliedVersion="v0.0.1"
+				// LastAppliedVersion matching rrPromiseVersion does NOT mean we are done —
+				// the RR still needs upgrading to Spec.Version="v0.0.2"
+				resourceBinding.Status.LastAppliedVersion = "v0.0.1"
+				Expect(fakeK8sClient.Status().Update(ctx, &resourceBinding)).To(Succeed())
+
+				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+				result, err := reconciler.Reconcile(ctx, request)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				fakeK8sClient.Get(ctx,
+					types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()},
+					rr,
+				)
+				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal("true"))
+			})
+
+			It("does not apply the manual reconciliation label when the binding tracks latest and the version has already been applied", func() {
+				// Spec.Version="latest" will never equal a concrete version like "v0.0.1",
+				// so we rely on LastAppliedVersion to detect the RR is already up to date
+				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
+				resourceBinding.Spec.Version = "latest"
+				Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())
+
+				resourceBinding.Status.LastAppliedVersion = "v0.0.1"
+				Expect(fakeK8sClient.Status().Update(ctx, &resourceBinding)).To(Succeed())
+
+				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+				result, err := reconciler.Reconcile(ctx, request)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 
 				fakeK8sClient.Get(ctx,

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -172,8 +172,6 @@ var _ = Describe("ResourceBinding Controller", func() {
 			})
 
 			It("does not apply the manual reconciliation label when the binding tracks latest", func() {
-				// "latest" bindings are handled by the DRRC's periodic reconciliation,
-				// not by this controller — it must not interfere
 				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
 				resourceBinding.Spec.Version = "latest"
 				Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -148,6 +148,28 @@ var _ = Describe("ResourceBinding Controller", func() {
 				)
 				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal(""))
 			})
+
+			It("does not apply the manual reconciliation label when the promise has no version", func() {
+				fakeK8sClient.Get(ctx,
+					types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()},
+					rr,
+				)
+
+				resourceutil.SetStatus(rr, logr.Discard(), "promiseVersion", "not-set")
+				Expect(fakeK8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+				request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+				result, err := reconciler.Reconcile(ctx, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				fakeK8sClient.Get(ctx,
+					types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()},
+					rr,
+				)
+				Expect(rr.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal(""))
+			})
 		})
 	})
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -93,6 +93,7 @@ var _ = BeforeEach(func() {
 			&v1alpha1.GitStateStore{},
 			&v1alpha1.BucketStateStore{},
 			&v1alpha1.PromiseRevision{},
+			&v1alpha1.ResourceBinding{},
 			//Add redis.marketplace.kratix.io/v1alpha1 so we can update its status
 			resReq,
 		).

--- a/test/system/assets/promise-revision/resource-request.yaml
+++ b/test/system/assets/promise-revision/resource-request.yaml
@@ -3,5 +3,7 @@ kind: Upgrade
 metadata:
   name: upgrade-rr-one
   namespace: default
+  labels:
+    environment: staging
 spec:
   configMapName: banana

--- a/test/system/promise_revision_test.go
+++ b/test/system/promise_revision_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Promise Revisions", func() {
 		By("propagating resource request labels to the resource binding", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(getBindingLabels(promiseName, rrOneName)).To(Equal(map[string]string{
-					"environment":              "staging",
+					"environment":             "staging",
 					"kratix.io/promise-name":  promiseName,
 					"kratix.io/resource-name": rrOneName,
 				}))
@@ -109,7 +109,7 @@ var _ = Describe("Promise Revisions", func() {
 			platform.Kubectl("label", "--overwrite", "upgrades", rrOneName, "environment=production")
 			Eventually(func(g Gomega) {
 				g.Expect(getBindingLabels(promiseName, rrOneName)).To(Equal(map[string]string{
-					"environment":              "production",
+					"environment":             "production",
 					"kratix.io/promise-name":  promiseName,
 					"kratix.io/resource-name": rrOneName,
 				}))

--- a/test/system/promise_revision_test.go
+++ b/test/system/promise_revision_test.go
@@ -90,6 +90,42 @@ var _ = Describe("Promise Revisions", func() {
 			}
 		})
 
+		By("propagating resource request labels to the resource binding", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(getBindingLabels(promiseName, rrOneName)).To(Equal(map[string]string{
+					"environment":              "staging",
+					"kratix.io/promise-name":  promiseName,
+					"kratix.io/resource-name": rrOneName,
+				}))
+				// rrTwo has no custom labels, so only the binding-specific labels should be present
+				g.Expect(getBindingLabels(promiseName, rrTwoName)).To(Equal(map[string]string{
+					"kratix.io/promise-name":  promiseName,
+					"kratix.io/resource-name": rrTwoName,
+				}))
+			}).Should(Succeed())
+		})
+
+		By("updating a label on the resource request updates the resource binding", func() {
+			platform.Kubectl("label", "--overwrite", "upgrades", rrOneName, "environment=production")
+			Eventually(func(g Gomega) {
+				g.Expect(getBindingLabels(promiseName, rrOneName)).To(Equal(map[string]string{
+					"environment":              "production",
+					"kratix.io/promise-name":  promiseName,
+					"kratix.io/resource-name": rrOneName,
+				}))
+			}).Should(Succeed())
+		})
+
+		By("removing a label from the resource request removes it from the resource binding", func() {
+			platform.Kubectl("label", "upgrades", rrOneName, "environment-")
+			Eventually(func(g Gomega) {
+				g.Expect(getBindingLabels(promiseName, rrOneName)).To(Equal(map[string]string{
+					"kratix.io/promise-name":  promiseName,
+					"kratix.io/resource-name": rrOneName,
+				}))
+			}).Should(Succeed())
+		})
+
 		By("pinning resource two to the current version", func() {
 			bindingName := getBindingName(promiseName, rrTwoName)
 
@@ -249,4 +285,17 @@ func getBindingName(promiseName, resourceName string) string {
 	return strings.TrimSpace(
 		platform.Kubectl("get", "--namespace=default", "resourcebindings", "-l", resourceBindingLabels, "-o=name"),
 	)
+}
+
+func getBindingLabels(promiseName, resourceName string) map[string]string {
+	GinkgoHelper()
+	name := getBindingName(promiseName, resourceName)
+	output := platform.Kubectl("get", "--namespace=default", name, "-o=json")
+	var obj struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	Expect(json.Unmarshal([]byte(output), &obj)).To(Succeed())
+	return obj.Metadata.Labels
 }

--- a/test/system/promise_revision_test.go
+++ b/test/system/promise_revision_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Promise Revisions", func() {
 				Eventually(func(g Gomega) {
 					name := getBindingName(promiseName, resourceName)
 					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.spec.version}'")).To(ContainSubstring("latest"))
+					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(initialPromiseVersion))
 				}).Should(Succeed())
 			}
 		})
@@ -156,6 +157,11 @@ var _ = Describe("Promise Revisions", func() {
 			Eventually(func() string {
 				return worker.Kubectl("get", "configmap")
 			}).Should(ContainSubstring(rrOneAfterUpgradeCMName))
+
+			Eventually(func(g Gomega) {
+				name := getBindingName(promiseName, rrOneName)
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(updatedPromiseVersion))
+			}).Should(Succeed())
 		})
 
 		By("not updating the resource request pinned to a specific version", func() {
@@ -166,6 +172,11 @@ var _ = Describe("Promise Revisions", func() {
 			Consistently(func() string {
 				return worker.Kubectl("get", "configmap")
 			}, time.Second*5).Should(ContainSubstring(rrTwoBeforeUpgradeCMName))
+
+			Eventually(func(g Gomega) {
+				name := getBindingName(promiseName, rrTwoName)
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(initialPromiseVersion))
+			}).Should(Succeed())
 		})
 
 		By("updating the resource binding to the new promise version", func() {
@@ -193,6 +204,11 @@ var _ = Describe("Promise Revisions", func() {
 			}).Should(SatisfyAll(
 				ContainSubstring(rrTwoAfterUpgradeCMName),
 				Not(ContainSubstring(rrTwoBeforeUpgradeCMName))))
+
+			Eventually(func(g Gomega) {
+				name := getBindingName(promiseName, rrTwoName)
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(updatedPromiseVersion))
+			}).Should(Succeed())
 		})
 
 		By("restoring the bindings correctly when they are deleted", func() {

--- a/test/system/promise_revision_test.go
+++ b/test/system/promise_revision_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Promise Revisions", func() {
 				Eventually(func(g Gomega) {
 					name := getBindingName(promiseName, resourceName)
 					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.spec.version}'")).To(ContainSubstring("latest"))
-					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(initialPromiseVersion))
+					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(initialPromiseVersion))
 				}).Should(Succeed())
 			}
 		})
@@ -196,7 +196,7 @@ var _ = Describe("Promise Revisions", func() {
 
 			Eventually(func(g Gomega) {
 				name := getBindingName(promiseName, rrOneName)
-				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(updatedPromiseVersion))
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(updatedPromiseVersion))
 			}).Should(Succeed())
 		})
 
@@ -211,7 +211,7 @@ var _ = Describe("Promise Revisions", func() {
 
 			Eventually(func(g Gomega) {
 				name := getBindingName(promiseName, rrTwoName)
-				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(initialPromiseVersion))
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(initialPromiseVersion))
 			}).Should(Succeed())
 		})
 
@@ -243,7 +243,7 @@ var _ = Describe("Promise Revisions", func() {
 
 			Eventually(func(g Gomega) {
 				name := getBindingName(promiseName, rrTwoName)
-				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.resourceRequestVersion}'")).To(ContainSubstring(updatedPromiseVersion))
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(updatedPromiseVersion))
 			}).Should(Succeed())
 		})
 

--- a/test/system/promise_revision_test.go
+++ b/test/system/promise_revision_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Promise Revisions", func() {
 				Eventually(func(g Gomega) {
 					name := getBindingName(promiseName, resourceName)
 					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.spec.version}'")).To(ContainSubstring("latest"))
-					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(initialPromiseVersion))
+					g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppliedVersion}'")).To(ContainSubstring(initialPromiseVersion))
 				}).Should(Succeed())
 			}
 		})
@@ -196,7 +196,7 @@ var _ = Describe("Promise Revisions", func() {
 
 			Eventually(func(g Gomega) {
 				name := getBindingName(promiseName, rrOneName)
-				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(updatedPromiseVersion))
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppliedVersion}'")).To(ContainSubstring(updatedPromiseVersion))
 			}).Should(Succeed())
 		})
 
@@ -211,7 +211,7 @@ var _ = Describe("Promise Revisions", func() {
 
 			Eventually(func(g Gomega) {
 				name := getBindingName(promiseName, rrTwoName)
-				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(initialPromiseVersion))
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppliedVersion}'")).To(ContainSubstring(initialPromiseVersion))
 			}).Should(Succeed())
 		})
 
@@ -243,7 +243,7 @@ var _ = Describe("Promise Revisions", func() {
 
 			Eventually(func(g Gomega) {
 				name := getBindingName(promiseName, rrTwoName)
-				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppiedVersion}'")).To(ContainSubstring(updatedPromiseVersion))
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.status.lastAppliedVersion}'")).To(ContainSubstring(updatedPromiseVersion))
 			}).Should(Succeed())
 		})
 

--- a/test/system/reconciliation_test.go
+++ b/test/system/reconciliation_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Reconciliation", func() {
 			numberOfTriggeredPodsPlusOne := "2"
 			Eventually(func() string {
 				return platform.Kubectl("get", "pods", "-l", podLabels, "-o", goTemplate)
-			}, 30*time.Second).Should(ContainSubstring(numberOfTriggeredPodsPlusOne))
+			}, 90*time.Second).Should(ContainSubstring(numberOfTriggeredPodsPlusOne))
 
 			Eventually(func() string {
 				return platform.Kubectl("get", kindName, resourceRequestName)

--- a/test/system/reconciliation_test.go
+++ b/test/system/reconciliation_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Reconciliation", func() {
 			By("not running any workflow while paused")
 			Consistently(func() string {
 				return platform.Kubectl("get", "pods", "-l", podLabels, "-o", goTemplate)
-			}, 10*time.Second).Should(Equal(numberOfTriggeredPods))
+			}, 70*time.Second).Should(Equal(numberOfTriggeredPods))
 
 			By("rerunning promise workflows after unpaused")
 			platform.Kubectl("label", "promise", promiseName, "kratix.io/paused-")

--- a/test/system/reconciliation_test.go
+++ b/test/system/reconciliation_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Reconciliation", func() {
 			By("resuming reconciliation for resource requests after unpaused")
 			Eventually(func() string {
 				return platform.Kubectl("get", "pods", "-l", podLabels, "-o", goTemplate)
-			}, 90*time.Second).Should(ContainSubstring("3"))
+			}, 90*time.Second, time.Second).Should(ContainSubstring("3"))
 
 			Eventually(func() string {
 				return platform.Kubectl("get", promiseName, "one")


### PR DESCRIPTION
closes #744 

- mirror labels (excl kratix temp labels like manual reconciliation)
- update status to reflect actual version