### PR TITLE
fix(Promise): Reconcile Promise when Work resources change

### DIFF
--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -1774,6 +1774,28 @@ func (r *PromiseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return resources
 			}),
 		).
+		// Reconcile a Promise when one of its Work resources changes.
+		// This triggers the Promise reconciliation when a Work resource changes to update the "Reconciled" and
+		// "WorksSucceeded" conditions on the Promise's status.
+		Watches(
+			&v1alpha1.Work{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				// Read the Promise name from the Work label that links Work -> Promise.
+				work := obj.(*v1alpha1.Work)
+				promiseName, exists := work.Labels[v1alpha1.PromiseNameLabel]
+
+				// Ignore Works where v1alpha1.PromiseNameLabel is missing or empty, i.e., Works that are not associated
+				// with any Promise.
+				if !exists || promiseName == "" {
+					return nil
+				}
+
+				// Enqueue reconciliation for the Promise associated with the Work that changed.
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{Name: promiseName},
+				}}
+			}),
+		).
 		Complete(r)
 }
 


### PR DESCRIPTION
## Summary


Fix Promise reconciliation when related Work resources change.

This resolves #777, where Promise status conditions `Reconciled` and `WorksSucceeded` could become stale because updates to associated Work resources did not trigger Promise reconciliation.


## Related Issue


Fixes #777


## Changes


- Updated the Promise controller reconciler's watch configuration to trigger reconciliation when Work resources associated with a Promise are updated.
- ~Added a system test, `Promise Reconciliation on Work Changes`, to verify that Work resource updates trigger reconciliation and correctly update the Promise status conditions `Reconciled` and `WorksSucceeded`. The test uses the Crossplane Promise and its `crossplane=enabled` label to closely mirror the scenario described in the issue.~ (Excluded from this PR)


## Testing


- [ ] ~System tests~ (Excluded from this PR)
- [x] Manual testing


### Test Results


~System tests:~ (Excluded from this PR)
```bash
# One-time setup: Increase inotify limits for file watching. Required by `make quick-start` in Kratix.
sudo sysctl fs.inotify.max_user_watches=524288
sudo sysctl fs.inotify.max_user_instances=512

# Pre-clean-up.
make teardown
kind delete clusters platform worker

# Deploy platform and worker clusters, and setup Kratix on them.
make quick-start

# Run the system test.
make run-system-test GINKGO_FLAGS='--focus-file=test/system/promise_reconciliation_on_work_changes_test.go'

# Also run the full system test suite to ensure this change does not introduce regressions.
make run-system-test
```
<img width="1868" height="1112" alt="image" src="https://github.com/user-attachments/assets/9025ce35-606a-4193-91c1-2f5712695fc0" />
<img width="1868" height="1112" alt="image" src="https://github.com/user-attachments/assets/3d938b42-8054-4238-8670-c321301ab4b8" />


Manual testing:
```bash
# One-time setup: Increase inotify limits for file watching. Required by `make quick-start` in Kratix.
sudo sysctl fs.inotify.max_user_watches=524288
sudo sysctl fs.inotify.max_user_instances=512

# Pre-clean-up.
make teardown
kind delete clusters platform worker

# Deploy platform and worker clusters, and setup Kratix on them.
make quick-start
export PLATFORM=kind-platform
export WORKER=kind-worker

# Manually test issue #777's scenario.
# Unset the `crossplane` label on the worker destination to prevent the Crossplane Work from scheduling initially.
kubectl label --context $PLATFORM destinations.platform.kratix.io worker-1 crossplane-
# Verify that the `crossplane` label is removed from the worker destination.
kubectl get destination --context $PLATFORM --show-labels
# Apply the Crossplane Promise to the platform cluster.
kubectl apply --context $PLATFORM -f https://raw.githubusercontent.com/syntasso/kratix-marketplace/refs/heads/main/crossplane/promise.yaml
# Verify that the Crossplane Promise is created and is in `Pending` state in the platform cluster.
kubectl get --context $PLATFORM promise crossplane
# Verify that the Work resource is created in the platform cluster and is in `Pending` state due to the missing `crossplane` label on the worker destination.
kubectl get --context $PLATFORM -n kratix-platform-system works
# Verify that no WorkPlacement resource is created in the platform cluster due to the missing `crossplane` label on the worker destination.
kubectl get --context $PLATFORM -n kratix-platform-system workplacements
# Verify that the Crossplane Promise's status conditions `Reconciled` (type) is `WorkflowPending` (reason) and `WorksSucceeded` (type) is `WorksPending` (reason) due to the missing `crossplane` label on the worker destination.
kubectl get promise crossplane --context kind-platform -o=jsonpath='{.status.conditions}' |  jq
# Set the `crossplane=enabled` label on the worker destination to allow the Crossplane Work to schedule.
kubectl label --context $PLATFORM destinations.platform.kratix.io worker-1 crossplane="enabled"
# Verify that the `crossplane=enabled` label is set on the worker destination.
kubectl get destination --context $PLATFORM --show-labels
# Verify that the Work resource is now in `Ready` state in the platform cluster after the `crossplane=enabled` label is set on the worker destination.
kubectl get --context $PLATFORM -n kratix-platform-system works
# Verify that the WorkPlacement resource is now created and in `Ready` state in the platform cluster after the `crossplane=enabled` label is set on the worker destination.
kubectl get --context $PLATFORM -n kratix-platform-system workplacements
# Verify that the Crossplane Promise's status conditions `Reconciled` (type) is `Reconciled` (reason) and `WorksSucceeded` (type) is `WorksSucceeded` (reason) after the `crossplane=enabled` label is set on the worker destination.
# Note: This behavior reflects the fix introduced in this PR. Prior to the fix, updates to a Work resource did not trigger reconciliation of the associated Promise. As a result, the Promise status conditions `Reconciled` and `WorksSucceeded` could become stale and no longer reflect the current state of the underlying Work resources.
kubectl get promise crossplane --context kind-platform -o=jsonpath='{.status.conditions}' |  jq
```
<img width="1868" height="1112" alt="image" src="https://github.com/user-attachments/assets/cd703f58-b798-44fe-a8e6-b46e8854a6c4" />


## Checklist


- [x] I have tested my changes
- [ ] I have updated documentation if needed
- [ ] I have added/updated tests where appropriate - Tests are excluded from this PR as discussed in https://github.com/syntasso/kratix/pull/827#discussion_r3492903730
- [x] My commit messages follow project conventions