### PR TITLE
chore: remove act targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,20 +270,6 @@ lint: golangci-lint # Lint with required config
 lint-all: # Lint with full config
 	golangci-lint run --config=.golangci.yml
 
-##@ act targets to run GH Action jobs locally
-
-ACT_JOB = act -j '$(1)' --rm -s GITHUB_TOKEN="$(shell gh auth token)"
-act-test-and-lint:
-	$(call ACT_JOB,unit-tests-and-lint)
-
-act-integration-test:
-	$(call ACT_JOB,integration-test)
-
-act-system-test:
-	$(call ACT_JOB,system-test)
-
-act-run-all: act-system-test act-integration-test
-
 ##@ Deprecated: will be deleted soon
 
 # build-and-reload-kratix is deprecated in favor of build-and-load-kratix


### PR DESCRIPTION
## Summary

The local `act-*` Makefile targets no longer work now that CI jobs are externalized through the reusable `syntasso/ci` workflow. Keeping those targets advertises broken local commands and adds unused build logic.

This removes the stale `act` helper and the `act-test-and-lint`, `act-integration-test`, `act-system-test`, and `act-run-all` targets from the root Makefile.

Fixes #604.

## Testing

- `make help`
- `git diff --check`
- `make test`
