### PR TITLE
chore: using strict line matching to avoid false positives

### DIFF
--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -200,7 +200,7 @@ _build_kratix_image() {
 
 cluster_exists() {
     local cluster_name="$1"
-    kind get clusters | grep -q "$cluster_name"
+    kind get clusters | grep -qx "$cluster_name"
 }
 
 step_build_and_load_kratix() {


### PR DESCRIPTION
The quick-start script checks for any cluster with the specified name using a loose match. If any other cluster includes the desired cluster name (e.g. there is a cluster named platform-2), it will assume the desired cluster exists.

This changes the filter to a strict line matching. This way, the filter will detect clusters which name completely matches the desired name, avoiding false positives.