### PR TITLE
feat: warn when destination references missing statestore

### DIFF
--- a/internal/webhook/v1alpha1/destination_webhook.go
+++ b/internal/webhook/v1alpha1/destination_webhook.go
@@ -83,9 +83,14 @@ func (v *DestinationCustomValidator) ValidateCreate(ctx context.Context, destina
 		return nil, stderror.New("path field is required")
 	}
 
+	warnings, err := v.validateStateStoreRef(ctx, destination.Spec.StateStoreRef)
+	if err != nil {
+		return nil, err
+	}
+
 	// Check for path clashes with other destinations using the same state store
 	destinationList := &v1alpha1.DestinationList{}
-	err := v.Client.List(ctx, destinationList, client.MatchingFields{
+	err = v.Client.List(ctx, destinationList, client.MatchingFields{
 		"stateStoreRef": fmt.Sprintf("%s.%s", destination.Spec.StateStoreRef.Kind, destination.Spec.StateStoreRef.Name),
 	})
 	if err != nil {
@@ -100,6 +105,33 @@ func (v *DestinationCustomValidator) ValidateCreate(ctx context.Context, destina
 			return nil, fmt.Errorf("destination path '%s' already exists for state store '%s'",
 				destination.Spec.Path, destination.Spec.StateStoreRef.Name)
 		}
+	}
+
+	return warnings, nil
+}
+
+func (v *DestinationCustomValidator) validateStateStoreRef(ctx context.Context, ref *v1alpha1.StateStoreReference) (admission.Warnings, error) {
+	if ref == nil {
+		return nil, stderror.New("stateStoreRef field is required")
+	}
+
+	var stateStore client.Object
+	switch ref.Kind {
+	case "BucketStateStore":
+		stateStore = &v1alpha1.BucketStateStore{}
+	case "GitStateStore":
+		stateStore = &v1alpha1.GitStateStore{}
+	default:
+		return nil, nil
+	}
+
+	if err := v.Client.Get(ctx, client.ObjectKey{Name: ref.Name}, stateStore); err != nil {
+		if errors.IsNotFound(err) {
+			return admission.Warnings{
+				fmt.Sprintf("Warning: referenced %s %q does not exist", ref.Kind, ref.Name),
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to get state store %s/%s: %w", ref.Kind, ref.Name, err)
 	}
 
 	return nil, nil

--- a/internal/webhook/v1alpha1/destination_webhook_test.go
+++ b/internal/webhook/v1alpha1/destination_webhook_test.go
@@ -139,6 +139,82 @@ var _ = Describe("Destination Webhook", func() {
 
 	})
 
+	Describe("validating state store references", func() {
+		BeforeEach(func() {
+			destination.Spec.Path = "destination-path"
+		})
+
+		It("fails when stateStoreRef is missing", func() {
+			destination.Spec.StateStoreRef = nil
+
+			warnings, err := validator.ValidateCreate(ctx, destination)
+
+			Expect(err).To(MatchError("stateStoreRef field is required"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("warns when the referenced BucketStateStore does not exist", func() {
+			destination.Spec.StateStoreRef = &v1alpha1.StateStoreReference{
+				Name: "missing-bucket-state-store",
+				Kind: "BucketStateStore",
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, destination)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(ConsistOf(
+				`Warning: referenced BucketStateStore "missing-bucket-state-store" does not exist`,
+			))
+		})
+
+		It("warns when the referenced GitStateStore does not exist", func() {
+			destination.Spec.StateStoreRef = &v1alpha1.StateStoreReference{
+				Name: "missing-git-state-store",
+				Kind: "GitStateStore",
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, destination)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(ConsistOf(
+				`Warning: referenced GitStateStore "missing-git-state-store" does not exist`,
+			))
+		})
+
+		It("does not warn when the referenced state store exists", func() {
+			stateStore := &v1alpha1.GitStateStore{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existing-git-state-store",
+				},
+			}
+			Expect(fakeClient.Create(ctx, stateStore)).To(Succeed())
+
+			destination.Spec.StateStoreRef = &v1alpha1.StateStoreReference{
+				Name: stateStore.Name,
+				Kind: "GitStateStore",
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, destination)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("warns on update when the referenced state store does not exist", func() {
+			destination.Spec.StateStoreRef = &v1alpha1.StateStoreReference{
+				Name: "missing-git-state-store",
+				Kind: "GitStateStore",
+			}
+
+			warnings, err := validator.ValidateUpdate(ctx, &v1alpha1.Destination{}, destination)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(ConsistOf(
+				`Warning: referenced GitStateStore "missing-git-state-store" does not exist`,
+			))
+		})
+	})
+
 	Describe("defaulting filename", func() {
 		It("sets the filename when the filepath.mode requires it", func() {
 			destination.Spec.Filepath = v1alpha1.Filepath{


### PR DESCRIPTION
## Summary

Destinations can reference a `BucketStateStore` or `GitStateStore` that has not been created yet. Today, that only becomes visible later through Destination status, which makes the problem slower to diagnose.

This change adds an admission warning when a Destination references a missing StateStore. The warning gives immediate feedback during create/update, while still allowing the request so users are not forced to create resources in a strict order.

It also returns a clear validation error when `stateStoreRef` is omitted, instead of letting validation continue into code that expects the reference to exist.

Fixes #345.

## Testing

- `go run github.com/onsi/ginkgo/v2/ginkgo -r internal/webhook/v1alpha1`
- `make test`
- `PATH="$(go env GOPATH)/bin:$PATH" make lint`
