### PR TITLE
fix: Ensure status is updated when removing the reconcilitation labels

### DIFF
--- a/api/v1alpha1/resourcebinding_types.go
+++ b/api/v1alpha1/resourcebinding_types.go
@@ -17,6 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
+	"unicode"
+
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -93,4 +97,34 @@ type ResourceBindingList struct {
 
 func init() {
 	SchemeBuilder.Register(&ResourceBinding{}, &ResourceBindingList{})
+}
+
+// InFlightVersion returns the promise version of the resource configure
+// workflow that is currently being attempted for this binding, or an empty
+// string if no upgrade is in flight.
+//
+// It is inferred from the UpgradeSucceeded condition: while an upgrade is in
+// progress that condition is set to Unknown with reason UpgradeInProgress, and
+// its message embeds the desired version after the literal token "version ".
+// The controller is the sole writer of that condition, so coupling the parser
+// to the message format is acceptable as long as both stay in step.
+func (rb *ResourceBinding) InFlightVersion() string {
+	cond := apiMeta.FindStatusCondition(rb.Status.Conditions, UpgradeSucceededCondition)
+	if cond == nil {
+		return ""
+	}
+	if cond.Status != metav1.ConditionUnknown || cond.Reason != UpgradeInProgressReason {
+		return ""
+	}
+
+	const marker = "version "
+	idx := strings.Index(cond.Message, marker)
+	if idx == -1 {
+		return ""
+	}
+	rest := cond.Message[idx+len(marker):]
+	if i := strings.IndexFunc(rest, unicode.IsSpace); i != -1 {
+		rest = rest[:i]
+	}
+	return rest
 }

--- a/api/v1alpha1/resourcebinding_types_test.go
+++ b/api/v1alpha1/resourcebinding_types_test.go
@@ -1,0 +1,61 @@
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	platformv1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ResourceBinding", func() {
+	Describe("InFlightVersion", func() {
+		var binding *platformv1alpha1.ResourceBinding
+
+		BeforeEach(func() {
+			binding = &platformv1alpha1.ResourceBinding{}
+		})
+
+		setCondition := func(status metav1.ConditionStatus, reason, message string) {
+			binding.Status.Conditions = []metav1.Condition{
+				{
+					Type:    platformv1alpha1.UpgradeSucceededCondition,
+					Status:  status,
+					Reason:  reason,
+					Message: message,
+				},
+			}
+		}
+
+		It("returns empty when no UpgradeSucceeded condition is present", func() {
+			Expect(binding.InFlightVersion()).To(BeEmpty())
+		})
+
+		It("returns empty when the condition status is not Unknown", func() {
+			setCondition(metav1.ConditionTrue, platformv1alpha1.UpgradeCompleteReason, "Upgrade to version v1.2.3 succeeded")
+			Expect(binding.InFlightVersion()).To(BeEmpty())
+
+			setCondition(metav1.ConditionFalse, platformv1alpha1.UpgradeFailedReason, "Upgrade to version v1.2.3 failed")
+			Expect(binding.InFlightVersion()).To(BeEmpty())
+		})
+
+		It("returns empty when the reason is not UpgradeInProgress", func() {
+			setCondition(metav1.ConditionUnknown, "SomethingElse", "Upgrade to version v1.2.3 is in progress")
+			Expect(binding.InFlightVersion()).To(BeEmpty())
+		})
+
+		It("returns the version embedded in the upgrade-in-progress message", func() {
+			setCondition(metav1.ConditionUnknown, platformv1alpha1.UpgradeInProgressReason, "Upgrade to version v1.2.3 is in progress")
+			Expect(binding.InFlightVersion()).To(Equal("v1.2.3"))
+		})
+
+		It("returns the version embedded in the manual reconciliation message", func() {
+			setCondition(metav1.ConditionUnknown, platformv1alpha1.UpgradeInProgressReason, "Reconciliation requested for version v0.0.2")
+			Expect(binding.InFlightVersion()).To(Equal("v0.0.2"))
+		})
+
+		It("returns empty when the message has no version marker", func() {
+			setCondition(metav1.ConditionUnknown, platformv1alpha1.UpgradeInProgressReason, "no marker here")
+			Expect(binding.InFlightVersion()).To(BeEmpty())
+		})
+	})
+})

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -583,7 +583,7 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 			mergedLabels = make(map[string]string)
 		}
 		maps.Copy(mergedLabels, resourceBindingLabels(rr, promise))
-		//if a binding is in middle of an upgrade, where the manual label is used, preserve it.
+		// If a binding is in the middle of an upgrade where the manual label is used, preserve it.
 		if resourceBinding.GetLabels()[resourceutil.ManualReconciliationLabel] == "true" {
 			mergedLabels[resourceutil.ManualReconciliationLabel] = "true"
 		}

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -583,6 +583,11 @@ func (r *DynamicResourceRequestController) updateResourceBinding(ctx context.Con
 			mergedLabels = make(map[string]string)
 		}
 		maps.Copy(mergedLabels, resourceBindingLabels(rr, promise))
+		//if a binding is in middle of an upgrade, where the manual label is used, preserve it.
+		if resourceBinding.GetLabels()[resourceutil.ManualReconciliationLabel] == "true" {
+			mergedLabels[resourceutil.ManualReconciliationLabel] = "true"
+		}
+
 		resourceBinding.SetLabels(mergedLabels)
 		if resourceBinding.Spec.Version == "" {
 			// if the resource binding got deleted, when we recreate the resource binding we infer what the resource binding

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -143,7 +143,7 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, nil
 		}
 
-		needsStatusUpdate = !bindingAlreadyAdvertisesUpgradeInProgress(resourceBinding)
+		needsStatusUpdate = !bindingAlreadyAdvertisesUpgradeInProgress(resourceBinding) || resourceBinding.InFlightVersion() != desiredVersion
 	}
 
 	if resourceBinding.InFlightVersion() != desiredVersion {

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -165,6 +165,9 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err := r.Client.Update(ctx, resourceBinding); err != nil {
 			return ctrl.Result{}, err
 		}
+		if err := r.Client.Get(ctx, req.NamespacedName, resourceBinding); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if needsStatusUpdate {

--- a/internal/controller/resourcebinding_controller.go
+++ b/internal/controller/resourcebinding_controller.go
@@ -120,11 +120,10 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		desiredVersion = provisionRevisionMarkedWithLatest.Spec.Version
 	}
 
-	upgradeSucceededCond := apiMeta.FindStatusCondition(resourceBinding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
+	manualReconciliationRequested := resourceBinding.GetLabels()[resourceutil.ManualReconciliationLabel] == "true"
 
-	manualReconciliationLabel := resourceBinding.GetLabels()[resourceutil.ManualReconciliationLabel] == "true"
 	var needsStatusUpdate bool
-	if manualReconciliationLabel {
+	if manualReconciliationRequested {
 		logging.Info(logger, "manual reconciliation label is set, forcing resource reconciliation")
 		needsStatusUpdate = true
 	} else {
@@ -139,32 +138,39 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			"resource request version", rrPromiseVersion,
 			"resource binding version", resourceBinding.Spec.Version,
 		)
-		if upgradeSucceededCond != nil &&
-			upgradeSucceededCond.Status == metav1.ConditionFalse &&
-			resourceBinding.Status.FailedVersion == desiredVersion {
+
+		if lastUpgradeAttemptFailedForVersion(resourceBinding, desiredVersion) {
 			return ctrl.Result{}, nil
 		}
-		needsStatusUpdate = upgradeSucceededCond == nil ||
-			upgradeSucceededCond.Status != metav1.ConditionUnknown ||
-			upgradeSucceededCond.Reason != v1alpha1.UpgradeInProgressReason ||
-			resourceBinding.Status.FailedVersion != ""
+
+		needsStatusUpdate = !bindingAlreadyAdvertisesUpgradeInProgress(resourceBinding)
 	}
 
-	labels := rr.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	labels[resourceutil.ManualReconciliationLabel] = "true"
-	rr.SetLabels(labels)
-	if err := r.Client.Update(ctx, rr); err != nil {
-		return ctrl.Result{}, err
+	if resourceBinding.InFlightVersion() != desiredVersion {
+		labels := rr.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[resourceutil.ManualReconciliationLabel] = "true"
+		rr.SetLabels(labels)
+		if err := r.Client.Update(ctx, rr); err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		logging.Debug(
+			logger,
+			"in-flight workflow already targets desired version; skipping applying manual reconciliation label to resource request",
+			"version", desiredVersion,
+		)
 	}
 
-	if manualReconciliationLabel {
+	if manualReconciliationRequested {
 		delete(resourceBinding.Labels, resourceutil.ManualReconciliationLabel)
 		if err := r.Client.Update(ctx, resourceBinding); err != nil {
 			return ctrl.Result{}, err
 		}
+
+		//refetch so that we can update the status successfully afterwards without hitting a resource version conflict
 		if err := r.Client.Get(ctx, req.NamespacedName, resourceBinding); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -172,7 +178,7 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if needsStatusUpdate {
 		statusMessage := fmt.Sprintf("Upgrade to version %s is in progress", desiredVersion)
-		if manualReconciliationLabel {
+		if manualReconciliationRequested {
 			statusMessage = fmt.Sprintf("Reconciliation requested for version %s", desiredVersion)
 		}
 		apiMeta.SetStatusCondition(&resourceBinding.Status.Conditions, metav1.Condition{
@@ -189,6 +195,31 @@ func (r *ResourceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	}
 	return ctrl.Result{}, nil
+}
+
+// lastUpgradeAttemptFailedForVersion reports whether the binding's last
+// recorded upgrade attempt failed against this exact version, so we should
+// stop hammering it until something changes.
+func lastUpgradeAttemptFailedForVersion(binding *v1alpha1.ResourceBinding, version string) bool {
+	cond := apiMeta.FindStatusCondition(binding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
+	if cond == nil {
+		return false
+	}
+	return cond.Status == metav1.ConditionFalse && binding.Status.FailedVersion == version
+}
+
+// bindingAlreadyAdvertisesUpgradeInProgress reports whether the binding's
+// status already reflects an upgrade-in-progress with a clean slate (no stale
+// FailedVersion left over from a previous attempt).
+func bindingAlreadyAdvertisesUpgradeInProgress(binding *v1alpha1.ResourceBinding) bool {
+	if binding.Status.FailedVersion != "" {
+		return false
+	}
+	cond := apiMeta.FindStatusCondition(binding.Status.Conditions, v1alpha1.UpgradeSucceededCondition)
+	if cond == nil {
+		return false
+	}
+	return cond.Status == metav1.ConditionUnknown && cond.Reason == v1alpha1.UpgradeInProgressReason
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -390,6 +390,16 @@ var _ = Describe("ResourceBinding Controller", func() {
 				Entry("when upgrade failed and FailedVersion guard would block", "v0.0.1", metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2"),
 			)
 
+			It("updates status using a fresh binding after removing the manual reconciliation label", func() {
+				rr = createResourceRequestWithVersion(ctx, resourceRequestPath, "v0.0.2")
+				setUpgradeCondition(metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2")
+				reconciler.Client = staleResourceVersionAfterBindingUpdateClient{
+					Client: fakeK8sClient,
+				}
+
+				expectManualReconciliationRetry()
+			})
+
 			It("does not retry when the resource promise version is unversioned", func() {
 				rr = createResourceRequestWithVersion(ctx, resourceRequestPath, controller.UnversionedPromiseVersion)
 				setUpgradeCondition(metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2")
@@ -428,4 +438,27 @@ func createResourceRequestWithVersion(ctx context.Context, resourceRequestPath s
 
 	Expect(fakeK8sClient.Get(ctx, resNameNamespacedName, rr)).To(Succeed())
 	return rr
+}
+
+type staleResourceVersionAfterBindingUpdateClient struct {
+	client.Client
+}
+
+func (c staleResourceVersionAfterBindingUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	previousResourceVersion := obj.GetResourceVersion()
+
+	if err := c.Client.Update(ctx, obj, opts...); err != nil {
+		return err
+	}
+
+	resourceBinding, isResourceBinding := obj.(*v1alpha1.ResourceBinding)
+	if !isResourceBinding {
+		return nil
+	}
+	if resourceBinding.GetLabels()[resourceutil.ManualReconciliationLabel] == "true" {
+		return nil
+	}
+
+	obj.SetResourceVersion(previousResourceVersion)
+	return nil
 }

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -95,7 +95,7 @@ var _ = Describe("ResourceBinding Controller", func() {
 
 		When("the resource request has a version that does not match the spec.Version", func() {
 			BeforeEach(func() {
-				rr = createResourceRequestWithVersion(ctx, resourceRequestPath, "v0.0.1")
+				rr = createResourceRequestWithVersion(ctx, "v0.0.1")
 				Expect(resourceutil.GetStatus(rr, "promiseVersion")).To(Equal("v0.0.1"))
 			})
 
@@ -381,7 +381,7 @@ var _ = Describe("ResourceBinding Controller", func() {
 
 			DescribeTable("retries when the binding is labelled for manual reconciliation",
 				func(rrVersion string, condStatus metav1.ConditionStatus, condReason, failedVersion string) {
-					rr = createResourceRequestWithVersion(ctx, resourceRequestPath, rrVersion)
+					rr = createResourceRequestWithVersion(ctx, rrVersion)
 					setUpgradeCondition(condStatus, condReason, failedVersion)
 					expectManualReconciliationRetry()
 				},
@@ -391,7 +391,7 @@ var _ = Describe("ResourceBinding Controller", func() {
 			)
 
 			It("updates status using a fresh binding after removing the manual reconciliation label", func() {
-				rr = createResourceRequestWithVersion(ctx, resourceRequestPath, "v0.0.2")
+				rr = createResourceRequestWithVersion(ctx, "v0.0.2")
 				setUpgradeCondition(metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2")
 				reconciler.Client = staleResourceVersionAfterBindingUpdateClient{
 					Client: fakeK8sClient,
@@ -401,7 +401,7 @@ var _ = Describe("ResourceBinding Controller", func() {
 			})
 
 			It("does not retry when the resource promise version is unversioned", func() {
-				rr = createResourceRequestWithVersion(ctx, resourceRequestPath, controller.UnversionedPromiseVersion)
+				rr = createResourceRequestWithVersion(ctx, controller.UnversionedPromiseVersion)
 				setUpgradeCondition(metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2")
 
 				result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: bindingName})
@@ -419,7 +419,7 @@ var _ = Describe("ResourceBinding Controller", func() {
 	})
 })
 
-func createResourceRequestWithVersion(ctx context.Context, resourceRequestPath string, version string) *unstructured.Unstructured {
+func createResourceRequestWithVersion(ctx context.Context, version string) *unstructured.Unstructured {
 	GinkgoHelper()
 	yamlFile, err := os.ReadFile(resourceRequestPath)
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -328,6 +328,82 @@ var _ = Describe("ResourceBinding Controller", func() {
 					Expect(rb.Status.FailedVersion).To(BeEmpty())
 				})
 			})
+
+			When("an upgrade is already in flight targeting the desired version", func() {
+				BeforeEach(func() {
+					Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
+					apiMeta.SetStatusCondition(&resourceBinding.Status.Conditions, metav1.Condition{
+						Type:    v1alpha1.UpgradeSucceededCondition,
+						Status:  metav1.ConditionUnknown,
+						Reason:  v1alpha1.UpgradeInProgressReason,
+						Message: "Upgrade to version v0.0.2 is in progress",
+					})
+					Expect(fakeK8sClient.Status().Update(ctx, &resourceBinding)).To(Succeed())
+				})
+
+				It("does not re-apply the manual reconciliation label to the resource request", func() {
+					request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+					result, err := reconciler.Reconcile(ctx, request)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()}, rr)).To(Succeed())
+					Expect(rr.GetLabels()).NotTo(HaveKey(resourceutil.ManualReconciliationLabel))
+				})
+
+				When("the manual reconciliation label is set on the binding", func() {
+					BeforeEach(func() {
+						Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
+						labels := resourceBinding.GetLabels()
+						if labels == nil {
+							labels = make(map[string]string)
+						}
+						labels[resourceutil.ManualReconciliationLabel] = "true"
+						resourceBinding.SetLabels(labels)
+						Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())
+					})
+
+					It("doesn't apply the manual reconcil label to RR, but it does clear it from the binding", func() {
+						request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+						result, err := reconciler.Reconcile(ctx, request)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).To(Equal(ctrl.Result{}))
+
+						Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()}, rr)).To(Succeed())
+						Expect(rr.GetLabels()).NotTo(HaveKey(resourceutil.ManualReconciliationLabel))
+
+						var rb v1alpha1.ResourceBinding
+						Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &rb)).To(Succeed())
+						Expect(rb.GetLabels()).NotTo(HaveKey(resourceutil.ManualReconciliationLabel))
+					})
+				})
+			})
+
+			When("an upgrade is in flight targeting a different version than desired", func() {
+				BeforeEach(func() {
+					Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}, &resourceBinding)).To(Succeed())
+					apiMeta.SetStatusCondition(&resourceBinding.Status.Conditions, metav1.Condition{
+						Type:    v1alpha1.UpgradeSucceededCondition,
+						Status:  metav1.ConditionUnknown,
+						Reason:  v1alpha1.UpgradeInProgressReason,
+						Message: "Upgrade to version v0.0.1 is in progress",
+					})
+					Expect(fakeK8sClient.Status().Update(ctx, &resourceBinding)).To(Succeed())
+				})
+
+				It("applies the manual reconciliation label to the resource request", func() {
+					request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
+
+					result, err := reconciler.Reconcile(ctx, request)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: rr.GetName(), Namespace: rr.GetNamespace()}, rr)).To(Succeed())
+					Expect(rr.GetLabels()).To(HaveKeyWithValue(resourceutil.ManualReconciliationLabel, "true"))
+				})
+			})
 		})
 
 		When("the manual reconciliation label is applied to the binding", func() {

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -390,16 +390,6 @@ var _ = Describe("ResourceBinding Controller", func() {
 				Entry("when upgrade failed and FailedVersion guard would block", "v0.0.1", metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2"),
 			)
 
-			It("updates status using a fresh binding after removing the manual reconciliation label", func() {
-				rr = createResourceRequestWithVersion(ctx, "v0.0.2")
-				setUpgradeCondition(metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2")
-				reconciler.Client = staleResourceVersionAfterBindingUpdateClient{
-					Client: fakeK8sClient,
-				}
-
-				expectManualReconciliationRetry()
-			})
-
 			It("does not retry when the resource promise version is unversioned", func() {
 				rr = createResourceRequestWithVersion(ctx, controller.UnversionedPromiseVersion)
 				setUpgradeCondition(metav1.ConditionFalse, v1alpha1.UpgradeFailedReason, "v0.0.2")
@@ -438,27 +428,4 @@ func createResourceRequestWithVersion(ctx context.Context, version string) *unst
 
 	Expect(fakeK8sClient.Get(ctx, resNameNamespacedName, rr)).To(Succeed())
 	return rr
-}
-
-type staleResourceVersionAfterBindingUpdateClient struct {
-	client.Client
-}
-
-func (c staleResourceVersionAfterBindingUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	previousResourceVersion := obj.GetResourceVersion()
-
-	if err := c.Client.Update(ctx, obj, opts...); err != nil {
-		return err
-	}
-
-	resourceBinding, isResourceBinding := obj.(*v1alpha1.ResourceBinding)
-	if !isResourceBinding {
-		return nil
-	}
-	if resourceBinding.GetLabels()[resourceutil.ManualReconciliationLabel] == "true" {
-		return nil
-	}
-
-	obj.SetResourceVersion(previousResourceVersion)
-	return nil
 }

--- a/internal/controller/resourcebinding_controller_test.go
+++ b/internal/controller/resourcebinding_controller_test.go
@@ -364,7 +364,7 @@ var _ = Describe("ResourceBinding Controller", func() {
 						Expect(fakeK8sClient.Update(ctx, &resourceBinding)).To(Succeed())
 					})
 
-					It("doesn't apply the manual reconcil label to RR, but it does clear it from the binding", func() {
+					It("doesn't apply the manual reconciliation label to RR, but it does clear it from the binding", func() {
 						request := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceBindingName, Namespace: resourceBindingNamespace}}
 
 						result, err := reconciler.Reconcile(ctx, request)


### PR DESCRIPTION
paired with @senglezou 

Solves two issues:
1. If a workflow is inflight, and its currently for the version we want to be upgrading to, dont apply the manual reconcilation label. Issue to improve it in the longterm https://github.com/syntasso/kratix/issues/814
1. After applying a manaul reconcilation label, ensure the status is updated. Previously the status update would fail since we just updated the binding to not have the label, the version of the binding we have is stale, so status update fails. Ideally we wouldn't fetch bt instead requeue, but we have no way to know if we've already applied a label, so this would trigger an infinite requeue and label scenario.