### PR TITLE
fix: inconsitent upgrade status for resource bindings

### DIFF
--- a/api/v1alpha1/resourcebinding_types.go
+++ b/api/v1alpha1/resourcebinding_types.go
@@ -46,8 +46,8 @@ type ResourceBindingSpec struct {
 // +kubebuilder:resource:scope=Namespaced,path=resourcebindings,categories=kratix
 // +kubebuilder:printcolumn:name="Resource",type=string,JSONPath=".spec.resourceRef.name",description="Resource using a Promise"
 // +kubebuilder:printcolumn:name="Promise",type=string,JSONPath=".spec.promiseRef.name",description="Promise being used by the Resource"
-// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=".spec.version",description="Promise version used by the Resource"
-// +kubebuilder:printcolumn:name="Upgrade Succeeded",type=string,JSONPath=".status.conditions[?(@.type=='UpgradeSucceeded')].status",description="Whether the last upgrade succeeded"
+// +kubebuilder:printcolumn:name="Desired",type=string,JSONPath=".spec.version",description="Promise version the resource should be reconciled with"
+// +kubebuilder:printcolumn:name="Applied",type=string,JSONPath=".status.lastAppliedVersion",description="Promise version the resource was last reconciled with"
 
 // ResourceBinding is the Schema for the resourcebindings API
 type ResourceBinding struct {

--- a/config/crd/bases/platform.kratix.io_resourcebindings.yaml
+++ b/config/crd/bases/platform.kratix.io_resourcebindings.yaml
@@ -25,13 +25,13 @@ spec:
       jsonPath: .spec.promiseRef.name
       name: Promise
       type: string
-    - description: Promise version used by the Resource
+    - description: Promise version the resource should be reconciled with
       jsonPath: .spec.version
-      name: Version
+      name: Desired
       type: string
-    - description: Whether the last upgrade succeeded
-      jsonPath: .status.conditions[?(@.type=='UpgradeSucceeded')].status
-      name: Upgrade Succeeded
+    - description: Promise version the resource was last reconciled with
+      jsonPath: .status.lastAppliedVersion
+      name: Applied
       type: string
     name: v1alpha1
     schema:

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -287,6 +287,16 @@ func (r *DynamicResourceRequestController) reconcileAfterConfigure(
 	}
 
 	if !promise.HasPipeline(v1alpha1.WorkflowTypeResource, v1alpha1.WorkflowActionConfigure) {
+		if r.PromiseUpgradeFeatFlag {
+			versionUpdated := r.updatePromiseVersionStatus(logger, rr, bindingVersion, promiseRevisionUsed)
+			if err := r.syncNoPipelineBindingUpgradeStatus(ctx, logger, promise.GetName(), rr); err != nil {
+				logging.Error(logger, err, "failed to update resource binding version status")
+				return ctrl.Result{}, err
+			}
+			if versionUpdated {
+				return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
+			}
+		}
 		return r.nextReconciliation(logger), r.cleanupWorkflowCountersAndExecution(ctx, logger, rr)
 	}
 
@@ -410,10 +420,28 @@ func (r *DynamicResourceRequestController) ensureResourceStatus(
 	return false, nil
 }
 
+// syncNoPipelineBindingUpgradeStatus marks the binding as UpgradeSucceeded=True for promises that
+// have no configure pipeline. Without a pipeline there is nothing to run, so the upgrade succeeds
+// immediately once the version on the RR has been updated.
+func (r *DynamicResourceRequestController) syncNoPipelineBindingUpgradeStatus(ctx context.Context, logger logr.Logger, promiseName string, rr *unstructured.Unstructured) error {
+	resourceBinding, err := r.getResourceBindingForRR(ctx, promiseName, rr)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get resourceBinding: %w", err)
+	}
+
+	appliedVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
+	return r.applyResourceBindingUpgradeStatus(ctx, logger, resourceBinding, metav1.Condition{
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.UpgradeCompleteReason,
+		Message: fmt.Sprintf("Resource is at version %s", appliedVersion),
+	}, appliedVersion, "")
+}
+
 func (r *DynamicResourceRequestController) syncResourceBindingUpgradeStatus(ctx context.Context, logger logr.Logger, promiseName string, rr *unstructured.Unstructured, attemptedVersion string) error {
-	resourceBindingName := objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promiseName))
-	resourceBinding := &v1alpha1.ResourceBinding{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: rr.GetNamespace()}, resourceBinding)
+	resourceBinding, err := r.getResourceBindingForRR(ctx, promiseName, rr)
 	if err != nil {
 		return fmt.Errorf("failed to get resourceBinding: %w", err)
 	}
@@ -421,30 +449,55 @@ func (r *DynamicResourceRequestController) syncResourceBindingUpgradeStatus(ctx 
 	workflowCompleted := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
 	appliedVersion := resourceutil.GetStatus(rr, resourcePromiseVersionStatus)
 
-	var (
-		newCondStatus                 metav1.ConditionStatus
-		newCondReason, newCondMessage string
-	)
-
+	var upgradeCondition metav1.Condition
 	switch {
 	case workflowsCompletedSuccessfully(workflowCompleted):
-		newCondStatus = metav1.ConditionTrue
-		newCondReason = v1alpha1.UpgradeCompleteReason
-		newCondMessage = fmt.Sprintf("Resource is at version %s", appliedVersion)
+		upgradeCondition = metav1.Condition{
+			Status:  metav1.ConditionTrue,
+			Reason:  v1alpha1.UpgradeCompleteReason,
+			Message: fmt.Sprintf("Resource is at version %s", appliedVersion),
+		}
 	case workflowCompletedWithFailure(workflowCompleted):
-		newCondStatus = metav1.ConditionFalse
-		newCondReason = v1alpha1.UpgradeFailedReason
-		newCondMessage = workflowCompleted.Message
+		upgradeCondition = metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.UpgradeFailedReason,
+			Message: workflowCompleted.Message,
+		}
 	default:
 		return nil
 	}
 
-	needsVersionUpdate := newCondStatus == metav1.ConditionTrue && resourceBinding.Status.LastAppliedVersion != appliedVersion
-	needsFailedVersionUpdate := newCondStatus == metav1.ConditionFalse && resourceBinding.Status.FailedVersion != attemptedVersion
-	needsFailedVersionClear := newCondStatus == metav1.ConditionTrue && resourceBinding.Status.FailedVersion != ""
+	return r.applyResourceBindingUpgradeStatus(ctx, logger, resourceBinding, upgradeCondition, appliedVersion, attemptedVersion)
+}
+
+func (r *DynamicResourceRequestController) getResourceBindingForRR(ctx context.Context, promiseName string, rr *unstructured.Unstructured) (*v1alpha1.ResourceBinding, error) {
+	resourceBinding := &v1alpha1.ResourceBinding{}
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      objectutil.GenerateDeterministicObjectName(fmt.Sprintf("%s-%s", rr.GetName(), promiseName)),
+		Namespace: rr.GetNamespace(),
+	}, resourceBinding)
+	if err != nil {
+		return nil, err
+	}
+	return resourceBinding, nil
+}
+
+func (r *DynamicResourceRequestController) applyResourceBindingUpgradeStatus(
+	ctx context.Context,
+	logger logr.Logger,
+	resourceBinding *v1alpha1.ResourceBinding,
+	upgradeCondition metav1.Condition,
+	appliedVersion, attemptedVersion string,
+) error {
+	needsVersionUpdate := upgradeCondition.Status == metav1.ConditionTrue && resourceBinding.Status.LastAppliedVersion != appliedVersion
+	needsFailedVersionUpdate := upgradeCondition.Status == metav1.ConditionFalse && resourceBinding.Status.FailedVersion != attemptedVersion
+	needsFailedVersionClear := upgradeCondition.Status == metav1.ConditionTrue && resourceBinding.Status.FailedVersion != ""
 
 	existing := apiMeta.FindStatusCondition(resourceBinding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
-	conditionChanged := existing == nil || string(existing.Status) != string(newCondStatus) || existing.Reason != newCondReason
+	conditionChanged := existing == nil ||
+		string(existing.Status) != string(upgradeCondition.Status) ||
+		existing.Reason != upgradeCondition.Reason ||
+		existing.Message != upgradeCondition.Message
 
 	if !needsVersionUpdate && !needsFailedVersionUpdate && !needsFailedVersionClear && !conditionChanged {
 		return nil
@@ -463,9 +516,9 @@ func (r *DynamicResourceRequestController) syncResourceBindingUpgradeStatus(ctx 
 
 	apiMeta.SetStatusCondition(&resourceBinding.Status.Conditions, metav1.Condition{
 		Type:               v1alpha1.UpgradeSucceededCondition,
-		Status:             newCondStatus,
-		Reason:             newCondReason,
-		Message:            newCondMessage,
+		Status:             upgradeCondition.Status,
+		Reason:             upgradeCondition.Reason,
+		Message:            upgradeCondition.Message,
 		LastTransitionTime: metav1.Now(),
 	})
 

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -494,12 +494,20 @@ func (r *DynamicResourceRequestController) applyResourceBindingUpgradeStatus(
 	needsFailedVersionClear := upgradeCondition.Status == metav1.ConditionTrue && resourceBinding.Status.FailedVersion != ""
 
 	existing := apiMeta.FindStatusCondition(resourceBinding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
+	recordCondition := shouldRecordUpgradeSucceededCondition(
+		existing,
+		upgradeCondition,
+		resourceBinding.Status.LastAppliedVersion,
+		appliedVersion,
+		resourceBinding.Status.FailedVersion,
+	)
 	conditionChanged := existing == nil ||
 		string(existing.Status) != string(upgradeCondition.Status) ||
 		existing.Reason != upgradeCondition.Reason ||
 		existing.Message != upgradeCondition.Message
+	needsConditionUpdate := recordCondition && conditionChanged
 
-	if !needsVersionUpdate && !needsFailedVersionUpdate && !needsFailedVersionClear && !conditionChanged {
+	if !needsVersionUpdate && !needsFailedVersionUpdate && !needsFailedVersionClear && !needsConditionUpdate {
 		return nil
 	}
 
@@ -514,18 +522,47 @@ func (r *DynamicResourceRequestController) applyResourceBindingUpgradeStatus(
 		resourceBinding.Status.FailedVersion = ""
 	}
 
-	apiMeta.SetStatusCondition(&resourceBinding.Status.Conditions, metav1.Condition{
-		Type:               v1alpha1.UpgradeSucceededCondition,
-		Status:             upgradeCondition.Status,
-		Reason:             upgradeCondition.Reason,
-		Message:            upgradeCondition.Message,
-		LastTransitionTime: metav1.Now(),
-	})
+	if recordCondition {
+		apiMeta.SetStatusCondition(&resourceBinding.Status.Conditions, metav1.Condition{
+			Type:               v1alpha1.UpgradeSucceededCondition,
+			Status:             upgradeCondition.Status,
+			Reason:             upgradeCondition.Reason,
+			Message:            upgradeCondition.Message,
+			LastTransitionTime: metav1.Now(),
+		})
+	}
 
 	if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
 		return fmt.Errorf("failed to update resource binding status: %w", err)
 	}
 	return nil
+}
+
+// shouldRecordUpgradeSucceededCondition reports whether UpgradeSucceeded should be written.
+// UpgradeSucceeded=True is only recorded when an upgrade was attempted; fresh deployments
+// update LastAppliedVersion without setting the condition. Failures are always recorded.
+func shouldRecordUpgradeSucceededCondition(
+	existing *metav1.Condition,
+	desired metav1.Condition,
+	lastAppliedVersion, appliedVersion, failedVersion string,
+) bool {
+	if desired.Status == metav1.ConditionFalse {
+		return true
+	}
+
+	if failedVersion != "" {
+		return true
+	}
+	if existing != nil && existing.Reason == v1alpha1.UpgradeInProgressReason {
+		return true
+	}
+	if existing != nil && existing.Status == metav1.ConditionFalse {
+		return true
+	}
+	if lastAppliedVersion != "" && lastAppliedVersion != appliedVersion {
+		return true
+	}
+	return false
 }
 
 func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Context, logger logr.Logger, rr *unstructured.Unstructured, promise *v1alpha1.Promise) error {

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1541,7 +1541,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			})
 
 			When("the resource binding Status.LastAppliedVersion does not yet reflect the current promise version", func() {
-				It("updates Status.LastAppliedVersion and sets UpgradeSucceeded=True", func() {
+				It("updates Status.LastAppliedVersion without setting UpgradeSucceeded on a fresh deployment", func() {
 					setReconcileConfigureWorkflowToReturnFinished()
 					setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
 					_, err := t.reconcileUntilCompletion(reconciler, resReq)
@@ -1549,6 +1549,33 @@ var _ = Describe("DynamicResourceRequestController", func() {
 
 					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Spec.Version).To(Equal("latest"))
+					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))
+
+					cond := apiMeta.FindStatusCondition(binding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
+					Expect(cond).To(BeNil(), "fresh deployments should not set UpgradeSucceeded")
+				})
+			})
+
+			When("an upgrade is in progress", func() {
+				BeforeEach(func() {
+					createResourceBinding(fakeK8sClient, promise, resReq, promiseVersion)
+					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+					binding.Status.LastAppliedVersion = "v1.0.0"
+					apiMeta.SetStatusCondition(&binding.Status.Conditions, metav1.Condition{
+						Type:   v1alpha1.UpgradeSucceededCondition,
+						Status: metav1.ConditionUnknown,
+						Reason: v1alpha1.UpgradeInProgressReason,
+					})
+					Expect(fakeK8sClient.Status().Update(ctx, binding)).To(Succeed())
+				})
+
+				It("sets UpgradeSucceeded=True when the configure workflow succeeds", func() {
+					setReconcileConfigureWorkflowToReturnFinished()
+					setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+
+					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))
 
 					cond := apiMeta.FindStatusCondition(binding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
@@ -1563,7 +1590,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					createResourceBinding(fakeK8sClient, promise, resReq, promiseVersion)
 				})
 
-				It("updates Status.LastAppliedVersion and sets UpgradeSucceeded=True", func() {
+				It("updates Status.LastAppliedVersion without setting UpgradeSucceeded on a fresh deployment", func() {
 					setReconcileConfigureWorkflowToReturnFinished()
 					setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
 					_, err := t.reconcileUntilCompletion(reconciler, resReq)
@@ -1574,9 +1601,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))
 
 					cond := apiMeta.FindStatusCondition(binding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
-					Expect(cond).NotTo(BeNil())
-					Expect(string(cond.Status)).To(Equal(string(metav1.ConditionTrue)))
-					Expect(cond.Reason).To(Equal(v1alpha1.UpgradeCompleteReason))
+					Expect(cond).To(BeNil(), "fresh deployments should not set UpgradeSucceeded")
 				})
 			})
 

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1651,6 +1651,96 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					Expect(string(cond.Status)).To(Equal(string(metav1.ConditionTrue)))
 				})
 			})
+
+			When("the configure workflow fails again with a different message while FailedVersion is already set", func() {
+				It("updates the UpgradeSucceeded condition message to the latest failure", func() {
+					// First reconcile: creates the binding.
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Pre-set the binding with UpgradeSucceeded=False and FailedVersion already recorded.
+					// This simulates the state after a first failure: the binding already has
+					// FailedVersion=promiseVersion so needsFailedVersionUpdate will be false.
+					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+					apiMeta.SetStatusCondition(&binding.Status.Conditions, metav1.Condition{
+						Type:    v1alpha1.UpgradeSucceededCondition,
+						Status:  metav1.ConditionFalse,
+						Reason:  v1alpha1.UpgradeFailedReason,
+						Message: "A Configure Pipeline has failed: old-pipeline-xyz",
+					})
+					binding.Status.FailedVersion = promiseVersion
+					Expect(fakeK8sClient.Status().Update(ctx, binding)).To(Succeed())
+
+					// Update the RR's workflow condition to a new failure with a different message
+					// (e.g., a new job was started and failed differently — without changing the version).
+					setConfigureWorkflowAsFailed(resReq, "new-pipeline-abc")
+
+					_, err = t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+
+					binding = getResourceBinding(promise.GetName(), resReqNameNamespace)
+					cond := apiMeta.FindStatusCondition(binding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
+					Expect(cond).NotTo(BeNil())
+					Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)))
+					Expect(cond.Message).To(ContainSubstring("new-pipeline-abc"),
+						"condition message should reflect the latest failure, not be silently dropped")
+				})
+			})
+
+			When("the promise has no configure pipeline", func() {
+				BeforeEach(func() {
+					// Simulate a prior successful reconcile that set rrPromiseVersion,
+					// then the pipeline was removed in a new promise version.
+					resourceutil.SetStatus(resReq, l, "promiseVersion", "v1.0.0")
+					Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
+
+					promise.Spec.Workflows.Resource.Configure = nil
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					// The outer BeforeEach created the PromiseRevision while the promise still
+					// had its configure pipeline. Update the revision's PromiseSpec to match the
+					// current (no-pipeline) promise spec, because resolvePromiseRevisionForRR
+					// replaces promise.Spec with revision.Spec.PromiseSpec — restoring the
+					// pipeline if we don't update the revision here.
+					revisionName := fmt.Sprintf("%s-%s", promise.GetName(), promiseVersion)
+					revision := &v1alpha1.PromiseRevision{}
+					Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: revisionName}, revision)).To(Succeed())
+					revision.Spec.PromiseSpec = promise.Spec
+					Expect(fakeK8sClient.Update(ctx, revision)).To(Succeed())
+
+					// Without a pipeline, workflow.ReconcileConfigure returns (false, nil) in
+					// production. Mirror that here so reconcileAfterConfigure is entered.
+					setReconcileConfigureWorkflowToReturnFinished()
+				})
+
+				It("sets UpgradeSucceeded=True and updates rrPromiseVersion so the upgrade resolves", func() {
+					createResourceBinding(fakeK8sClient, promise, resReq, promiseVersion)
+					binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+					binding.Status.FailedVersion = "v1.0.0"
+					apiMeta.SetStatusCondition(&binding.Status.Conditions, metav1.Condition{
+						Type:   v1alpha1.UpgradeSucceededCondition,
+						Status: metav1.ConditionFalse,
+						Reason: v1alpha1.UpgradeFailedReason,
+					})
+					Expect(fakeK8sClient.Status().Update(ctx, binding)).To(Succeed())
+
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+					Expect(resourceutil.GetStatus(resReq, "promiseVersion")).To(Equal(promiseVersion),
+						"rrPromiseVersion must be updated so the ResourceBinding controller sees no mismatch")
+
+					binding = getResourceBinding(promise.GetName(), resReqNameNamespace)
+					cond := apiMeta.FindStatusCondition(binding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
+					Expect(cond).NotTo(BeNil())
+					Expect(string(cond.Status)).To(Equal(string(metav1.ConditionTrue)),
+						"no-pipeline upgrade should be marked as succeeded immediately")
+					Expect(binding.Status.LastAppliedVersion).To(Equal(promiseVersion))
+					Expect(binding.Status.FailedVersion).To(BeEmpty(),
+						"stale FailedVersion from a prior pipeline failure should be cleared")
+				})
+			})
 		})
 
 		When("creating the resource binding", func() {


### PR DESCRIPTION
Bug 1: No-pipeline promise stuck at Unknown (edge case, real loop)
    If a promise previously had a configure pipeline (so status.promiseVersion is set on the RR), then is upgraded to a new version without a configure pipeline the binding is stuck Unknown indefinitely.

Bug 2: Stale condition message on same-version re-failure
    If a workflow fails twice (same version, same reason, different message, the condition message was never updated. The binding shows the original failure message forever.