### PR TITLE
chore: ClearPipelineSuspension does not error if status keys are missing

### DIFF
--- a/work-creator/lib/status_updater.go
+++ b/work-creator/lib/status_updater.go
@@ -128,17 +128,17 @@ func MarkPipelineAsSuspended(status map[string]any, pipelineName, msg, retryAtTi
 func ClearPipelineSuspension(status map[string]any, pipelineName string) (map[string]any, error) {
 	kratix, ok := status["kratix"].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("missing status.kratix while clearing suspension for pipeline %q", pipelineName)
+		return status, nil
 	}
 
 	workflows, ok := kratix["workflows"].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("missing status.kratix.workflows while clearing suspension for pipeline %q", pipelineName)
+		return status, nil
 	}
 
 	pipelines, ok := workflows["pipelines"].([]any)
 	if !ok {
-		return nil, fmt.Errorf("missing status.kratix.workflows.pipelines while clearing suspension for pipeline %q", pipelineName)
+		return status, nil
 	}
 
 	for i, pipeline := range pipelines {

--- a/work-creator/lib/status_updater_test.go
+++ b/work-creator/lib/status_updater_test.go
@@ -495,5 +495,34 @@ var _ = Describe("StatusUpdater", func() {
 
 			Expect(err).To(MatchError(ContainSubstring("\"pipeline-b\" not found in status.kratix.workflows.pipelines")))
 		})
+
+		It("is a no-op when status.kratix is missing", func() {
+			status := map[string]any{"message": "Pending"}
+			result, err := lib.ClearPipelineSuspension(status, "promise-configure")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(status))
+		})
+
+		It("is a no-op when status.kratix.workflows is missing", func() {
+			status := map[string]any{
+				"kratix": map[string]any{"kind": "Jenkins"},
+			}
+			result, err := lib.ClearPipelineSuspension(status, "promise-configure")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(status))
+		})
+
+		It("is a no-op when status.kratix.workflows.pipelines is missing", func() {
+			status := map[string]any{
+				"kratix": map[string]any{
+					"workflows": map[string]any{
+						"suspendedGeneration": int64(3),
+					},
+				},
+			}
+			result, err := lib.ClearPipelineSuspension(status, "promise-configure")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(status))
+		})
 	})
 })


### PR DESCRIPTION
* There is a race condition when running other promise workflows (e.g. backstage-gen) the results in promises not having all of the expected status keys. Instead of failing if there are not present, this silentl returns the status object
