### PR TITLE
fix: invalid resource binding version no longer prevents deletion of resource

### DIFF
--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -144,18 +144,8 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	if v, ok := promise.Labels[pauseReconciliationLabel]; ok && v == "true" {
-		msg := fmt.Sprintf("'%s' label set to 'true' for promise; pausing reconciliation for this resource request",
-			pauseReconciliationLabel)
-		logging.Info(logger, msg)
-		return ctrl.Result{}, r.setPausedReconciliationStatusConditions(ctx, rr, msg)
-	}
-
-	if v, ok := rr.GetLabels()[pauseReconciliationLabel]; ok && v == "true" {
-		msg := fmt.Sprintf("'%s' label set to 'true' for this resource request; pausing reconciliation",
-			pauseReconciliationLabel)
-		logging.Info(logger, msg)
-		return ctrl.Result{}, r.setPausedReconciliationStatusConditions(ctx, rr, msg)
+	if paused, err := r.reconcileIfPaused(ctx, promise, rr, logger); paused || err != nil {
+		return ctrl.Result{}, err
 	}
 
 	resourceLabels := getResourceLabels(rr)
@@ -168,31 +158,9 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 
 	opts := opts{client: r.Client, ctx: ctx, logger: logger}
 
-	var (
-		promiseRevisionUsed *v1alpha1.PromiseRevision
-		binding             *v1alpha1.ResourceBinding
-		bindingVersion      string
-	)
-	if r.PromiseUpgradeFeatFlag {
-		logging.Trace(baseLogger,
-			"PromiseUpgrade feature flag set to true; will reconcile with a PromiseRevision.")
-
-		var err error
-		if !rr.GetDeletionTimestamp().IsZero() {
-			promiseRevisionUsed, binding, err = getPromiseRevisionForDelete(ctx, rr, baseLogger, r, promise)
-		} else {
-			promiseRevisionUsed, binding, err = getPromiseRevisionForReconcile(ctx, rr, baseLogger, r, promise)
-		}
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
-		bindingVersion = binding.Spec.Version
-		promise.Spec = promiseRevisionUsed.Spec.PromiseSpec
-		logging.Debug(baseLogger,
-			"Found PromiseRevision from ResourceRequest", "revision name", promiseRevisionUsed.Name)
-		r.EventRecorder.Eventf(rr, v1.EventTypeNormal, "ReconcileStarted",
-			fmt.Sprintf("reconciling resource request with promise revision %s", promiseRevisionUsed.Name))
+	promiseRevisionUsed, bindingVersion, err := r.resolvePromiseRevisionForRR(ctx, rr, promise, baseLogger)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if !rr.GetDeletionTimestamp().IsZero() {
@@ -329,6 +297,65 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *DynamicResourceRequestController) reconcileIfPaused(
+	ctx context.Context,
+	promise *v1alpha1.Promise,
+	rr *unstructured.Unstructured,
+	logger logr.Logger,
+) (bool, error) {
+	if v, ok := promise.Labels[pauseReconciliationLabel]; ok && v == "true" {
+		msg := fmt.Sprintf("'%s' label set to 'true' for promise; pausing reconciliation for this resource request",
+			pauseReconciliationLabel)
+		logging.Info(logger, msg)
+		return true, r.setPausedReconciliationStatusConditions(ctx, rr, msg)
+	}
+
+	if v, ok := rr.GetLabels()[pauseReconciliationLabel]; ok && v == "true" {
+		msg := fmt.Sprintf("'%s' label set to 'true' for this resource request; pausing reconciliation",
+			pauseReconciliationLabel)
+		logging.Info(logger, msg)
+		return true, r.setPausedReconciliationStatusConditions(ctx, rr, msg)
+	}
+
+	return false, nil
+}
+
+func (r *DynamicResourceRequestController) resolvePromiseRevisionForRR(
+	ctx context.Context,
+	rr *unstructured.Unstructured,
+	promise *v1alpha1.Promise,
+	baseLogger logr.Logger,
+) (*v1alpha1.PromiseRevision, string, error) {
+	if !r.PromiseUpgradeFeatFlag {
+		return nil, "", nil
+	}
+
+	logging.Trace(baseLogger,
+		"PromiseUpgrade feature flag set to true; will reconcile with a PromiseRevision.")
+
+	var (
+		promiseRevisionUsed *v1alpha1.PromiseRevision
+		binding             *v1alpha1.ResourceBinding
+		err                 error
+	)
+	if !rr.GetDeletionTimestamp().IsZero() {
+		promiseRevisionUsed, binding, err = getPromiseRevisionForDelete(ctx, rr, baseLogger, r, promise)
+	} else {
+		promiseRevisionUsed, binding, err = getPromiseRevisionForReconcile(ctx, rr, baseLogger, r, promise)
+	}
+	if err != nil {
+		return nil, "", err
+	}
+
+	promise.Spec = promiseRevisionUsed.Spec.PromiseSpec
+	logging.Debug(baseLogger,
+		"Found PromiseRevision from ResourceRequest", "revision name", promiseRevisionUsed.Name)
+	r.EventRecorder.Eventf(rr, v1.EventTypeNormal, "ReconcileStarted",
+		fmt.Sprintf("reconciling resource request with promise revision %s", promiseRevisionUsed.Name))
+
+	return promiseRevisionUsed, binding.Spec.Version, nil
 }
 
 func (r *DynamicResourceRequestController) ensureResourceStatus(

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -170,6 +170,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 
 	var (
 		promiseRevisionUsed *v1alpha1.PromiseRevision
+		binding             *v1alpha1.ResourceBinding
 		bindingVersion      string
 	)
 	if r.PromiseUpgradeFeatFlag {
@@ -177,11 +178,16 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 			"PromiseUpgrade feature flag set to true; will reconcile with a PromiseRevision.")
 
 		var err error
-		promiseRevisionUsed, bindingVersion, err = getPromiseRevisionToUse(ctx, rr, baseLogger, r, promise)
+		if !rr.GetDeletionTimestamp().IsZero() {
+			promiseRevisionUsed, binding, err = getPromiseRevisionForDelete(ctx, rr, baseLogger, r, promise)
+		} else {
+			promiseRevisionUsed, binding, err = getPromiseRevisionForReconcile(ctx, rr, baseLogger, r, promise)
+		}
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
+		bindingVersion = binding.Spec.Version
 		promise.Spec = promiseRevisionUsed.Spec.PromiseSpec
 		logging.Debug(baseLogger,
 			"Found PromiseRevision from ResourceRequest", "revision name", promiseRevisionUsed.Name)
@@ -213,7 +219,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	if r.PromiseUpgradeFeatFlag {
+	if r.PromiseUpgradeFeatFlag && rr.GetDeletionTimestamp().IsZero() {
 		err := r.updateResourceBinding(ctx, logger, rr, promise)
 		if err != nil {
 			logging.Error(logger, err, "failed to update resource binding for resource request")
@@ -1033,8 +1039,6 @@ func (r *DynamicResourceRequestController) ensurePromiseIsAvailable(ctx context.
 	return r.Client.Status().Update(ctx, rr)
 }
 
-var errResourceBindingNotFound = fmt.Errorf("cannot find any ResourceBinding for Resource")
-
 func (r *DynamicResourceRequestController) fetchResourceBinding(
 	ctx context.Context,
 	rr *unstructured.Unstructured,
@@ -1073,29 +1077,95 @@ func notWorkflowSuspended(rr client.Object) bool {
 	return !isWorkflowSuspended(rr)
 }
 
-func getPromiseRevisionToUse(ctx context.Context, rr *unstructured.Unstructured, baseLogger logr.Logger, r *DynamicResourceRequestController, promise *v1alpha1.Promise) (*v1alpha1.PromiseRevision, string, error) {
+func getPromiseRevisionForReconcile(ctx context.Context, rr *unstructured.Unstructured, baseLogger logr.Logger, r *DynamicResourceRequestController, promise *v1alpha1.Promise) (*v1alpha1.PromiseRevision, *v1alpha1.ResourceBinding, error) {
 	var promiseRevisionToUse *v1alpha1.PromiseRevision
 
 	statusPromiseVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
 	resourceBinding, err := r.fetchResourceBinding(ctx, rr, promise)
 	if err != nil && !errors.Is(err, errResourceBindingNotFound) {
 		baseLogger.Error(err, "failed to fetch ResourceBinding for ResourceRequest")
-		return nil, "", err
+		return nil, nil, err
 	}
 
-	bindingVersion := "latest"
-	if resourceBinding != nil {
-		logging.Debug(baseLogger, "fetched ResourceBinding for ResourceRequest", "resourceBinding", resourceBinding.Spec.Version)
-		bindingVersion = resourceBinding.Spec.Version
-	}
 	promiseRevisionToUse, err = fetchRevision(ctx, r.Client, promise, resourceBinding, statusPromiseVersion)
 	if err != nil {
 		baseLogger.Error(err, "failed to fetch PromiseRevision for ResourceRequest")
 		r.EventRecorder.Eventf(rr, v1.EventTypeWarning, promiseRevisionLookupFailedReason, err.Error())
-		return nil, "", err
+		return nil, nil, err
 	}
 
-	return promiseRevisionToUse, bindingVersion, nil
+	if resourceBinding == nil {
+		resourceBinding = &v1alpha1.ResourceBinding{
+			Spec: v1alpha1.ResourceBindingSpec{
+				Version: LatestVersion,
+			},
+			Status: v1alpha1.ResourceBindingStatus{
+				LastAppliedVersion: statusPromiseVersion,
+			},
+		}
+	}
+
+	return promiseRevisionToUse, resourceBinding, nil
+}
+
+func getPromiseRevisionForDelete(ctx context.Context, rr *unstructured.Unstructured, baseLogger logr.Logger, r *DynamicResourceRequestController, promise *v1alpha1.Promise) (*v1alpha1.PromiseRevision, *v1alpha1.ResourceBinding, error) {
+	statusPromiseVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
+	resourceBinding, err := r.fetchResourceBinding(ctx, rr, promise)
+	if err != nil && !errors.Is(err, errResourceBindingNotFound) {
+		baseLogger.Error(err, "failed to fetch ResourceBinding for ResourceRequest")
+		return nil, nil, err
+	}
+
+	promiseRevisionToUse, err := fetchRevisionForDelete(ctx, r.Client, promise, rr, resourceBinding)
+	if err != nil {
+		baseLogger.Error(err, "failed to fetch PromiseRevision for ResourceRequest delete")
+		r.EventRecorder.Eventf(rr, v1.EventTypeWarning, promiseRevisionLookupFailedReason, err.Error())
+		return nil, nil, err
+	}
+
+	if resourceBinding == nil {
+		applied := resolveAppliedVersionForDelete(rr, nil)
+		specVer := LatestVersion
+		if applied != "" && applied != LatestVersion {
+			specVer = applied
+		}
+		resourceBinding = &v1alpha1.ResourceBinding{
+			Spec: v1alpha1.ResourceBindingSpec{
+				Version: specVer,
+			},
+			Status: v1alpha1.ResourceBindingStatus{
+				LastAppliedVersion: statusPromiseVersion,
+			},
+		}
+	}
+
+	return promiseRevisionToUse, resourceBinding, nil
+}
+
+// resolveAppliedVersionForDelete picks the version that was applied to the resource for
+// delete workflows. If status.promiseVersion is non-empty it wins (including when it
+// disagrees with binding status.lastAppliedVersion). Otherwise, when a binding exists,
+// lastAppliedVersion is used (so binding.spec.version "latest" does not re-resolve at
+// delete time). If both promiseVersion and lastAppliedVersion are empty, returns ""
+// (caller resolves latest).
+func resolveAppliedVersionForDelete(rr *unstructured.Unstructured, binding *v1alpha1.ResourceBinding) string {
+	pv := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
+	if pv != "" {
+		return pv
+	}
+	if binding != nil {
+		return binding.Status.LastAppliedVersion
+	}
+	return ""
+}
+
+func fetchRevisionForDelete(ctx context.Context, c client.Client, promise *v1alpha1.Promise,
+	rr *unstructured.Unstructured, binding *v1alpha1.ResourceBinding) (*v1alpha1.PromiseRevision, error) {
+	applied := resolveAppliedVersionForDelete(rr, binding)
+	if applied == "" || applied == LatestVersion {
+		return latestRevision(ctx, c, promise)
+	}
+	return promiseRevisionByExactVersion(ctx, c, promise, applied)
 }
 
 func resourceBindingLabels(rr *unstructured.Unstructured, promise *v1alpha1.Promise) map[string]string {
@@ -1123,6 +1193,33 @@ func latestRevision(ctx context.Context, c client.Client, promise *v1alpha1.Prom
 		promise.GetName())
 }
 
+func promiseRevisionByExactVersion(ctx context.Context, c client.Client, promise *v1alpha1.Promise, version string) (*v1alpha1.PromiseRevision, error) {
+	revisionList := &v1alpha1.PromiseRevisionList{}
+	if err := c.List(ctx, revisionList, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(promise.GenerateSharedLabels()),
+	}); err != nil {
+		return nil, err
+	}
+
+	revisions := []v1alpha1.PromiseRevision{}
+	for i := range revisionList.Items {
+		revision := &revisionList.Items[i]
+		if revision.Spec.Version == version {
+			revisions = append(revisions, *revision)
+		}
+	}
+
+	if len(revisions) == 0 {
+		return nil, fmt.Errorf("cannot find a PromiseRevision for Promise %s with version %s: %w",
+			promise.GetName(), version, errPromiseRevisionNotFound)
+	}
+	if len(revisions) > 1 {
+		return nil, fmt.Errorf("multiple PromiseRevisions for Promise %s with version %s",
+			promise.GetName(), version)
+	}
+	return &revisions[0], nil
+}
+
 func fetchRevision(ctx context.Context, c client.Client, promise *v1alpha1.Promise,
 	binding *v1alpha1.ResourceBinding, promiseVersionFromRRStatus string) (*v1alpha1.PromiseRevision, error) {
 
@@ -1134,7 +1231,7 @@ func fetchRevision(ctx context.Context, c client.Client, promise *v1alpha1.Promi
 	desiredVersion := promiseVersionFromRRStatus
 
 	if binding != nil {
-		if binding.Spec.Version == "latest" {
+		if binding.Spec.Version == LatestVersion {
 			return latestRevision(ctx, c, promise)
 		}
 		desiredVersion = binding.Spec.Version
@@ -1145,30 +1242,14 @@ func fetchRevision(ctx context.Context, c client.Client, promise *v1alpha1.Promi
 		return latestRevision(ctx, c, promise)
 	}
 
-	revisionList := &v1alpha1.PromiseRevisionList{}
-	if err := c.List(ctx, revisionList, &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(promise.GenerateSharedLabels()),
-	}); err != nil {
-		return nil, err
+	rev, err := promiseRevisionByExactVersion(ctx, c, promise, desiredVersion)
+	if err == nil {
+		return rev, nil
 	}
-
-	revisions := []v1alpha1.PromiseRevision{}
-	for i := range revisionList.Items {
-		revision := &revisionList.Items[i]
-		if revision.Spec.Version == desiredVersion {
-			revisions = append(revisions, *revision)
-		}
+	if errors.Is(err, errPromiseRevisionNotFound) && promiseVersionFromRRStatus != "" && promiseVersionFromRRStatus != desiredVersion {
+		return promiseRevisionByExactVersion(ctx, c, promise, promiseVersionFromRRStatus)
 	}
-
-	if len(revisions) == 0 {
-		return nil, fmt.Errorf("cannot find a PromiseRevision for Promise %s with version %s",
-			promise.GetName(), desiredVersion)
-	}
-	if len(revisions) > 1 {
-		return nil, fmt.Errorf("multiple PromiseRevisions for Promise %s with version %s",
-			promise.GetName(), desiredVersion)
-	}
-	return &revisions[0], nil
+	return nil, err
 }
 
 func updateObservedGeneration(
@@ -1253,3 +1334,9 @@ func addDynamicResourceRequestSpanAttributes(traceCtx *reconcileTrace, promise *
 		attribute.String("kratix.action", traceCtx.Action()),
 	)
 }
+
+var errResourceBindingNotFound = fmt.Errorf("cannot find any ResourceBinding for Resource")
+
+// errPromiseRevisionNotFound is wrapped by promiseRevisionByExactVersion when no revision
+// matches the requested version; use errors.Is to detect it.
+var errPromiseRevisionNotFound = errors.New("promise revision not found")

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1488,6 +1488,50 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			})
 		})
 
+		Context("deleting the resource request", func() {
+			BeforeEach(func() {
+				// This Context is not nested under "updating an existing resource", so we must
+				// register a revision here for delete reconciliation (and for tests that pin an applied version).
+				createPromiseRevision(fakeK8sClient, promise, "v1.1.0")
+			})
+
+			It("also deletes the associated resource binding", func() {
+				Expect(fakeK8sClient.Delete(ctx, resReq)).To(Succeed())
+				_, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).ToNot(HaveOccurred())
+				binding := listBindings(promise.GetName(), resReqNameNamespace)
+				Expect(binding.Items).To(BeEmpty())
+			})
+
+			When("the binding spec references a missing PromiseRevision but applied version is valid", func() {
+				It("deletes the resource request and removes the resource binding", func() {
+					appliedVersion := "v1.1.0"
+					badDesiredVersion := "v1.2.0"
+
+					resourceutil.SetStatus(resReq, l, "promiseVersion", appliedVersion)
+					Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
+
+					createResourceBinding(fakeK8sClient, promise, resReq, badDesiredVersion)
+					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+					binding.Status.LastAppliedVersion = appliedVersion
+					Expect(fakeK8sClient.Status().Update(ctx, binding)).To(Succeed())
+
+					// Without Kratix finalizers, the fake client drops the RR immediately on Delete,
+					// so reconcile never runs deleteResources / ensureResourceBindingRemoved.
+					addResourceRequestDeleteFinalizers(resReq)
+
+					Expect(fakeK8sClient.Delete(ctx, resReq)).To(Succeed())
+					setReconcileConfigureWorkflowToReturnFinished()
+					setReconcileDeleteWorkflowToReturnFinished(resReq)
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).ToNot(HaveOccurred())
+
+					bindings := listBindings(promise.GetName(), resReqNameNamespace)
+					Expect(bindings.Items).To(BeEmpty())
+				})
+			})
+		})
+
 		When("updating the resource binding version status", func() {
 			const promiseVersion = "v1.1.0"
 
@@ -1605,7 +1649,6 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				Expect(binding.GetLabels()).To(HaveKeyWithValue("kratix.io/resource-name", resReq.GetName()))
 			})
 		})
-
 	})
 })
 
@@ -1654,6 +1697,18 @@ func createPromiseRevision(fakeK8sClient client.Client, promise *v1alpha1.Promis
 	promiseRevision.SetLatestRevisionLabel()
 	Expect(fakeK8sClient.Create(ctx, promiseRevision)).To(Succeed())
 	Expect(fakeK8sClient.Status().Update(ctx, promiseRevision)).To(Succeed())
+}
+
+func addResourceRequestDeleteFinalizers(rr *unstructured.Unstructured) {
+	GinkgoHelper()
+	Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(rr), rr)).To(Succeed())
+	rr.SetFinalizers([]string{
+		v1alpha1.KratixPrefix + "work-cleanup",
+		v1alpha1.KratixPrefix + "workflows-cleanup",
+		v1alpha1.KratixPrefix + "delete-workflows",
+		v1alpha1.KratixPrefix + "resource-binding-cleanup",
+	})
+	Expect(fakeK8sClient.Update(ctx, rr)).To(Succeed())
 }
 
 func createResourceBinding(client client.Client, promise *v1alpha1.Promise, rr *unstructured.Unstructured, version string) {
@@ -1777,7 +1832,7 @@ func verifyPauseReconciliationStatus(rr *unstructured.Unstructured, rrNameNamesp
 	ExpectWithOffset(1, condition.Message).To(ContainSubstring("Paused"))
 }
 
-func getResourceBinding(promiseName string, resource types.NamespacedName) *v1alpha1.ResourceBinding {
+func listBindings(promiseName string, resource types.NamespacedName) *v1alpha1.ResourceBindingList {
 	GinkgoHelper()
 	bindingLabels := map[string]string{
 		"kratix.io/promise-name":  promiseName,
@@ -1788,7 +1843,12 @@ func getResourceBinding(promiseName string, resource types.NamespacedName) *v1al
 		Namespace:     resource.Namespace,
 		LabelSelector: labels.SelectorFromSet(bindingLabels),
 	})
+	return &bindingList
+}
 
+func getResourceBinding(promiseName string, resource types.NamespacedName) *v1alpha1.ResourceBinding {
+	GinkgoHelper()
+	bindingList := listBindings(promiseName, resource)
 	Expect(bindingList.Items).To(HaveLen(1), "found multiple resource bindings, expecting one")
 	return &bindingList.Items[0]
 }


### PR DESCRIPTION
instead of using the `spec.version` found in the resource binding, the
controller will use the version found in the resource status.
