### PR TITLE
Feat(791): set owner reference on jobs

### DIFF
--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -378,13 +378,22 @@ func (p *PipelineFactory) pipelineJob(
 		},
 	}
 
-	if !p.ResourceWorkflow {
-		if err = controllerutil.SetControllerReference(obj, job, scheme.Scheme); err != nil {
-			return nil, err
-		}
-	}
+	err = p.setReferences(obj, job)
 
 	return job, nil
+}
+
+func (p *PipelineFactory) setReferences(owner metav1.Object, job *batchv1.Job) error {
+	if p.ResourceWorkflow {
+		if owner.GetNamespace() != job.GetNamespace() {
+			return nil
+		}
+		return controllerutil.SetOwnerReference(owner, job, scheme.Scheme)
+	}
+	if err := controllerutil.SetControllerReference(owner, job, scheme.Scheme); err != nil {
+		return err
+	}
+	return controllerutil.SetOwnerReference(owner, job, scheme.Scheme)
 }
 
 func (p *PipelineFactory) statusWriterContainer(env []corev1.EnvVar) corev1.Container {

--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -378,7 +378,9 @@ func (p *PipelineFactory) pipelineJob(
 		},
 	}
 
-	err = p.setReferences(obj, job)
+	if err = p.setReferences(obj, job); err != nil {
+		return nil, err
+	}
 
 	return job, nil
 }

--- a/api/v1alpha1/pipeline_factory.go
+++ b/api/v1alpha1/pipeline_factory.go
@@ -392,10 +392,7 @@ func (p *PipelineFactory) setReferences(owner metav1.Object, job *batchv1.Job) e
 		}
 		return controllerutil.SetOwnerReference(owner, job, scheme.Scheme)
 	}
-	if err := controllerutil.SetControllerReference(owner, job, scheme.Scheme); err != nil {
-		return err
-	}
-	return controllerutil.SetOwnerReference(owner, job, scheme.Scheme)
+	return controllerutil.SetControllerReference(owner, job, scheme.Scheme)
 }
 
 func (p *PipelineFactory) statusWriterContainer(env []corev1.EnvVar) corev1.Container {

--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -664,6 +664,59 @@ var _ = Describe("Pipeline", func() {
 				})
 			})
 
+			Describe("Owner references", func() {
+				When("building a job for a promise workflow", func() {
+					BeforeEach(func() {
+						promise.SetUID("promise-uid")
+						var err error
+						resources, err = factory.Resources(nil)
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("sets the promise as the owner reference on the job", func() {
+						Expect(resources.Job.GetOwnerReferences()).To(HaveLen(1))
+						ownerRef := resources.Job.GetOwnerReferences()[0]
+						Expect(string(ownerRef.UID)).To(Equal("promise-uid"))
+						Expect(ownerRef.Name).To(Equal(promise.GetName()))
+						Expect(ownerRef.Kind).To(Equal("Promise"))
+					})
+				})
+
+				When("building a job for a resource workflow", func() {
+					BeforeEach(func() {
+						resourceRequest.SetUID("resource-uid")
+						factory.ResourceWorkflow = true
+						var err error
+						resources, err = factory.Resources(nil)
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("sets the resource request as the owner reference on the job", func() {
+						Expect(resources.Job.GetOwnerReferences()).To(HaveLen(1))
+						ownerRef := resources.Job.GetOwnerReferences()[0]
+						Expect(string(ownerRef.UID)).To(Equal("resource-uid"))
+						Expect(ownerRef.Name).To(Equal(resourceRequest.GetName()))
+						Expect(ownerRef.Kind).To(Equal("promisecrd"))
+						Expect(ownerRef.Controller).To(BeNil())
+					})
+				})
+
+				When("the pipeline namespace differs from the resource request namespace", func() {
+					BeforeEach(func() {
+						factory.ResourceWorkflow = true
+						factory.Namespace = "pipeline-namespace"
+						resourceRequest.SetNamespace("resource-namespace")
+						var err error
+						resources, err = factory.Resources(nil)
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("does not set an owner reference on the job", func() {
+						Expect(resources.Job.GetOwnerReferences()).To(BeEmpty())
+					})
+				})
+			})
+
 			Describe("Default Volumes", func() {
 				It("returns a list of volumes that contains default volumes", func() {
 					volumes := resources.Job.Spec.Template.Spec.Volumes

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -793,7 +793,7 @@ var _ = Describe("Workflow Reconciler", func() {
 			})
 		})
 
-		When("there are more old workflow execution than configured in workflow options ", func() {
+		When("the number of old workflows exceeds the number of jobs to keep ", func() {
 			It("deletes the oldest jobs", func() {
 				var updatedPromise v1alpha1.Promise
 				numberOfJobLimit := 7


### PR DESCRIPTION
For promise and resource workflows, the promise or resource is set as the owner.

### When Pipelines do not run in a configured dedicated namespace

**Promise Configure**

The owner reference is set for the promise job

```yaml
    kratix.io/workflow-type: promise
  name: kratix-redis-promise-configure-cd9c8
  namespace: kratix-platform-system
  ownerReferences:
  - apiVersion: platform.kratix.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Promise
    name: redis
    uid: b3609e88-f3c1-4fa8-9bc9-5c7defd775c2
```

The owner reference is set for the resource request job

**Resource Configure**

```yaml
  ownerReferences:
  - apiVersion: marketplace.kratix.io/v1alpha1
    kind: redis
    name: example-booped
    uid: d0806975-9f58-4d71-86f0-252008941724
  resourceVersion: "2504"
  uid: 61460e76-8623-4414-8af8-4fb1052e6768
```

### When Pipelines do run in a configured dedicated namespace

The owner reference is set for the promise job

```yaml
  name: kratix-redis-promise-configure-6419e
  namespace: elsewhere
  ownerReferences:
  - apiVersion: platform.kratix.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Promise
    name: redis
    uid: b3609e88-f3c1-4fa8-9bc9-5c7defd775c2
```

The owner reference is not set for the resource request job

```bash
kratix git:(feat/791/set-owner-refernce) k get job kratix-redis-example-booped-default-instance-configure-d1072 -n elsewhere -o yaml | yq .ownerReferences
null
```
