### PR TITLE
feat: updating a resource/promise does not suspend jobs

### DIFF
--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -195,6 +195,11 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		}
 	}
 
+	if !promise.DeletionTimestamp.IsZero() {
+		logging.Info(logger, "promise is being deleted; skipping configure workflow")
+		return ctrl.Result{}, nil
+	}
+
 	logging.Info(logger, "resource contains configure workflow(s); reconciling workflows")
 	completedCond := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
 	forcePipelineRun := shouldForcePipelineRun(completedCond, r.ReconciliationInterval) &&

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -287,6 +287,26 @@ var _ = Describe("DynamicResourceRequestController", func() {
 		})
 	})
 
+	When("the promise is being deleted", func() {
+		BeforeEach(func() {
+			setReconcileConfigureWorkflowToReturnFinished()
+			_, err := t.reconcileUntilCompletion(reconciler, resReq)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: promise.GetName()}, promise)).To(Succeed())
+			promise.SetFinalizers(append(promise.GetFinalizers(), "kratix.io/test-finalizer"))
+			Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+			Expect(fakeK8sClient.Delete(ctx, promise)).To(Succeed())
+		})
+
+		It("skips the configure workflow", func() {
+			reconcileConfigureOptsArg = workflow.Opts{}
+			_, err := t.reconcileUntilCompletion(reconciler, resReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reconcileConfigureOptsArg.Resources).To(BeEmpty())
+		})
+	})
+
 	When("resource is being deleted", func() {
 		BeforeEach(func() {
 			setReconcileConfigureWorkflowToReturnFinished()

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1460,15 +1460,9 @@ func (r *PromiseReconciler) deletePromise(o opts, promise *v1alpha1.Promise) (ct
 	}
 
 	if controllerutil.ContainsFinalizer(promise, runDeleteWorkflowsFinalizer) {
-		running, err := r.resourceConfigureJobsRunning(o, promise)
-		if err != nil {
-			return ctrl.Result{}, err
+		if result, err := r.waitForResourceConfigureJobs(o, promise); result != nil || err != nil {
+			return *result, err
 		}
-		if running {
-			logging.Info(o.logger, "resource configure pipeline still running; waiting for completion before starting promise delete workflow")
-			return defaultRequeue, nil
-		}
-
 		logging.Info(o.logger, "running promise delete workflows")
 		unstructuredPromise, err := promise.ToUnstructured()
 		if err != nil {
@@ -1577,7 +1571,7 @@ func (r *PromiseReconciler) deletePromise(o opts, promise *v1alpha1.Promise) (ct
 	return fastRequeue, nil
 }
 
-func (r *PromiseReconciler) resourceConfigureJobsRunning(o opts, promise *v1alpha1.Promise) (bool, error) {
+func (r *PromiseReconciler) waitForResourceConfigureJobs(o opts, promise *v1alpha1.Promise) (*ctrl.Result, error) {
 	jobLabels := map[string]string{
 		v1alpha1.WorkflowTypeLabel:   string(v1alpha1.WorkflowTypeResource),
 		v1alpha1.WorkflowActionLabel: string(v1alpha1.WorkflowActionConfigure),
@@ -1585,15 +1579,20 @@ func (r *PromiseReconciler) resourceConfigureJobsRunning(o opts, promise *v1alph
 	}
 	selector, err := labels.Parse(labels.FormatLabels(jobLabels))
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	jobs := &batchv1.JobList{}
 	if err := r.Client.List(o.ctx, jobs, &client.ListOptions{LabelSelector: selector}); err != nil {
-		return false, err
+		return nil, err
 	}
 
-	return resourceutil.IsThereAPipelineRunning(o.logger, jobs.Items), nil
+	if resourceutil.IsThereAPipelineRunning(o.logger, jobs.Items) {
+		logging.Info(o.logger, "resource configure pipeline still running; waiting for completion before starting promise delete workflow")
+		result := defaultRequeue
+		return &result, nil
+	}
+	return nil, nil
 }
 
 func (r *PromiseReconciler) deletePromiseWorkflowJobs(o opts, promise *v1alpha1.Promise, finalizer string) error {

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1100,7 +1100,6 @@ func setNewPipelineStatus(promise *v1alpha1.Promise) {
 }
 
 func (r *PromiseReconciler) reconcileAllRRs(ctx context.Context, rrGVK *schema.GroupVersionKind) error {
-	//label all rr with manual reconciliation
 	rrs := &unstructured.UnstructuredList{}
 	rrListGVK := *rrGVK
 	rrListGVK.Kind = rrListGVK.Kind + "List"
@@ -1114,7 +1113,7 @@ func (r *PromiseReconciler) reconcileAllRRs(ctx context.Context, rrGVK *schema.G
 		if newLabels == nil {
 			newLabels = make(map[string]string)
 		}
-		newLabels[resourceutil.ManualReconciliationLabel] = "true"
+		newLabels[resourceutil.WorkflowRunFromStartLabel] = "true"
 		rr.SetLabels(newLabels)
 		if err := r.Client.Update(ctx, &rr); err != nil {
 			return err

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1587,6 +1587,8 @@ func (r *PromiseReconciler) waitForResourceConfigureJobs(o opts, promise *v1alph
 		return nil, err
 	}
 
+	logging.Debug(o.logger, "found resource configure pipelines", "count", len(jobs.Items))
+
 	if resourceutil.IsThereAPipelineRunning(o.logger, jobs.Items) {
 		logging.Info(o.logger, "resource configure pipeline still running; waiting for completion before starting promise delete workflow")
 		result := defaultRequeue

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1460,6 +1460,15 @@ func (r *PromiseReconciler) deletePromise(o opts, promise *v1alpha1.Promise) (ct
 	}
 
 	if controllerutil.ContainsFinalizer(promise, runDeleteWorkflowsFinalizer) {
+		running, err := r.resourceConfigureJobsRunning(o, promise)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if running {
+			logging.Info(o.logger, "resource configure pipeline still running; waiting for completion before starting promise delete workflow")
+			return defaultRequeue, nil
+		}
+
 		logging.Info(o.logger, "running promise delete workflows")
 		unstructuredPromise, err := promise.ToUnstructured()
 		if err != nil {
@@ -1566,6 +1575,25 @@ func (r *PromiseReconciler) deletePromise(o opts, promise *v1alpha1.Promise) (ct
 	}
 
 	return fastRequeue, nil
+}
+
+func (r *PromiseReconciler) resourceConfigureJobsRunning(o opts, promise *v1alpha1.Promise) (bool, error) {
+	jobLabels := map[string]string{
+		v1alpha1.WorkflowTypeLabel:   string(v1alpha1.WorkflowTypeResource),
+		v1alpha1.WorkflowActionLabel: string(v1alpha1.WorkflowActionConfigure),
+		v1alpha1.PromiseNameLabel:    promise.GetName(),
+	}
+	selector, err := labels.Parse(labels.FormatLabels(jobLabels))
+	if err != nil {
+		return false, err
+	}
+
+	jobs := &batchv1.JobList{}
+	if err := r.Client.List(o.ctx, jobs, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return false, err
+	}
+
+	return resourceutil.IsThereAPipelineRunning(o.logger, jobs.Items), nil
 }
 
 func (r *PromiseReconciler) deletePromiseWorkflowJobs(o opts, promise *v1alpha1.Promise, finalizer string) error {

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -1234,6 +1234,52 @@ var _ = Describe("PromiseController", func() {
 					Expect(result).To(Equal(ctrl.Result{}))
 				})
 
+				When("a resource configure job is still running", func() {
+					var resourceJob *batchv1.Job
+
+					BeforeEach(func() {
+						resourceJob = &batchv1.Job{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "resource-configure-job",
+								Namespace: "kratix-platform-system",
+								Labels: map[string]string{
+									v1alpha1.WorkflowTypeLabel:   string(v1alpha1.WorkflowTypeResource),
+									v1alpha1.WorkflowActionLabel: string(v1alpha1.WorkflowActionConfigure),
+									v1alpha1.PromiseNameLabel:    promise.GetName(),
+								},
+							},
+						}
+						Expect(fakeK8sClient.Create(ctx, resourceJob)).To(Succeed())
+						Expect(fakeK8sClient.Delete(ctx, promise)).To(Succeed())
+					})
+
+					It("waits for the resource configure job to complete before running delete workflows", func() {
+						deleteWorkflowCalled := false
+						controller.SetReconcileDeleteWorkflow(func(w workflow.Opts) (bool, error) {
+							deleteWorkflowCalled = true
+							return false, nil
+						})
+
+						result, err := t.reconcileUntilCompletion(reconciler, promise)
+						Expect(err).To(MatchError("reconcile loop detected"))
+						Expect(result).To(Equal(ctrl.Result{RequeueAfter: 15 * time.Second}))
+						Expect(deleteWorkflowCalled).To(BeFalse())
+					})
+
+					It("runs the delete workflow once the resource configure job completes", func() {
+						resourceJob.Status.Conditions = []batchv1.JobCondition{
+							{Type: batchv1.JobComplete, Status: v1.ConditionTrue},
+						}
+						resourceJob.Status.Succeeded = 1
+						Expect(fakeK8sClient.Status().Update(ctx, resourceJob)).To(Succeed())
+
+						setReconcileDeleteWorkflowToReturnFinished(promise)
+						result, err := t.reconcileUntilCompletion(reconciler, promise)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).To(Equal(ctrl.Result{}))
+					})
+				})
+
 				When("the delete pipeline fails", func() {
 					BeforeEach(func() {
 						setReconcileDeleteWorkflowToReturnError(promise)

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -1518,7 +1518,7 @@ var _ = Describe("PromiseController", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				By("labelling manual reconciliation on resources", func() {
+				By("labelling run-from-start on resources", func() {
 					updatedRR := &unstructured.Unstructured{}
 					updatedRR.SetGroupVersionKind(schema.GroupVersionKind{
 						Group:   "marketplace.kratix.io",
@@ -1529,7 +1529,7 @@ var _ = Describe("PromiseController", func() {
 						Name:      resReq.GetName(),
 						Namespace: resReq.GetNamespace(),
 					}, updatedRR)).To(Succeed())
-					Expect(updatedRR.GetLabels()).To(HaveKeyWithValue(resourceutil.ManualReconciliationLabel, "true"))
+					Expect(updatedRR.GetLabels()).To(HaveKeyWithValue(resourceutil.WorkflowRunFromStartLabel, "true"))
 				})
 
 				By("removing ReconcileResources label from promise", func() {

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -332,9 +332,9 @@ func executeReconcileAction(opts Opts, state *workflowState, pipeline v1alpha1.P
 
 	if isRunning(state.mostRecentJob) {
 		if state.manualReconcile {
-			logging.Info(opts.logger, "suspending job for manual reconciliation", "job", state.mostRecentJob.Name)
+			logging.Info(opts.logger, "suspending job for manual reconciliation", "jobName", state.mostRecentJob.Name)
 			if err = suspendJob(opts.ctx, opts.client, state.mostRecentJob); err != nil {
-				logging.Error(opts.logger, err, "failed to suspend job", "job", state.mostRecentJob.GetName())
+				logging.Error(opts.logger, err, "failed to suspend job", "jobName", state.mostRecentJob.GetName())
 			}
 			return true, err
 		}

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -331,11 +331,14 @@ func executeReconcileAction(opts Opts, state *workflowState, pipeline v1alpha1.P
 	}
 
 	if isRunning(state.mostRecentJob) {
-		logging.Info(opts.logger, "job already inflight for another workflow; suspending it", "job", state.mostRecentJob.Name)
-		err = suspendJob(opts.ctx, opts.client, state.mostRecentJob)
-		if err != nil {
-			logging.Error(opts.logger, err, "failed to suspend job", "job", state.mostRecentJob.GetName())
+		if state.manualReconcile {
+			logging.Info(opts.logger, "suspending job for manual reconciliation", "job", state.mostRecentJob.Name)
+			if err = suspendJob(opts.ctx, opts.client, state.mostRecentJob); err != nil {
+				logging.Error(opts.logger, err, "failed to suspend job", "job", state.mostRecentJob.GetName())
+			}
+			return true, err
 		}
+		logging.Info(opts.logger, "job already inflight for another workflow; waiting for completion", "job", state.mostRecentJob.Name)
 		return true, nil
 	}
 

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -103,6 +103,20 @@ func ReconcileDelete(opts Opts) (bool, error) {
 	}
 
 	if mostRecentJob == nil || isManualReconciliation {
+		configureLabels := labelsForJobs(opts)
+		configureLabels[v1alpha1.WorkflowActionLabel] = string(v1alpha1.WorkflowActionConfigure)
+		configureJobs, listErr := getJobsWithLabels(opts, configureLabels, opts.namespace)
+		if listErr != nil {
+			return false, listErr
+		}
+		for i := range configureJobs {
+			if isRunning(&configureJobs[i]) {
+				logging.Info(opts.logger, "configure pipeline still running; "+
+					"waiting for completion before starting delete pipeline",
+					"runningJob", configureJobs[i].Name)
+				return true, nil
+			}
+		}
 		return createDeletePipeline(opts, pipeline)
 	}
 

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -673,6 +673,64 @@ var _ = Describe("Workflow Reconciler", func() {
 						Expect(findByName(jobList, workflowPipelines[1].Job.Name)).To(BeFalse())
 					})
 				})
+
+				When("manual reconciliation is also requested", func() {
+					It("suspends the running job", func() {
+						uPromise.SetLabels(map[string]string{
+							"kratix.io/manual-reconciliation": "true",
+						})
+						opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, updatedWorkflowPipeline, "promise", 5, namespace)
+						passiveRequeue, err := workflow.ReconcileConfigure(opts)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(passiveRequeue).To(BeTrue())
+
+						job := &batchv1.Job{}
+						Expect(fakeK8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: workflowPipelines[0].Job.Name}, job)).To(Succeed())
+						Expect(job.Spec.Suspend).NotTo(BeNil())
+						Expect(*job.Spec.Suspend).To(BeTrue())
+					})
+				})
+
+				When("the workflow-run-from-start label is also set", func() {
+					var runningJobName string
+
+					BeforeEach(func() {
+						runningJobName = workflowPipelines[0].Job.Name
+						labelPromiseWithWorkflowRestart("redis")
+						workflowPipelines, uPromise = setupTest(promise, pipelines)
+					})
+
+					It("waits for the running job to complete", func() {
+						opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, updatedWorkflowPipeline, "promise", 5, namespace)
+						passiveRequeue, err := workflow.ReconcileConfigure(opts)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(passiveRequeue).To(BeTrue())
+
+						By("not creating any new jobs")
+						Expect(listJobs(namespace)).To(HaveLen(1))
+
+						By("not suspending the running job")
+						job := &batchv1.Job{}
+						Expect(fakeK8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: runningJobName}, job)).To(Succeed())
+						Expect(job.Spec.Suspend).To(BeNil())
+					})
+
+					It("restarts from the first pipeline once the running job completes", func() {
+						opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, updatedWorkflowPipeline, "promise", 5, namespace)
+						_, err := workflow.ReconcileConfigure(opts)
+						Expect(err).NotTo(HaveOccurred())
+
+						markJobAsComplete(runningJobName)
+
+						passiveRequeue, err := workflow.ReconcileConfigure(opts)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(passiveRequeue).To(BeTrue())
+
+						jobList := listJobs(namespace)
+						Expect(jobList).To(HaveLen(2))
+						Expect(findByName(jobList, updatedWorkflowPipeline[0].Job.Name)).To(BeTrue())
+					})
+				})
 			})
 		})
 
@@ -2300,43 +2358,54 @@ var _ = Describe("Workflow Reconciler", func() {
 
 			When("there are running configure pipeline", func() {
 				var deleteWorkflowPipelines []v1alpha1.PipelineJobResources
+				var opts workflow.Opts
 
 				BeforeEach(func() {
+					deleteWorkflowPipelines = nil
 					Expect(fakeK8sClient.Create(ctx, workflowPipelines[0].Job)).To(Succeed())
 
 					generatedResources, err := pipelines[0].ForPromise(&promise, v1alpha1.WorkflowActionDelete).Resources(nil)
 					Expect(err).NotTo(HaveOccurred())
 					generatedResources.Job.SetCreationTimestamp(nextTimestamp())
 					deleteWorkflowPipelines = append(deleteWorkflowPipelines, generatedResources)
+
+					opts = workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, deleteWorkflowPipelines, "promise", 5, namespace)
+					requeue, err := workflow.ReconcileDelete(opts)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeue).To(BeTrue())
+					Expect(listJobs(namespace)).To(HaveLen(1))
 				})
 
 				It("waits for configure pipeline to finish before starting delete pipeline", func() {
-					opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, deleteWorkflowPipelines, "promise", 5, namespace)
-					requeue, err := workflow.ReconcileDelete(opts)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(requeue).To(BeTrue())
-
-					By("not creating any delete jobs")
-					jobList := listJobs(namespace)
-					Expect(jobList).To(HaveLen(1))
-					Expect(findByName(jobList, workflowPipelines[0].Job.Name)).To(BeTrue())
+					Expect(findByName(listJobs(namespace), workflowPipelines[0].Job.Name)).To(BeTrue())
 				})
 
-				It("creates the delete pipeline once the configure pipeline completes", func() {
-					opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, deleteWorkflowPipelines, "promise", 5, namespace)
-					requeue, err := workflow.ReconcileDelete(opts)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(requeue).To(BeTrue())
+				When("the configure pipeline completes", func() {
+					It("creates the delete pipeline", func() {
+						markJobAsComplete(workflowPipelines[0].Job.Name)
 
-					markJobAsComplete(workflowPipelines[0].Job.Name)
+						requeue, err := workflow.ReconcileDelete(opts)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(requeue).To(BeTrue())
 
-					requeue, err = workflow.ReconcileDelete(opts)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(requeue).To(BeTrue())
+						jobList := listJobs(namespace)
+						Expect(jobList).To(HaveLen(2))
+						Expect(findByName(jobList, deleteWorkflowPipelines[0].Job.Name)).To(BeTrue())
+					})
+				})
 
-					jobList := listJobs(namespace)
-					Expect(jobList).To(HaveLen(2))
-					Expect(findByName(jobList, deleteWorkflowPipelines[0].Job.Name)).To(BeTrue())
+				When("the configure pipeline fails", func() {
+					It("creates the delete pipeline", func() {
+						markJobAsFailed(workflowPipelines[0].Job.Name)
+
+						requeue, err := workflow.ReconcileDelete(opts)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(requeue).To(BeTrue())
+
+						jobList := listJobs(namespace)
+						Expect(jobList).To(HaveLen(2))
+						Expect(findByName(jobList, deleteWorkflowPipelines[0].Job.Name)).To(BeTrue())
+					})
 				})
 			})
 		})

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -2298,6 +2298,48 @@ var _ = Describe("Workflow Reconciler", func() {
 					})
 				})
 			})
+
+			When("there are running configure pipeline", func() {
+				var deleteWorkflowPipelines []v1alpha1.PipelineJobResources
+
+				BeforeEach(func() {
+					Expect(fakeK8sClient.Create(ctx, workflowPipelines[0].Job)).To(Succeed())
+
+					generatedResources, err := pipelines[0].ForPromise(&promise, v1alpha1.WorkflowActionDelete).Resources(nil)
+					Expect(err).NotTo(HaveOccurred())
+					generatedResources.Job.SetCreationTimestamp(nextTimestamp())
+					deleteWorkflowPipelines = append(deleteWorkflowPipelines, generatedResources)
+				})
+
+				It("waits for configure pipeline to finish before starting delete pipeline", func() {
+					opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, deleteWorkflowPipelines, "promise", 5, namespace)
+					requeue, err := workflow.ReconcileDelete(opts)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeue).To(BeTrue())
+
+					By("not creating any delete jobs")
+					jobList := listJobs(namespace)
+					Expect(jobList).To(HaveLen(1))
+					Expect(findByName(jobList, workflowPipelines[0].Job.Name)).To(BeTrue())
+				})
+
+				It("creates the delete pipeline once the configure pipeline completes", func() {
+					opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, deleteWorkflowPipelines, "promise", 5, namespace)
+					requeue, err := workflow.ReconcileDelete(opts)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeue).To(BeTrue())
+
+					markJobAsComplete(workflowPipelines[0].Job.Name)
+
+					requeue, err = workflow.ReconcileDelete(opts)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeue).To(BeTrue())
+
+					jobList := listJobs(namespace)
+					Expect(jobList).To(HaveLen(2))
+					Expect(findByName(jobList, deleteWorkflowPipelines[0].Job.Name)).To(BeTrue())
+				})
+			})
 		})
 	})
 })

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -641,7 +641,7 @@ var _ = Describe("Workflow Reconciler", func() {
 					Expect(passiveRequeue).To(BeTrue())
 				})
 
-				It("suspends the previous job", func() {
+				It("waits for the previous job to complete without suspending it", func() {
 					opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, updatedWorkflowPipeline, "promise", 5, namespace)
 					_, err := workflow.ReconcileConfigure(opts)
 					Expect(err).NotTo(HaveOccurred())
@@ -649,8 +649,7 @@ var _ = Describe("Workflow Reconciler", func() {
 					job := &batchv1.Job{}
 					Expect(fakeK8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: workflowPipelines[0].Job.Name}, job)).To(Succeed())
 
-					Expect(job.Spec.Suspend).NotTo(BeNil())
-					Expect(*job.Spec.Suspend).To(BeTrue())
+					Expect(job.Spec.Suspend).To(BeNil())
 				})
 
 				When("the outdated job completes", func() {


### PR DESCRIPTION
## Context

closes #794

Changes in the PR:
  - ReconcileConfigure: wait for running jobs to complete when spec changes (hash mismatch), instead of suspending
  them
  - ReconcileDelete: check for running configure jobs before creating delete pipelines. Wait for them to complete
  - when a promise spec change triggers resource re-reconciliation, use WorkflowRunFromStartLabel instead of
  manual reconciliation label. This ensures we wait for running resource jobs instead of suspending them.
  - when a promise is deleted, wait for running resource configure jobs to complete before starting the promise
  delete workflow.
  - dynamic resource controller: skip configure workflows when the promise is being deleted.

Complete pipeline means completed/failed/suspended.
This PR does not change the behavior of manual reconciliation label.

