### PR TITLE
feat(789): bind resources to version

### DIFF
--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 Syntasso.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cmd Suite")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,19 +73,15 @@ func init() {
 }
 
 type KratixConfig struct {
-	Workflows                Workflows               `json:"workflows"`
-	NumberOfJobsToKeep       int                     `json:"numberOfJobsToKeep,omitempty"`
-	ControllerLeaderElection *LeaderElectionConfig   `json:"controllerLeaderElection,omitempty"`
-	SelectiveCache           bool                    `json:"selectiveCache,omitempty"`
-	ReconciliationInterval   *metav1.Duration        `json:"reconciliationInterval,omitempty"`
-	Telemetry                *telemetry.Config       `json:"telemetry,omitempty"`
-	Logging                  *LoggingConfig          `json:"logging,omitempty"`
-	FeatureFlags             *FeatureFlags           `json:"featureFlags,omitempty"`
-	ResourceBindings         *ResourceBindingsConfig `json:"resourceBindings,omitempty"`
-}
-
-type ResourceBindingsConfig struct {
-	DefaultVersion ResourceBindingDefaultVersion `json:"defaultVersion,omitempty"`
+	Workflows                      Workflows                     `json:"workflows"`
+	NumberOfJobsToKeep             int                           `json:"numberOfJobsToKeep,omitempty"`
+	ControllerLeaderElection       *LeaderElectionConfig         `json:"controllerLeaderElection,omitempty"`
+	SelectiveCache                 bool                          `json:"selectiveCache,omitempty"`
+	ReconciliationInterval         *metav1.Duration              `json:"reconciliationInterval,omitempty"`
+	Telemetry                      *telemetry.Config             `json:"telemetry,omitempty"`
+	Logging                        *LoggingConfig                `json:"logging,omitempty"`
+	FeatureFlags                   *FeatureFlags                 `json:"featureFlags,omitempty"`
+	ResourceBindingVersionStrategy ResourceBindingDefaultVersion `json:"resourceBindingVersionStrategy,omitempty"`
 }
 
 // ResourceBindingDefaultVersion controls the version strategy for ResourceBindings.
@@ -510,14 +506,14 @@ func getPodTTLAfterFinished(kratixConfig *KratixConfig) *time.Duration {
 }
 
 func getResourceBindingDefaultVersion(kratixConfig *KratixConfig) ResourceBindingDefaultVersion {
-	if kratixConfig == nil || kratixConfig.ResourceBindings == nil || kratixConfig.ResourceBindings.DefaultVersion == "" {
+	if kratixConfig == nil || kratixConfig.ResourceBindingVersionStrategy == "" {
 		return ResourceBindingDefaultVersionFloating
 	}
-	v := kratixConfig.ResourceBindings.DefaultVersion
+	v := kratixConfig.ResourceBindingVersionStrategy
 	if v != ResourceBindingDefaultVersionFloating && v != ResourceBindingDefaultVersionPinned {
 		setupLog.Error(fmt.Errorf("invalid Kratix Config"),
-			"resourceBindings.defaultVersion must be 'floating' or 'pinned'; defaulting to 'floating'",
-			"defaultVersion", v)
+			"resourceBindingVersionStrategy must be 'floating' or 'pinned'; defaulting to 'floating'",
+			"resourceBindingVersionStrategy", v)
 		return ResourceBindingDefaultVersionFloating
 	}
 	return v

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -207,6 +207,8 @@ func main() {
 	}
 
 	podTTLAfterFinished := getPodTTLAfterFinished(kratixConfig)
+	resourceBindingDefaultVersion := getResourceBindingDefaultVersion(kratixConfig)
+	setupLog.Info("resource binding default version strategy configured", "defaultVersion", resourceBindingDefaultVersion)
 
 	telemetryShutdown := func(context.Context) error { return nil }
 	if shutdown, err := telemetry.SetupTracerProvider(context.Background(), ctrl.Log.WithName("telemetry"), "kratix-controller-manager", telemetryConfigFromKratixConfig(kratixConfig)); err != nil {
@@ -298,7 +300,7 @@ func main() {
 		ReconciliationInterval: getRegularReconciliationInterval(kratixConfig),
 		EventRecorder:          mgr.GetEventRecorderFor("PromiseController"),
 		PromiseUpgrade:         promiseUpgradeEnabled(kratixConfig),
-		ResourceBindingPinned:  getResourceBindingDefaultVersion(kratixConfig) == ResourceBindingDefaultVersionPinned,
+		ResourceBindingPinned:  resourceBindingDefaultVersion == ResourceBindingDefaultVersionPinned,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Promise")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -511,7 +511,14 @@ func getResourceBindingDefaultVersion(kratixConfig *KratixConfig) ResourceBindin
 	if kratixConfig == nil || kratixConfig.ResourceBindings == nil || kratixConfig.ResourceBindings.DefaultVersion == "" {
 		return ResourceBindingDefaultVersionFloating
 	}
-	return kratixConfig.ResourceBindings.DefaultVersion
+	v := kratixConfig.ResourceBindings.DefaultVersion
+	if v != ResourceBindingDefaultVersionFloating && v != ResourceBindingDefaultVersionPinned {
+		setupLog.Error(fmt.Errorf("invalid Kratix Config"),
+			"resourceBindings.defaultVersion must be 'floating' or 'pinned'; defaulting to 'floating'",
+			"defaultVersion", v)
+		return ResourceBindingDefaultVersionFloating
+	}
+	return v
 }
 
 func getRegularReconciliationInterval(kratixConfig *KratixConfig) time.Duration {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,15 +73,30 @@ func init() {
 }
 
 type KratixConfig struct {
-	Workflows                Workflows             `json:"workflows"`
-	NumberOfJobsToKeep       int                   `json:"numberOfJobsToKeep,omitempty"`
-	ControllerLeaderElection *LeaderElectionConfig `json:"controllerLeaderElection,omitempty"`
-	SelectiveCache           bool                  `json:"selectiveCache,omitempty"`
-	ReconciliationInterval   *metav1.Duration      `json:"reconciliationInterval,omitempty"`
-	Telemetry                *telemetry.Config     `json:"telemetry,omitempty"`
-	Logging                  *LoggingConfig        `json:"logging,omitempty"`
-	FeatureFlags             *FeatureFlags         `json:"featureFlags,omitempty"`
+	Workflows                Workflows               `json:"workflows"`
+	NumberOfJobsToKeep       int                     `json:"numberOfJobsToKeep,omitempty"`
+	ControllerLeaderElection *LeaderElectionConfig   `json:"controllerLeaderElection,omitempty"`
+	SelectiveCache           bool                    `json:"selectiveCache,omitempty"`
+	ReconciliationInterval   *metav1.Duration        `json:"reconciliationInterval,omitempty"`
+	Telemetry                *telemetry.Config       `json:"telemetry,omitempty"`
+	Logging                  *LoggingConfig          `json:"logging,omitempty"`
+	FeatureFlags             *FeatureFlags           `json:"featureFlags,omitempty"`
+	ResourceBindings         *ResourceBindingsConfig `json:"resourceBindings,omitempty"`
 }
+
+type ResourceBindingsConfig struct {
+	DefaultVersion ResourceBindingDefaultVersion `json:"defaultVersion,omitempty"`
+}
+
+// ResourceBindingDefaultVersion controls the version strategy for ResourceBindings.
+// "floating" sets spec.version to "latest"; "pinned" sets it to the current PromiseRevision version.
+// Defaults to "floating" when not set.
+type ResourceBindingDefaultVersion string
+
+const (
+	ResourceBindingDefaultVersionFloating ResourceBindingDefaultVersion = "floating"
+	ResourceBindingDefaultVersionPinned   ResourceBindingDefaultVersion = "pinned"
+)
 
 type FeatureFlags struct {
 	PromiseUpgrade *bool `json:"promiseUpgrade,omitempty"`
@@ -283,6 +298,7 @@ func main() {
 		ReconciliationInterval: getRegularReconciliationInterval(kratixConfig),
 		EventRecorder:          mgr.GetEventRecorderFor("PromiseController"),
 		PromiseUpgrade:         promiseUpgradeEnabled(kratixConfig),
+		ResourceBindingPinned:  getResourceBindingDefaultVersion(kratixConfig) == ResourceBindingDefaultVersionPinned,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Promise")
 		os.Exit(1)
@@ -489,6 +505,13 @@ func getPodTTLAfterFinished(kratixConfig *KratixConfig) *time.Duration {
 
 	ttl := time.Duration(podTTLSecondsAfterFinished) * time.Second
 	return &ttl
+}
+
+func getResourceBindingDefaultVersion(kratixConfig *KratixConfig) ResourceBindingDefaultVersion {
+	if kratixConfig == nil || kratixConfig.ResourceBindings == nil || kratixConfig.ResourceBindings.DefaultVersion == "" {
+		return ResourceBindingDefaultVersionFloating
+	}
+	return kratixConfig.ResourceBindings.DefaultVersion
 }
 
 func getRegularReconciliationInterval(kratixConfig *KratixConfig) time.Duration {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -59,6 +59,13 @@ func TestGetResourceBindingDefaultVersion(t *testing.T) {
 			},
 			expected: ResourceBindingDefaultVersionPinned,
 		},
+		{
+			name: "unrecognised value defaults to floating",
+			config: &KratixConfig{
+				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: "invalid"},
+			},
+			expected: ResourceBindingDefaultVersionFloating,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -26,35 +26,27 @@ var _ = Describe("getResourceBindingDefaultVersion", func() {
 		Expect(getResourceBindingDefaultVersion(nil)).To(Equal(ResourceBindingDefaultVersionFloating))
 	})
 
-	It("returns floating when config has no resourceBindings section", func() {
+	It("returns floating when config has no resourceBindingVersionStrategy set", func() {
 		Expect(getResourceBindingDefaultVersion(&KratixConfig{})).To(Equal(ResourceBindingDefaultVersionFloating))
 	})
 
-	It("returns floating when defaultVersion is empty", func() {
-		config := &KratixConfig{
-			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ""},
-		}
+	It("returns floating when resourceBindingVersionStrategy is empty", func() {
+		config := &KratixConfig{ResourceBindingVersionStrategy: ""}
 		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionFloating))
 	})
 
-	It("returns floating when defaultVersion is set to floating", func() {
-		config := &KratixConfig{
-			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionFloating},
-		}
+	It("returns floating when resourceBindingVersionStrategy is set to floating", func() {
+		config := &KratixConfig{ResourceBindingVersionStrategy: ResourceBindingDefaultVersionFloating}
 		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionFloating))
 	})
 
-	It("returns pinned when defaultVersion is set to pinned", func() {
-		config := &KratixConfig{
-			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionPinned},
-		}
+	It("returns pinned when resourceBindingVersionStrategy is set to pinned", func() {
+		config := &KratixConfig{ResourceBindingVersionStrategy: ResourceBindingDefaultVersionPinned}
 		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionPinned))
 	})
 
-	It("returns floating for an unrecognised defaultVersion value", func() {
-		config := &KratixConfig{
-			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: "invalid"},
-		}
+	It("returns floating for an unrecognised resourceBindingVersionStrategy value", func() {
+		config := &KratixConfig{ResourceBindingVersionStrategy: "invalid"}
 		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionFloating))
 	})
 })

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -17,61 +17,44 @@ limitations under the License.
 package main
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-func TestGetResourceBindingDefaultVersion(t *testing.T) {
-	tests := []struct {
-		name     string
-		config   *KratixConfig
-		expected ResourceBindingDefaultVersion
-	}{
-		{
-			name:     "nil config defaults to floating",
-			config:   nil,
-			expected: ResourceBindingDefaultVersionFloating,
-		},
-		{
-			name:     "config with no resourceBindings section defaults to floating",
-			config:   &KratixConfig{},
-			expected: ResourceBindingDefaultVersionFloating,
-		},
-		{
-			name: "config with empty defaultVersion defaults to floating",
-			config: &KratixConfig{
-				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ""},
-			},
-			expected: ResourceBindingDefaultVersionFloating,
-		},
-		{
-			name: "config with floating returns floating",
-			config: &KratixConfig{
-				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionFloating},
-			},
-			expected: ResourceBindingDefaultVersionFloating,
-		},
-		{
-			name: "config with pinned returns pinned",
-			config: &KratixConfig{
-				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionPinned},
-			},
-			expected: ResourceBindingDefaultVersionPinned,
-		},
-		{
-			name: "unrecognised value defaults to floating",
-			config: &KratixConfig{
-				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: "invalid"},
-			},
-			expected: ResourceBindingDefaultVersionFloating,
-		},
-	}
+var _ = Describe("getResourceBindingDefaultVersion", func() {
+	It("returns floating when config is nil", func() {
+		Expect(getResourceBindingDefaultVersion(nil)).To(Equal(ResourceBindingDefaultVersionFloating))
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(getResourceBindingDefaultVersion(tt.config)).To(Equal(tt.expected))
-		})
-	}
-}
+	It("returns floating when config has no resourceBindings section", func() {
+		Expect(getResourceBindingDefaultVersion(&KratixConfig{})).To(Equal(ResourceBindingDefaultVersionFloating))
+	})
+
+	It("returns floating when defaultVersion is empty", func() {
+		config := &KratixConfig{
+			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ""},
+		}
+		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionFloating))
+	})
+
+	It("returns floating when defaultVersion is set to floating", func() {
+		config := &KratixConfig{
+			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionFloating},
+		}
+		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionFloating))
+	})
+
+	It("returns pinned when defaultVersion is set to pinned", func() {
+		config := &KratixConfig{
+			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionPinned},
+		}
+		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionPinned))
+	})
+
+	It("returns floating for an unrecognised defaultVersion value", func() {
+		config := &KratixConfig{
+			ResourceBindings: &ResourceBindingsConfig{DefaultVersion: "invalid"},
+		}
+		Expect(getResourceBindingDefaultVersion(config)).To(Equal(ResourceBindingDefaultVersionFloating))
+	})
+})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 Syntasso.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetResourceBindingDefaultVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *KratixConfig
+		expected ResourceBindingDefaultVersion
+	}{
+		{
+			name:     "nil config defaults to floating",
+			config:   nil,
+			expected: ResourceBindingDefaultVersionFloating,
+		},
+		{
+			name:     "config with no resourceBindings section defaults to floating",
+			config:   &KratixConfig{},
+			expected: ResourceBindingDefaultVersionFloating,
+		},
+		{
+			name: "config with empty defaultVersion defaults to floating",
+			config: &KratixConfig{
+				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ""},
+			},
+			expected: ResourceBindingDefaultVersionFloating,
+		},
+		{
+			name: "config with floating returns floating",
+			config: &KratixConfig{
+				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionFloating},
+			},
+			expected: ResourceBindingDefaultVersionFloating,
+		},
+		{
+			name: "config with pinned returns pinned",
+			config: &KratixConfig{
+				ResourceBindings: &ResourceBindingsConfig{DefaultVersion: ResourceBindingDefaultVersionPinned},
+			},
+			expected: ResourceBindingDefaultVersionPinned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(getResourceBindingDefaultVersion(tt.config)).To(Equal(tt.expected))
+		})
+	}
+}

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -587,18 +587,11 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 		if resourceBinding.Spec.Version == "" {
 			// if the resource binding got deleted, when we recreate the resource binding we infer what the resource binding
 			// version used to be from the resource request `status.resourceBindingVersion`
-			existingPromiseVersion := resourceutil.GetStatus(rr, resourceBindingVersionStatus)
-			if existingPromiseVersion != "" {
-				resourceBinding.Spec.Version = existingPromiseVersion
-			} else if r.ResourceBindingPinned {
-				revision, err := latestRevision(ctx, r.Client, promise)
-				if err != nil {
-					return err
-				}
-				resourceBinding.Spec.Version = revision.Spec.Version
-			} else {
-				resourceBinding.Spec.Version = LatestVersion
+			version, err := r.determineResourceBindingVersion(ctx, rr, promise)
+			if err != nil {
+				return err
 			}
+			resourceBinding.Spec.Version = version
 		}
 
 		resourceBinding.Spec.PromiseRef = v1alpha1.PromiseRef{Name: promise.GetName()}
@@ -631,6 +624,22 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 	}
 
 	return nil
+}
+
+func (r *DynamicResourceRequestController) determineResourceBindingVersion(ctx context.Context, rr *unstructured.Unstructured, promise *v1alpha1.Promise) (string, error) {
+	// if the resource binding got deleted, when we recreate the resource binding we infer what the resource binding
+	// version used to be from the resource request `status.resourceBindingVersion`
+	if existingVersion := resourceutil.GetStatus(rr, resourceBindingVersionStatus); existingVersion != "" {
+		return existingVersion, nil
+	}
+	if r.ResourceBindingPinned {
+		revision, err := latestRevision(ctx, r.Client, promise)
+		if err != nil {
+			return "", err
+		}
+		return revision.Spec.Version, nil
+	}
+	return LatestVersion, nil
 }
 
 func (r *DynamicResourceRequestController) ensureConfigureWorkflowStatus(

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -82,6 +82,7 @@ type DynamicResourceRequestController struct {
 	ReconciliationInterval      time.Duration
 	EventRecorder               record.EventRecorder
 	PromiseUpgradeFeatFlag      bool
+	ResourceBindingPinned       bool
 }
 
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;list;watch;create;update;patch;delete
@@ -584,12 +585,19 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 		maps.Copy(mergedLabels, resourceBindingLabels(rr, promise))
 		resourceBinding.SetLabels(mergedLabels)
 		if resourceBinding.Spec.Version == "" {
-			resourceBinding.Spec.Version = LatestVersion
 			// if the resource binding got deleted, when we recreate the resource binding we infer what the resource binding
 			// version used to be from the resource request `status.resourceBindingVersion`
 			existingPromiseVersion := resourceutil.GetStatus(rr, resourceBindingVersionStatus)
 			if existingPromiseVersion != "" {
 				resourceBinding.Spec.Version = existingPromiseVersion
+			} else if r.ResourceBindingPinned {
+				revision, err := latestRevision(ctx, r.Client, promise)
+				if err != nil {
+					return err
+				}
+				resourceBinding.Spec.Version = revision.Spec.Version
+			} else {
+				resourceBinding.Spec.Version = LatestVersion
 			}
 		}
 

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1306,6 +1306,18 @@ var _ = Describe("DynamicResourceRequestController", func() {
 
 						binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
 						Expect(binding.Spec.Version).To(Equal(promiseVersion))
+
+						By("running the promise workflows successfully", func() {
+							setReconcileConfigureWorkflowToReturnFinished()
+							result, err := t.reconcileUntilCompletion(reconciler, resReq)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(result).To(Equal(ctrl.Result{}))
+						})
+
+						By("setting the binding version in the resource status", func() {
+							Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+							Expect(resourceutil.GetStatus(resReq, "resourceBindingVersion")).To(Equal(promiseVersion))
+						})
 					})
 				})
 

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -1289,6 +1289,33 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					)))
 				})
 			})
+
+			When("ResourceBindingPinned is true", func() {
+				BeforeEach(func() {
+					reconciler.ResourceBindingPinned = true
+				})
+
+				When("there is a promise revision marked as latest", func() {
+					It("sets the binding version to the promise revision version, not latest", func() {
+						promiseVersion := "v1.1.0"
+						createPromiseRevision(fakeK8sClient, promise, promiseVersion)
+
+						result, err := t.reconcileUntilCompletion(reconciler, resReq)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).To(Equal(ctrl.Result{}))
+
+						binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+						Expect(binding.Spec.Version).To(Equal(promiseVersion))
+					})
+				})
+
+				When("there is no promise revision marked as latest", func() {
+					It("returns a reconciliation error", func() {
+						_, err := t.reconcileUntilCompletion(reconciler, resReq)
+						Expect(err).To(MatchError(ContainSubstring("cannot find any PromiseRevision for Promise redis with status.latest set to true")))
+					})
+				})
+			})
 		})
 
 		When("the resource was created from a revision but the resource binding doesn't exist", func() {
@@ -1331,6 +1358,24 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					Expect(binding.Spec.ResourceRef.Name).To(Equal(resReqNameNamespace.Name))
 					Expect(binding.Spec.ResourceRef.Namespace).To(Equal(resReqNameNamespace.Namespace))
 					Expect(binding.Spec.Version).To(Equal(promiseVersion))
+				})
+
+				When("ResourceBindingPinned is true", func() {
+					BeforeEach(func() {
+						reconciler.ResourceBindingPinned = true
+					})
+
+					It("restores the version from status regardless of the pinned strategy", func() {
+						resourceutil.SetStatus(resReq, l, "resourceBindingVersion", promiseVersion)
+						Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
+
+						result, err := t.reconcileUntilCompletion(reconciler, resReq)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).To(Equal(ctrl.Result{}))
+
+						binding := getResourceBinding(promise.GetName(), resReqNameNamespace)
+						Expect(binding.Spec.Version).To(Equal(promiseVersion))
+					})
 				})
 			})
 

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -81,6 +81,7 @@ type PromiseReconciler struct {
 	ReconciliationInterval    time.Duration
 	EventRecorder             record.EventRecorder
 	PromiseUpgrade            bool
+	ResourceBindingPinned     bool
 }
 
 const (
@@ -1141,6 +1142,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		dynamicController.NumberOfJobsToKeep = r.NumberOfJobsToKeep
 		dynamicController.ReconciliationInterval = r.ReconciliationInterval
 		dynamicController.PromiseUpgradeFeatFlag = r.PromiseUpgrade
+		dynamicController.ResourceBindingPinned = r.ResourceBindingPinned
 		dynamicController.PromiseDestinationSelectors = promise.Spec.DestinationSelectors
 
 		if dynamicController.WatchStopped {
@@ -1171,6 +1173,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		ReconciliationInterval:      r.ReconciliationInterval,
 		EventRecorder:               r.Manager.GetEventRecorderFor("ResourceRequestController"),
 		PromiseUpgradeFeatFlag:      r.PromiseUpgrade,
+		ResourceBindingPinned:       r.ResourceBindingPinned,
 	}
 
 	unstructuredCRD := &unstructured.Unstructured{}

--- a/test/kubeutils/cluster.go
+++ b/test/kubeutils/cluster.go
@@ -45,12 +45,18 @@ func (c Cluster) kubectlInternalG(g Gomega, checkExitCode bool, args ...string) 
 
 	fmt.Fprintf(GinkgoWriter, "Running: kubectl %s\n", strings.Join(args, " "))
 
-	g.ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	g.ExpectWithOffset(2, err).ShouldNot(HaveOccurred())
+
+	g.EventuallyWithOffset(2, session, timeout, interval).Should(gexec.Exit())
+
+	if session.ExitCode() != 0 {
+		fmt.Fprintf(GinkgoWriter, "kubectl %s exited %d\nstdout: %s\nstderr: %s\n",
+			strings.Join(args, " "), session.ExitCode(),
+			session.Out.Contents(), session.Err.Contents())
+	}
 
 	if checkExitCode {
-		g.EventuallyWithOffset(1, session, timeout, interval).Should(gexec.Exit(0))
-	} else {
-		g.EventuallyWithOffset(1, session, timeout, interval).Should(gexec.Exit())
+		g.ExpectWithOffset(2, session.ExitCode()).To(Equal(0))
 	}
 
 	return string(session.Out.Contents()) + string(session.Err.Contents())

--- a/test/system/assets/resource-binding-default-version/kratix-config-pinned.yaml
+++ b/test/system/assets/resource-binding-default-version/kratix-config-pinned.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kratix
+  namespace: kratix-platform-system
+data:
+  config: |
+    featureFlags:
+      promiseUpgrade: true
+    resourceBindings:
+      defaultVersion: pinned
+    workflows:
+      jobOptions:
+        defaultBackoffLimit: 4
+      defaultContainerSecurityContext:
+        windowsOptions:
+          runAsUserName: "setInKratixConfig"

--- a/test/system/assets/resource-binding-default-version/kratix-config-pinned.yaml
+++ b/test/system/assets/resource-binding-default-version/kratix-config-pinned.yaml
@@ -7,8 +7,7 @@ data:
   config: |
     featureFlags:
       promiseUpgrade: true
-    resourceBindings:
-      defaultVersion: pinned
+    resourceBindingVersionStrategy: pinned
     workflows:
       jobOptions:
         defaultBackoffLimit: 4

--- a/test/system/assets/resource-binding-default-version/promise.yaml
+++ b/test/system/assets/resource-binding-default-version/promise.yaml
@@ -1,0 +1,42 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  name: rbversion
+  labels:
+    kratix.io/promise-version: v1.0.0
+spec:
+  api:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: rbversions.test.kratix.io
+    spec:
+      group: test.kratix.io
+      names:
+        kind: Rbversion
+        plural: rbversions
+        singular: rbversion
+      scope: Namespaced
+      versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+              type: object
+          served: true
+          storage: true
+  workflows:
+    resource:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: resource-configure
+          spec:
+            containers:
+              - image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+                name: no-op
+                command:
+                  - /bin/sh
+                args:
+                  - -c
+                  - "echo done"

--- a/test/system/assets/resource-binding-default-version/promise.yaml
+++ b/test/system/assets/resource-binding-default-version/promise.yaml
@@ -22,6 +22,7 @@ spec:
           schema:
             openAPIV3Schema:
               type: object
+              x-kubernetes-preserve-unknown-fields: true
           served: true
           storage: true
   workflows:

--- a/test/system/assets/resource-binding-default-version/resource-request.yaml
+++ b/test/system/assets/resource-binding-default-version/resource-request.yaml
@@ -1,0 +1,6 @@
+apiVersion: test.kratix.io/v1alpha1
+kind: Rbversion
+metadata:
+  name: example
+  namespace: default
+spec: {}

--- a/test/system/resource_binding_default_version_test.go
+++ b/test/system/resource_binding_default_version_test.go
@@ -81,4 +81,7 @@ func restartController() {
 	GinkgoHelper()
 	platform.Kubectl("delete", "pod", "-l", "control-plane=controller-manager", "-n", "kratix-platform-system")
 	platform.Kubectl("wait", "-n", "kratix-platform-system", "deployments", "-l", "control-plane=controller-manager", "--for=condition=Available")
+	Eventually(func() string {
+		return platform.KubectlAllowFail("apply", "--dry-run=server", "-f", "assets/kratix-config/promise.yaml")
+	}).Should(ContainSubstring("dry run"))
 }

--- a/test/system/resource_binding_default_version_test.go
+++ b/test/system/resource_binding_default_version_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/syntasso/kratix/test/kubeutils"
 )
 
-var _ = Describe("ResourceBinding Default Version", func() {
+var _ = Describe("ResourceBinding Default Version", Serial, func() {
 	const (
 		assetsPath     = "assets/resource-binding-default-version"
 		promiseName    = "rbversion"
@@ -27,6 +27,7 @@ var _ = Describe("ResourceBinding Default Version", func() {
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 		kubeutils.SetTimeoutAndInterval(4*time.Minute, 2*time.Second)
 
+		platform.EventuallyKubectlDelete("promise", promiseName)
 		platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "promise.yaml"))
 		Eventually(func() string {
 			return platform.Kubectl("get", "promise", promiseName)

--- a/test/system/resource_binding_default_version_test.go
+++ b/test/system/resource_binding_default_version_test.go
@@ -1,0 +1,84 @@
+package system_test
+
+import (
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/syntasso/kratix/test/kubeutils"
+)
+
+var _ = Describe("ResourceBinding Default Version", func() {
+	const (
+		assetsPath     = "assets/resource-binding-default-version"
+		promiseName    = "rbversion"
+		promiseKind    = "rbversions"
+		rrName         = "example"
+		promiseVersion = "v1.0.0"
+	)
+
+	BeforeEach(func() {
+		if getEnvOrDefault("UPGRADE_ENABLED", "false") != "true" {
+			Skip("skipping resource binding default version tests because UPGRADE_ENABLED is not set to true")
+		}
+
+		SetDefaultEventuallyTimeout(4 * time.Minute)
+		SetDefaultEventuallyPollingInterval(2 * time.Second)
+		kubeutils.SetTimeoutAndInterval(4*time.Minute, 2*time.Second)
+
+		platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "promise.yaml"))
+		Eventually(func() string {
+			return platform.Kubectl("get", "promise", promiseName)
+		}).Should(ContainSubstring("Available"))
+	})
+
+	AfterEach(func() {
+		if getEnvOrDefault("UPGRADE_ENABLED", "false") != "true" {
+			return
+		}
+
+		platform.EventuallyKubectlDelete(promiseKind, rrName)
+		platform.EventuallyKubectlDelete("promise", promiseName)
+
+		platform.Kubectl("apply", "-f", kratixConfigPath)
+		restartController()
+	})
+
+	When("defaultVersion is not set", func() {
+		It("creates a resource binding with spec.version set to 'latest'", func() {
+			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "resource-request.yaml"))
+
+			Eventually(func(g Gomega) {
+				name := getBindingName(promiseName, rrName)
+				g.Expect(name).NotTo(BeEmpty())
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.spec.version}'")).
+					To(ContainSubstring("latest"))
+			}).Should(Succeed())
+		})
+	})
+
+	When("defaultVersion is set to pinned", func() {
+		BeforeEach(func() {
+			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "kratix-config-pinned.yaml"))
+			restartController()
+		})
+
+		It("creates a resource binding with spec.version set to the current promise revision version", func() {
+			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "resource-request.yaml"))
+
+			Eventually(func(g Gomega) {
+				name := getBindingName(promiseName, rrName)
+				g.Expect(name).NotTo(BeEmpty())
+				g.Expect(platform.Kubectl("get", "--namespace=default", name, "-o=jsonpath='{.spec.version}'")).
+					To(ContainSubstring(promiseVersion))
+			}).Should(Succeed())
+		})
+	})
+})
+
+func restartController() {
+	GinkgoHelper()
+	platform.Kubectl("delete", "pod", "-l", "control-plane=controller-manager", "-n", "kratix-platform-system")
+	platform.Kubectl("wait", "-n", "kratix-platform-system", "deployments", "-l", "control-plane=controller-manager", "--for=condition=Available")
+}

--- a/test/system/system_suite_test.go
+++ b/test/system/system_suite_test.go
@@ -53,6 +53,10 @@ var _ = SynchronizedBeforeSuite(func() {
 	worker = &kubeutils.Cluster{
 		Context: getEnvOrDefault("WORKER_CONTEXT", "kind-worker"),
 		Name:    getEnvOrDefault("WORKER_NAME", "worker-1")}
+	kratixConfigPath = "./assets/kratix-config.yaml"
+	if getEnvOrDefault("UPGRADE_ENABLED", "false") == "true" {
+		kratixConfigPath = "./assets/kratix-config-upgrade.yaml"
+	}
 })
 
 func getEnvOrDefault(envVar, defaultValue string) string {


### PR DESCRIPTION
closes #789 

Example configmap:

```
apiVersion: v1
data:
  config: |
    logging:
      level: "trace" # one of info, warning, debug, trace
      structured: false # if true, emit logs as jso
    featureFlags:
      promiseUpgrade: true # enable/disable promise revisions
    ResourceBindingVersionStrategy: "pinned"
kind: ConfigMap
metadata:
  name: kratix
  namespace: kratix-platform-system
```


- **feat: ResourceBindings.DefaultVersion can be defined via the kratix configmap**
- **feat: set the resourceBinding.spec.version in accordance with the defaultVersion**
- **feat: provide feedback when an invalid defaultversion is provided**
- **feat: log the defaultVersion in startup**
- **chore: define system test for defaultVersion behaviour**
