### PR TITLE
perf: filter Job informer cache to only Kratix-managed Jobs

### DIFF
--- a/api/v1alpha1/pipeline_types_test.go
+++ b/api/v1alpha1/pipeline_types_test.go
@@ -417,6 +417,7 @@ var _ = Describe("Pipeline", func() {
 									HaveKeyWithValue(v1alpha1.WorkflowActionLabel, string(factory.WorkflowAction)),
 									HaveKeyWithValue(v1alpha1.PipelineNameLabel, pipeline.GetName()),
 									HaveKeyWithValue(v1alpha1.KratixResourceHashLabel, promiseHash(promise)),
+									HaveKeyWithValue(v1alpha1.ManagedByLabel, v1alpha1.ManagedByLabelValue),
 									Not(HaveKey(v1alpha1.ResourceNameLabel)),
 									Not(HaveKey(v1alpha1.ResourceNamespaceLabel)),
 								))
@@ -516,6 +517,7 @@ var _ = Describe("Pipeline", func() {
 									HaveKeyWithValue(v1alpha1.WorkflowActionLabel, string(factory.WorkflowAction)),
 									HaveKeyWithValue(v1alpha1.PipelineNameLabel, pipeline.GetName()),
 									HaveKeyWithValue(v1alpha1.KratixResourceHashLabel, combinedHash(promiseHash(promise), resourceHash(resourceRequest))),
+									HaveKeyWithValue(v1alpha1.ManagedByLabel, v1alpha1.ManagedByLabelValue),
 									HaveKeyWithValue(v1alpha1.ResourceNameLabel, resourceRequest.GetName()),
 									Not(HaveKey(v1alpha1.ResourceNamespaceLabel)),
 								))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ import (
 	kratixWebhook "github.com/syntasso/kratix/internal/webhook/v1alpha1"
 
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	platformv1alpha1 "github.com/syntasso/kratix/api/v1alpha1"
@@ -259,6 +260,11 @@ func main() {
 		setLeaderElectConfig(&mgrOptions, kratixConfig)
 	}
 
+	setupLog.Info("Filtering Job informer cache to Kratix-managed Jobs only")
+	mgrOptions.Cache.ByObject = map[client.Object]cache.ByObject{
+		&batchv1.Job{}: {Label: jobCacheSelector()},
+	}
+
 	if kratixConfig != nil && kratixConfig.SelectiveCache {
 		setupLog.Info("Building selective cache for Secrets to limit memory usage; Please ensure Secrets used by kratix are created with label: app.kubernetes.io/part-of=kratix.")
 		kratixLabel, labelErr := labels.NewRequirement("app.kubernetes.io/part-of", selection.Equals, []string{"kratix"})
@@ -267,9 +273,7 @@ func main() {
 			os.Exit(1)
 		}
 		kratixSelector := labels.NewSelector().Add(*kratixLabel)
-		mgrOptions.Cache.ByObject = map[client.Object]cache.ByObject{
-			&corev1.Secret{}: {Label: kratixSelector},
-		}
+		mgrOptions.Cache.ByObject[&corev1.Secret{}] = cache.ByObject{Label: kratixSelector}
 	}
 
 	mgr, err := ctrl.NewManager(config, mgrOptions)
@@ -636,6 +640,18 @@ func setLeaderElectConfig(mgrOptions *ctrl.Options, kConfig *KratixConfig) {
 		mgrOptions.RetryPeriod = &kConfig.ControllerLeaderElection.RetryPeriod.Duration
 		setupLog.Info("controller leader election configured", "RetryPeriod", mgrOptions.RetryPeriod)
 	}
+}
+
+func jobCacheSelector() labels.Selector {
+	requirement, err := labels.NewRequirement(
+		platformv1alpha1.ManagedByLabel,
+		selection.Equals,
+		[]string{platformv1alpha1.ManagedByLabelValue},
+	)
+	if err != nil {
+		panic(fmt.Sprintf("failed to build job cache label selector: %v", err))
+	}
+	return labels.NewSelector().Add(*requirement)
 }
 
 func promiseUpgradeEnabled(kConfig *KratixConfig) bool {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -21,6 +21,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("jobCacheSelector", func() {
+	It("returns a selector matching managed-by=Kratix", func() {
+		selector := jobCacheSelector()
+		Expect(selector.String()).To(Equal("app.kubernetes.io/managed-by=Kratix"))
+	})
+})
+
 var _ = Describe("getResourceBindingDefaultVersion", func() {
 	It("returns floating when config is nil", func() {
 		Expect(getResourceBindingDefaultVersion(nil)).To(Equal(ResourceBindingDefaultVersionFloating))


### PR DESCRIPTION
## Context

Reduce memory usage by configuring the controller-runtime cache to only watch Jobs with the `app.kubernetes.io/managed-by=Kratix` label. In busy clusters with many non kratix created Jobs, this avoids caching objects the controller pod doesn't need to care about.

This label is set on job from the pipeline factory: https://github.com/syntasso/kratix/blob/39638facea7bce967e22706cea5f4a6b068e7f54/api/v1alpha1/pipeline_factory.go#L434

There isn't any unit test coverage. This PR also adds unit test assertions on this label.