### PR TITLE
ci: use GH_ACTION_TRIGGER_TOKEN for Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Merge
         if: steps.eligible.outputs.result == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ACTION_TRIGGER_TOKEN }}
         run: |
           echo "Auto-merging: ${{ steps.eligible.outputs.reason }}"
           gh pr merge ${{ github.event.pull_request.number }} \


### PR DESCRIPTION
`GITHUB_TOKEN` is not in the push restrictions list for `main` — only `syntassodev` is allowed to push. Swapping to `GH_ACTION_TRIGGER_TOKEN` (a PAT authenticating as `syntassodev`) for the merge step only.

All other steps continue to use `GITHUB_TOKEN`.