### PR TITLE
feat: reconcile resources workflows even after failure

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,6 +121,9 @@ type Workflows struct {
 	DefaultImagePullPolicy          corev1.PullPolicy            `json:"defaultImagePullPolicy,omitempty"`
 	DefaultContainerResources       *corev1.ResourceRequirements `json:"defaultContainerResources,omitempty"`
 	JobOptions                      JobOptions                   `json:"jobOptions,omitempty"`
+	// ReconcileAfterFailure controls whether the periodic reconciliation re-runs a resource
+	// request's configure workflows after the previous run failed. Defaults to true
+	ReconcileAfterFailure *bool `json:"reconcileAfterFailure,omitempty"`
 }
 
 type JobOptions struct {
@@ -337,6 +340,7 @@ func main() {
 		Scheme:                 mgr.GetScheme(),
 		NumberOfJobsToKeep:     getNumJobsToKeep(kratixConfig),
 		ReconciliationInterval: getRegularReconciliationInterval(kratixConfig),
+		ReconcileAfterFailure:  getReconcileAfterFailure(kratixConfig),
 		EventRecorder:          mgr.GetEventRecorder("PromiseController"),
 		ResourceBindingPinned:  resourceBindingDefaultVersion == ResourceBindingDefaultVersionPinned,
 		DryRunEnabled:          dryRunFeatureEnabled,
@@ -632,6 +636,13 @@ func getStateStoreReconciliationInterval(kratixConfig *KratixConfig) time.Durati
 		return controller.DefaultReconciliationInterval
 	}
 	return kratixConfig.StateStoreReconciliationInterval.Duration
+}
+
+func getReconcileAfterFailure(kratixConfig *KratixConfig) bool {
+	if kratixConfig == nil || kratixConfig.Workflows.ReconcileAfterFailure == nil {
+		return true
+	}
+	return *kratixConfig.Workflows.ReconcileAfterFailure
 }
 
 func telemetryConfigFromKratixConfig(cfg *KratixConfig) *telemetry.Config {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,8 +121,7 @@ type Workflows struct {
 	DefaultImagePullPolicy          corev1.PullPolicy            `json:"defaultImagePullPolicy,omitempty"`
 	DefaultContainerResources       *corev1.ResourceRequirements `json:"defaultContainerResources,omitempty"`
 	JobOptions                      JobOptions                   `json:"jobOptions,omitempty"`
-	// ReconcileAfterFailure controls whether the periodic reconciliation re-runs a resource
-	// request's configure workflows after the previous run failed. Defaults to true
+	// Controls whether the periodic reconciliation re-runs resource workflows after they failed. Defaults to true
 	ReconcileAfterFailure *bool `json:"reconcileAfterFailure,omitempty"`
 }
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -133,3 +133,25 @@ var _ = Describe("getGitMinimumFetchInterval", func() {
 		Expect(getGitMinimumFetchInterval(config)).To(Equal(gitutil.DefaultMinimumFetchInterval))
 	})
 })
+
+var _ = Describe("getReconcileAfterFailure", func() {
+	It("returns true when config is nil", func() {
+		Expect(getReconcileAfterFailure(nil)).To(BeTrue())
+	})
+
+	It("returns true when workflows.reconcileAfterFailure is not set", func() {
+		Expect(getReconcileAfterFailure(&KratixConfig{})).To(BeTrue())
+	})
+
+	It("returns true when workflows.reconcileAfterFailure is explicitly true", func() {
+		enabled := true
+		config := &KratixConfig{Workflows: Workflows{ReconcileAfterFailure: &enabled}}
+		Expect(getReconcileAfterFailure(config)).To(BeTrue())
+	})
+
+	It("returns false when workflows.reconcileAfterFailure is explicitly false", func() {
+		disabled := false
+		config := &KratixConfig{Workflows: Workflows{ReconcileAfterFailure: &disabled}}
+		Expect(getReconcileAfterFailure(config)).To(BeFalse())
+	})
+})

--- a/config/samples/kratix-config.yaml
+++ b/config/samples/kratix-config.yaml
@@ -11,6 +11,10 @@ data:
       defaultContainerSecurityContext:
         windowsOptions:
           runAsUserName: "setInKratixConfig"
+      # reconcileAfterFailure controls whether the periodic reconciliation (on the
+      # Default Reconciliation Interval) re-runs a resource request's configure
+      # workflows after the previous run failed. Defaults to true.
+      reconcileAfterFailure: true
     telemetry:
       traces:
         enabled: true

--- a/config/samples/kratix-config.yaml
+++ b/config/samples/kratix-config.yaml
@@ -11,9 +11,6 @@ data:
       defaultContainerSecurityContext:
         windowsOptions:
           runAsUserName: "setInKratixConfig"
-      # reconcileAfterFailure controls whether the periodic reconciliation (on the
-      # Default Reconciliation Interval) re-runs a resource request's configure
-      # workflows after the previous run failed. Defaults to true.
       reconcileAfterFailure: true
     telemetry:
       traces:

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -276,7 +276,16 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 	}
 
 	if passiveRequeue {
-		return ctrl.Result{}, r.syncResourceBindingUpgradeStatusOnPassiveRequeue(ctx, logger, promise.GetName(), rr, promiseRevisionUsed)
+		if err := r.syncResourceBindingUpgradeStatusOnPassiveRequeue(ctx, logger, promise.GetName(), rr, promiseRevisionUsed); err != nil {
+			return ctrl.Result{}, err
+		}
+		// A failed configure workflow settles here (ReconcileConfigure returns a passive
+		// requeue) and never reaches reconcileAfterConfigure, so schedule the periodic
+		// reconcile here to retry the run on the interval.
+		if r.ReconcileAfterFailure && workflowCompletedWithFailure(resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)) {
+			return r.nextReconciliation(logger), nil
+		}
+		return ctrl.Result{}, nil
 	}
 
 	return r.reconcileAfterConfigure(ctx, logger, opts, rr, promise, pipelineResources, bindingVersion, promiseRevisionUsed)
@@ -356,10 +365,6 @@ func (r *DynamicResourceRequestController) reconcileAfterConfigure(
 
 	if r.updatePromiseVersionStatus(logger, rr, bindingVersion, promiseRevisionUsed) {
 		return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
-	}
-
-	if r.ReconcileAfterFailure && workflowCompletedWithFailure(workflowCompletedCondition) {
-		return r.nextReconciliation(logger), nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -84,6 +84,7 @@ type DynamicResourceRequestController struct {
 	CanCreateResources          *bool
 	NumberOfJobsToKeep          int
 	ReconciliationInterval      time.Duration
+	ReconcileAfterFailure       bool
 	EventRecorder               events.EventRecorder
 	ResourceBindingPinned       bool
 	// DryRunEnabled mirrors featureFlags.dryRun from the Kratix config. When
@@ -219,7 +220,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 
 	logging.Info(logger, "resource contains configure workflow(s); reconciling workflows")
 	completedCond := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
-	forcePipelineRun := shouldForcePipelineRun(completedCond, r.ReconciliationInterval) &&
+	forcePipelineRun := shouldForcePipelineRun(completedCond, r.ReconciliationInterval, r.ReconcileAfterFailure) &&
 		rr.GetLabels()[resourceutil.WorkflowRunFromStartLabel] != "true"
 
 	if restarted, err := r.restartOnReconciliationInterval(opts.ctx, logger, rr,
@@ -355,6 +356,10 @@ func (r *DynamicResourceRequestController) reconcileAfterConfigure(
 
 	if r.updatePromiseVersionStatus(logger, rr, bindingVersion, promiseRevisionUsed) {
 		return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
+	}
+
+	if r.ReconcileAfterFailure && workflowCompletedWithFailure(workflowCompletedCondition) {
+		return r.nextReconciliation(logger), nil
 	}
 
 	return ctrl.Result{}, nil
@@ -1760,10 +1765,12 @@ func updateObservedGeneration(
 	return opts.client.Status().Update(opts.ctx, rr)
 }
 
-func shouldForcePipelineRun(completedCond *clusterv1.Condition, reconciliationInterval time.Duration) bool {
-	return completedCond != nil &&
-		completedCond.Status == v1.ConditionTrue &&
-		time.Since(completedCond.LastTransitionTime.Time) > reconciliationInterval
+func shouldForcePipelineRun(completedCond *clusterv1.Condition, reconciliationInterval time.Duration, reconcileAfterFailure bool) bool {
+	if completedCond == nil || time.Since(completedCond.LastTransitionTime.Time) <= reconciliationInterval {
+		return false
+	}
+	return completedCond.Status == v1.ConditionTrue ||
+		(reconcileAfterFailure && workflowCompletedWithFailure(completedCond))
 }
 
 func (r *DynamicResourceRequestController) setPromiseLabels(ctx context.Context, promiseName string, rr *unstructured.Unstructured, resourceLabels map[string]string, logger logr.Logger) error {

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -552,63 +552,29 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		When("reconcileAfterFailure is true (default)", func() {
+		When("reconcileAfterFailure is true", func() {
 			BeforeEach(func() {
 				reconciler.ReconcileAfterFailure = true
 			})
 
-			It("re-runs the resource configure workflows and schedules the next reconciliation", func() {
-				// Reconcile until the reconciliation loop reaches the evaluation of whether the
-				// pipelines should re-run
-				result, err := reconciler.Reconcile(ctx, request)
-				Expect(result).To(Equal(ctrl.Result{}))
-				Expect(err).NotTo(HaveOccurred())
-				result, err = reconciler.Reconcile(ctx, request)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+			It("sets the manual reconciliation label to re-run the workflow", func() {
+				// the failed condition is already past the interval (outer BeforeEach)
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, request)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+					g.Expect(resReq.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal("true"))
+				}).Should(Succeed())
+			})
 
-				By("setting the manual reconciliation label", func() {
-					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
-					Expect(resReq.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal("true"))
-				})
-
-				By("updating the observed generation", func() {
-					observedGeneration := resourceutil.GetObservedGeneration(resReq)
-					setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
-					setReconcileConfigureWorkflowToReturnFinished()
-					// Reconcile until the reconciliation loop reaches observed generation update
-					// first reconcile will return at updating workflow execution phases to 'pending'
-					result, err = reconciler.Reconcile(ctx, request)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result).To(Equal(ctrl.Result{}))
-					result, err = reconciler.Reconcile(ctx, request)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result).To(Equal(ctrl.Result{}))
-
-					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
-					Expect(resourceutil.GetObservedGeneration(resReq)).To(Equal(observedGeneration + 1))
-				})
-
-				By("running the configure workflows and failing again", func() {
-					resourceutil.SetCondition(resReq, &clusterv1.Condition{
-						Type:               resourceutil.ConfigureWorkflowCompletedCondition,
-						Status:             v1.ConditionFalse,
-						Reason:             resourceutil.ConfigureWorkflowCompletedFailedReason,
-						Message:            "the pipeline failed again",
-						LastTransitionTime: metav1.NewTime(time.Now()),
-					})
-					Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
-
-					result, err = reconciler.Reconcile(ctx, request)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result).To(Equal(ctrl.Result{}))
-				})
-
-				By("scheduling the next reconciliation", func() {
-					result, err = reconciler.Reconcile(ctx, request)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
-				})
+			It("schedules the next reconciliation so a failed run is retried on the interval", func() {
+				// A failed configure workflow settles on the passive-requeue path; the
+				// controller must schedule the periodic reconcile itself.
+				Eventually(func(g Gomega) {
+					result, err := reconciler.Reconcile(ctx, request)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
+				}).Should(Succeed())
 			})
 		})
 
@@ -624,7 +590,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			})
 
 			It("does not re-run the resource configure workflows", func() {
-				_, err := reconciler.Reconcile(ctx, request)
+				_, err := t.reconcileUntilCompletion(reconciler, resReq)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -66,6 +66,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			Log:                         l,
 			UID:                         "1234abcd",
 			ReconciliationInterval:      controller.DefaultReconciliationInterval,
+			ReconcileAfterFailure:       true,
 			EventRecorder:               eventRecorder,
 		}
 
@@ -520,6 +521,114 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			By("updating the last successful workflow configure time", func() {
 				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
 				Expect(resourceutil.GetCondition(resReq, resourceutil.ConfigureWorkflowCompletedCondition).Status).To(Equal(v1.ConditionTrue))
+			})
+		})
+	})
+
+	When("the previous configure workflow failed", func() {
+		var request ctrl.Request
+		BeforeEach(func() {
+			Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+
+			lastTransitionTime := time.Now().Add(-reconciler.ReconciliationInterval).Add(-time.Hour * 1)
+			if resReq.Object["status"] == nil {
+				resReq.Object["status"] = map[string]interface{}{}
+			}
+			resourceutil.SetCondition(resReq, &clusterv1.Condition{
+				Type:               resourceutil.ConfigureWorkflowCompletedCondition,
+				Status:             v1.ConditionFalse,
+				Reason:             resourceutil.ConfigureWorkflowCompletedFailedReason,
+				Message:            "the pipeline failed",
+				LastTransitionTime: metav1.NewTime(lastTransitionTime),
+			})
+			setWorksSucceeded(resReq)
+			setReconciled(resReq)
+			setWorkflowsCounterStatus(resReq)
+			Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
+
+			request = ctrl.Request{NamespacedName: types.NamespacedName{Name: resReqNameNamespace.Name, Namespace: resReqNameNamespace.Namespace}}
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		When("reconcileAfterFailure is true (default)", func() {
+			BeforeEach(func() {
+				reconciler.ReconcileAfterFailure = true
+			})
+
+			It("re-runs the resource.configure workflows and schedules the next reconciliation on the Default Reconciliation Interval", func() {
+				// Reconcile until the reconciliation loop reaches the evaluation of whether the
+				// pipelines should re-run
+				result, err := reconciler.Reconcile(ctx, request)
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+				result, err = reconciler.Reconcile(ctx, request)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				By("setting the manual reconciliation label", func() {
+					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+					Expect(resReq.GetLabels()[resourceutil.ManualReconciliationLabel]).To(Equal("true"))
+				})
+
+				By("updating the observed generation", func() {
+					observedGeneration := resourceutil.GetObservedGeneration(resReq)
+					setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
+					setReconcileConfigureWorkflowToReturnFinished()
+					// Reconcile until the reconciliation loop reaches observed generation update
+					// first reconcile will return at updating workflow execution phases to 'pending'
+					result, err = reconciler.Reconcile(ctx, request)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+					result, err = reconciler.Reconcile(ctx, request)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+					Expect(resourceutil.GetObservedGeneration(resReq)).To(Equal(observedGeneration + 1))
+				})
+
+				By("running the configure workflows and failing again", func() {
+					resourceutil.SetCondition(resReq, &clusterv1.Condition{
+						Type:               resourceutil.ConfigureWorkflowCompletedCondition,
+						Status:             v1.ConditionFalse,
+						Reason:             resourceutil.ConfigureWorkflowCompletedFailedReason,
+						Message:            "the pipeline failed again",
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					})
+					Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
+
+					result, err = reconciler.Reconcile(ctx, request)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+				})
+
+				By("scheduling the next reconciliation on the Default Reconciliation Schedule", func() {
+					result, err = reconciler.Reconcile(ctx, request)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
+				})
+			})
+		})
+
+		When("reconcileAfterFailure is false", func() {
+			BeforeEach(func() {
+				reconciler.ReconcileAfterFailure = false
+			})
+
+			It("does not schedule a periodic reconciliation", func() {
+				result, err := t.reconcileUntilCompletion(reconciler, resReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+			})
+
+			It("does not re-run the resource.configure workflows", func() {
+				_, err := reconciler.Reconcile(ctx, request)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+				Expect(resReq.GetLabels()[resourceutil.ManualReconciliationLabel]).NotTo(Equal("true"))
 			})
 		})
 	})

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -557,7 +557,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				reconciler.ReconcileAfterFailure = true
 			})
 
-			It("re-runs the resource.configure workflows and schedules the next reconciliation on the Default Reconciliation Interval", func() {
+			It("re-runs the resource configure workflows and schedules the next reconciliation", func() {
 				// Reconcile until the reconciliation loop reaches the evaluation of whether the
 				// pipelines should re-run
 				result, err := reconciler.Reconcile(ctx, request)
@@ -604,7 +604,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					Expect(result).To(Equal(ctrl.Result{}))
 				})
 
-				By("scheduling the next reconciliation on the Default Reconciliation Schedule", func() {
+				By("scheduling the next reconciliation", func() {
 					result, err = reconciler.Reconcile(ctx, request)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
@@ -623,7 +623,7 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				Expect(result).To(Equal(ctrl.Result{}))
 			})
 
-			It("does not re-run the resource.configure workflows", func() {
+			It("does not re-run the resource configure workflows", func() {
 				_, err := reconciler.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -79,6 +79,7 @@ type PromiseReconciler struct {
 	StartedDynamicControllers map[string]*DynamicResourceRequestController
 	NumberOfJobsToKeep        int
 	ReconciliationInterval    time.Duration
+	ReconcileAfterFailure     bool
 	EventRecorder             events.EventRecorder
 	ResourceBindingPinned     bool
 	// DryRunEnabled mirrors featureFlags.dryRun from the Kratix config. When
@@ -1145,6 +1146,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		dynamicController.EventRecorder = r.Manager.GetEventRecorder("ResourceRequestController")
 		dynamicController.NumberOfJobsToKeep = r.NumberOfJobsToKeep
 		dynamicController.ReconciliationInterval = r.ReconciliationInterval
+		dynamicController.ReconcileAfterFailure = r.ReconcileAfterFailure
 		dynamicController.ResourceBindingPinned = r.ResourceBindingPinned
 		dynamicController.DryRunEnabled = r.DryRunEnabled
 		dynamicController.PromiseDestinationSelectors = promise.Spec.DestinationSelectors
@@ -1175,6 +1177,7 @@ func (r *PromiseReconciler) ensureDynamicControllerIsStarted(promise *v1alpha1.P
 		CanCreateResources:          canCreateResources,
 		NumberOfJobsToKeep:          r.NumberOfJobsToKeep,
 		ReconciliationInterval:      r.ReconciliationInterval,
+		ReconcileAfterFailure:       r.ReconcileAfterFailure,
 		EventRecorder:               r.Manager.GetEventRecorder("ResourceRequestController"),
 		ResourceBindingPinned:       r.ResourceBindingPinned,
 		DryRunEnabled:               r.DryRunEnabled,

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -408,7 +408,18 @@ func handleCurrentPipelineJob(opts Opts, state *workflowState, pipeline v1alpha1
 
 	if isFailed(state.mostRecentJob) {
 		logging.Debug(opts.logger, "job failed", "job", state.mostRecentJob.Name, "pipeline", pipeline.Name)
-		return setFailedConditionAndEvents(opts, state, pipeline)
+		passiveRequeue, err := setFailedConditionAndEvents(opts, state, pipeline)
+		if err != nil {
+			return passiveRequeue, err
+		}
+		// A workflow that keeps failing never reaches the cleanup at the end of this
+		// function, so without pruning here its Jobs grow without bound once the
+		// periodic reconcile retries failed runs. This reconciler is shared, so the
+		// pruning applies to promise and resource workflows alike; only resources
+		// retry on the interval today, so a failing promise workflow is pruned when
+		// it is re-run manually or by a spec change. Jobs only, not the full
+		// cleanup(): Works are left alone while the workflow has not completed.
+		return passiveRequeue, cleanupJobs(opts, opts.namespace)
 	}
 
 	return false, cleanup(opts, opts.namespace)
@@ -572,16 +583,13 @@ func isRunning(job *batchv1.Job) bool {
 }
 
 func cleanup(opts Opts, namespace string) error {
+	if err := cleanupJobs(opts, namespace); err != nil {
+		return err
+	}
+
 	pipelineNames := map[string]bool{}
 	for _, pipeline := range opts.Resources {
-		l := labelsForAllWorkflowJobs(pipeline)
-		l[v1alpha1.PipelineNameLabel] = pipeline.Name
 		pipelineNames[pipeline.Name] = true
-		jobsForPipeline, _ := getJobsWithLabels(opts, l, namespace)
-		if err := cleanupJobs(opts, jobsForPipeline); err != nil {
-			logging.Error(opts.logger, err, "failed to delete old jobs")
-			return err
-		}
 	}
 
 	allPipelineWorks, err := resourceutil.GetWorksByType(opts.client, v1alpha1.Type(opts.workflowType), opts.parentObject)
@@ -604,21 +612,42 @@ func cleanup(opts Opts, namespace string) error {
 	return nil
 }
 
-func cleanupJobs(opts Opts, pipelineJobsAtCurrentSpec []batchv1.Job) error {
-	if len(pipelineJobsAtCurrentSpec) <= opts.numberOfJobsToKeep {
+// cleanupJobs prunes the job history of every pipeline in the workflow. It runs
+// both when the workflow completes and when a pipeline fails, so that a workflow
+// that never succeeds still respects numberOfJobsToKeep.
+func cleanupJobs(opts Opts, namespace string) error {
+	for _, pipeline := range opts.Resources {
+		l := labelsForAllWorkflowJobs(pipeline)
+		l[v1alpha1.PipelineNameLabel] = pipeline.Name
+		jobsForPipeline, err := getJobsWithLabels(opts, l, namespace)
+		if err != nil {
+			logging.Error(opts.logger, err, "failed to list jobs for pipeline", "pipeline", pipeline.Name)
+			return err
+		}
+		if err := pruneJobs(opts, jobsForPipeline); err != nil {
+			logging.Error(opts.logger, err, "failed to delete old jobs")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func pruneJobs(opts Opts, jobsForPipeline []batchv1.Job) error {
+	if len(jobsForPipeline) <= opts.numberOfJobsToKeep {
 		logging.Debug(opts.logger,
-			"pipeline jobs at current spec do not exceed number of jobs to keep",
+			"pipeline jobs do not exceed number of jobs to keep",
 			"numberOfJobsToKeep", opts.numberOfJobsToKeep,
-			"number of pipeline jobs at current spec", len(pipelineJobsAtCurrentSpec))
+			"number of pipeline jobs", len(jobsForPipeline))
 		return nil
 	}
 
 	// Sort jobs by creation time
-	pipelineJobsAtCurrentSpec = resourceutil.SortJobsByCreationDateTime(pipelineJobsAtCurrentSpec, true)
+	jobsForPipeline = resourceutil.SortJobsByCreationDateTime(jobsForPipeline, true)
 
 	// Delete all but the last n jobs; n defaults to 5 and can be configured by env var for the operator
-	for i := 0; i < len(pipelineJobsAtCurrentSpec)-opts.numberOfJobsToKeep; i++ {
-		job := pipelineJobsAtCurrentSpec[i]
+	for i := 0; i < len(jobsForPipeline)-opts.numberOfJobsToKeep; i++ {
+		job := jobsForPipeline[i]
 		logging.Debug(opts.logger,
 			"deleting old job",
 			"name", job.GetName(),

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -891,6 +891,57 @@ var _ = Describe("Workflow Reconciler", func() {
 			})
 		})
 
+		When("a pipeline keeps failing", func() {
+			numberOfJobsToKeep := 2
+
+			// Runs a pipeline, fails it, and reconciles again so the failure is
+			// observed; mirrors what the periodic reconcile does once it re-runs a
+			// workflow whose previous run failed. Returns the failed job's name.
+			failPipelineRun := func() string {
+				GinkgoHelper()
+
+				labelPromiseForManualReconciliation(promise.Name)
+				newWorkflowPipelines, uPromise := setupTest(promise, pipelines)
+				setParentWorkflowCountersStatus(uPromise, 0)
+				opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise,
+					newWorkflowPipelines, "promise", numberOfJobsToKeep, namespace)
+
+				_, err := workflow.ReconcileConfigure(opts)
+				Expect(err).NotTo(HaveOccurred())
+
+				jobName := newWorkflowPipelines[0].Job.GetName()
+				markJobAsFailed(jobName)
+
+				_, err = workflow.ReconcileConfigure(opts)
+				Expect(err).NotTo(HaveOccurred())
+
+				return jobName
+			}
+
+			It("deletes the oldest failed jobs", func() {
+				var mostRecentJobName string
+				for range numberOfJobsToKeep + 2 {
+					mostRecentJobName = failPipelineRun()
+				}
+
+				jobList := listJobs(namespace)
+				Expect(jobList).To(HaveLen(numberOfJobsToKeep))
+				Expect(findByName(jobList, mostRecentJobName)).To(BeTrue())
+			})
+
+			It("does not delete works belonging to pipelines that no longer exist", func() {
+				createFakeWorks([]v1alpha1.Pipeline{{
+					ObjectMeta: metav1.ObjectMeta{Name: "removed-pipeline"},
+				}}, promise.Name)
+
+				failPipelineRun()
+
+				works := v1alpha1.WorkList{}
+				Expect(fakeK8sClient.List(ctx, &works)).To(Succeed())
+				Expect(works.Items).To(HaveLen(1))
+			})
+		})
+
 		When("all pipelines have executed", func() {
 			var updatedWorkflows []v1alpha1.PipelineJobResources
 

--- a/test/system/assets/reconcile-after-failure/kratix-config-no-retry.yaml
+++ b/test/system/assets/reconcile-after-failure/kratix-config-no-retry.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kratix
+  namespace: kratix-platform-system
+data:
+  config: |
+    logging:
+      level: debug
+    reconciliationInterval: 5s
+    workflows:
+      reconcileAfterFailure: false
+      jobOptions:
+        defaultBackoffLimit: 4
+      defaultContainerSecurityContext:
+        windowsOptions:
+          runAsUserName: "setInKratixConfig"

--- a/test/system/assets/reconcile-after-failure/kratix-config-retry.yaml
+++ b/test/system/assets/reconcile-after-failure/kratix-config-retry.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kratix
+  namespace: kratix-platform-system
+data:
+  config: |
+    logging:
+      level: debug
+    reconciliationInterval: 5s
+    workflows:
+      reconcileAfterFailure: true
+      jobOptions:
+        defaultBackoffLimit: 4
+      defaultContainerSecurityContext:
+        windowsOptions:
+          runAsUserName: "setInKratixConfig"

--- a/test/system/assets/reconcile-after-failure/kratix-config-retry.yaml
+++ b/test/system/assets/reconcile-after-failure/kratix-config-retry.yaml
@@ -8,6 +8,9 @@ data:
     logging:
       level: debug
     reconciliationInterval: 5s
+    # Kept low so the failed-job pruning assertion in the spec reaches the cap
+    # quickly; the spec references this value.
+    numberOfJobsToKeep: 2
     workflows:
       reconcileAfterFailure: true
       jobOptions:

--- a/test/system/assets/reconcile-after-failure/promise.yaml
+++ b/test/system/assets/reconcile-after-failure/promise.yaml
@@ -49,7 +49,7 @@ spec:
                 command: ["/bin/sh", "-c"]
                 args:
                   - |
-                    set -u
+                    set -eu
                     if kubectl get configmap reconcile-after-failure-gate -n default >/dev/null 2>&1; then
                       echo "gate present; configure succeeds"
                       exit 0

--- a/test/system/assets/reconcile-after-failure/promise.yaml
+++ b/test/system/assets/reconcile-after-failure/promise.yaml
@@ -1,0 +1,58 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  name: reconcilable
+spec:
+  api:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: reconcilables.test.kratix.io
+    spec:
+      group: test.kratix.io
+      names:
+        kind: Reconcilable
+        plural: reconcilables
+        singular: reconcilable
+      scope: Namespaced
+      versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+          schema:
+            openAPIV3Schema:
+              type: object
+              properties:
+                spec:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+  workflows:
+    resource:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: resource-configure
+          spec:
+            jobOptions:
+              backoffLimit: 0
+            rbac:
+              permissions:
+                - apiGroups: [""]
+                  resources: ["configmaps"]
+                  verbs: ["get"]
+            containers:
+              - name: gate
+                image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+                command: ["/bin/sh", "-c"]
+                args:
+                  - |
+                    set -u
+                    if kubectl get configmap reconcile-after-failure-gate -n default >/dev/null 2>&1; then
+                      echo "gate present; configure succeeds"
+                      exit 0
+                    fi
+                    echo "gate absent; configure fails"
+                    exit 1

--- a/test/system/assets/reconcile-after-failure/resource-request.yaml
+++ b/test/system/assets/reconcile-after-failure/resource-request.yaml
@@ -1,0 +1,7 @@
+apiVersion: test.kratix.io/v1alpha1
+kind: Reconcilable
+metadata:
+  name: example
+  namespace: default
+spec:
+  message: hello

--- a/test/system/promise_revision_test.go
+++ b/test/system/promise_revision_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Promise Revisions", func() {
 		})
 
 		By("retrying when labelled for manual reconciliation", func() {
-			configureJobCount := jobCountForResourcePipeline(promiseName, "resource-configure")
+			jobsBeforeRetry := jobNamesForResourcePipeline(promiseName, "resource-configure")
 			platform.Kubectl("label", "--overwrite", "--namespace=default", name, "kratix.io/manual-reconciliation=true")
 			Eventually(func(g Gomega) {
 				g.Expect(
@@ -291,8 +291,12 @@ var _ = Describe("Promise Revisions", func() {
 						`-o=jsonpath='{.metadata.labels.kratix\.io/manual-reconciliation}'`),
 				).To(Equal(`''`))
 			}).Should(Succeed())
+			// A job count is unreliable here: this upgrade fails, and a failed run
+			// prunes to numberOfJobsToKeep, so the count springs back instead of
+			// growing. A retry is only reliably visible as a new job name.
 			Eventually(func(g Gomega) {
-				g.Expect(jobCountForResourcePipeline(promiseName, "resource-configure")).To(Equal(configureJobCount + 1))
+				g.Expect(newJobNames(jobsBeforeRetry, jobNamesForResourcePipeline(promiseName, "resource-configure"))).
+					NotTo(BeEmpty())
 			}).Should(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(

--- a/test/system/reconcile_after_failure_test.go
+++ b/test/system/reconcile_after_failure_test.go
@@ -2,6 +2,7 @@ package system_test
 
 import (
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,6 +17,8 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 		promiseKind   = "reconcilables"
 		rrName        = "example"
 		gateConfigMap = "reconcile-after-failure-gate"
+		// Must match numberOfJobsToKeep in kratix-config-retry.yaml
+		numberOfJobsToKeep = 2
 	)
 
 	workflowStatusJSONPath := `-o=jsonpath='{.status.conditions[?(@.type=="ConfigureWorkflowCompleted")].status}'`
@@ -23,6 +26,36 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 
 	configureJobCount := func() int {
 		return jobCountForResourcePipeline(promiseName, "resource-configure")
+	}
+
+	// Names, not a count: numberOfJobsToKeep caps the count, so a re-run is only
+	// reliably visible as a job name that was not there before.
+	configureJobNames := func() []string {
+		output := platform.Kubectl(
+			"get", "jobs", "-n", "default",
+			"-l", strings.Join([]string{
+				"kratix.io/promise-name=" + promiseName,
+				"kratix.io/workflow-type=resource",
+				"kratix.io/workflow-action=configure",
+				"kratix.io/pipeline-name=resource-configure",
+			}, ","),
+			"-o=jsonpath={.items[*].metadata.name}",
+		)
+		return strings.Fields(output)
+	}
+
+	configureJobsSince := func(previous []string) []string {
+		seen := map[string]bool{}
+		for _, name := range previous {
+			seen[name] = true
+		}
+		var added []string
+		for _, name := range configureJobNames() {
+			if !seen[name] {
+				added = append(added, name)
+			}
+		}
+		return added
 	}
 
 	BeforeEach(func() {
@@ -58,20 +91,32 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 		It("re-runs failed workflows on the schedule and resumes to success", func() {
 			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "resource-request.yaml"))
 
-			var firstFailedCount int
+			var jobsAtFirstFailure []string
 			By("failing the configure workflow", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(configureJobCount()).To(BeNumerically(">=", 1))
 					g.Expect(platform.Kubectl("get", "--namespace=default", promiseKind, rrName, workflowStatusJSONPath)).
 						To(ContainSubstring("False"))
 				}).Should(Succeed())
-				firstFailedCount = configureJobCount()
+				jobsAtFirstFailure = configureJobNames()
 			})
 
 			By("re-running the workflow automatically", func() {
+				// Job names, not the count: failed jobs are now pruned to
+				// numberOfJobsToKeep, so the count stops growing once it caps.
 				Eventually(func(g Gomega) {
-					g.Expect(configureJobCount()).To(BeNumerically(">", firstFailedCount))
+					g.Expect(configureJobsSince(jobsAtFirstFailure)).NotTo(BeEmpty())
 				}).Should(Succeed())
+			})
+
+			By("pruning the failed jobs it re-runs", func() {
+				// A retry creates the next job before the previous failure is observed
+				// and pruned, so the steady state is numberOfJobsToKeep plus the run in
+				// flight. Without pruning on the failure path the count would climb
+				// past that within a few reconciliation intervals.
+				Consistently(func(g Gomega) {
+					g.Expect(configureJobCount()).To(BeNumerically("<=", numberOfJobsToKeep+1))
+				}, 30*time.Second, 2*time.Second).Should(Succeed())
 			})
 
 			By("succeeding once the gate exists", func() {

--- a/test/system/reconcile_after_failure_test.go
+++ b/test/system/reconcile_after_failure_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 	)
 
 	workflowStatusJSONPath := `-o=jsonpath='{.status.conditions[?(@.type=="ConfigureWorkflowCompleted")].status}'`
+	workflowTransitionJSONPath := `-o=jsonpath='{.status.conditions[?(@.type=="ConfigureWorkflowCompleted")].lastTransitionTime}'`
 
 	configureJobCount := func() int {
 		return jobCountForResourcePipeline(promiseName, "resource-configure")
@@ -33,6 +34,10 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 		Eventually(func() string {
 			return platform.Kubectl("get", "promise", promiseName)
 		}).Should(ContainSubstring("Available"))
+
+		// Wait for any Jobs from a previous spec to be garbage-collected so the
+		// configure-Job count starts from a clean, reliable baseline.
+		Eventually(configureJobCount).Should(Equal(0))
 	})
 
 	AfterEach(func() {
@@ -78,9 +83,13 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 			})
 
 			By("continuing to reconcile after success", func() {
-				countAfterSuccess := configureJobCount()
+				// Job count is unreliable here: numberOfJobsToKeep prunes on the success
+				// path, pinning the count. A success re-run flips the condition
+				// True->InProgress->True, so lastTransitionTime advances each cycle.
+				transitionBeforeReRun := platform.Kubectl("get", "--namespace=default", promiseKind, rrName, workflowTransitionJSONPath)
 				Eventually(func(g Gomega) {
-					g.Expect(configureJobCount()).To(BeNumerically(">", countAfterSuccess))
+					g.Expect(platform.Kubectl("get", "--namespace=default", promiseKind, rrName, workflowTransitionJSONPath)).
+						NotTo(Equal(transitionBeforeReRun))
 				}).Should(Succeed())
 			})
 		})

--- a/test/system/reconcile_after_failure_test.go
+++ b/test/system/reconcile_after_failure_test.go
@@ -2,7 +2,6 @@ package system_test
 
 import (
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,34 +27,8 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 		return jobCountForResourcePipeline(promiseName, "resource-configure")
 	}
 
-	// Names, not a count: numberOfJobsToKeep caps the count, so a re-run is only
-	// reliably visible as a job name that was not there before.
 	configureJobNames := func() []string {
-		output := platform.Kubectl(
-			"get", "jobs", "-n", "default",
-			"-l", strings.Join([]string{
-				"kratix.io/promise-name=" + promiseName,
-				"kratix.io/workflow-type=resource",
-				"kratix.io/workflow-action=configure",
-				"kratix.io/pipeline-name=resource-configure",
-			}, ","),
-			"-o=jsonpath={.items[*].metadata.name}",
-		)
-		return strings.Fields(output)
-	}
-
-	configureJobsSince := func(previous []string) []string {
-		seen := map[string]bool{}
-		for _, name := range previous {
-			seen[name] = true
-		}
-		var added []string
-		for _, name := range configureJobNames() {
-			if !seen[name] {
-				added = append(added, name)
-			}
-		}
-		return added
+		return jobNamesForResourcePipeline(promiseName, "resource-configure")
 	}
 
 	BeforeEach(func() {
@@ -105,7 +78,7 @@ var _ = Describe("Reconcile after failure", Serial, func() {
 				// Job names, not the count: failed jobs are now pruned to
 				// numberOfJobsToKeep, so the count stops growing once it caps.
 				Eventually(func(g Gomega) {
-					g.Expect(configureJobsSince(jobsAtFirstFailure)).NotTo(BeEmpty())
+					g.Expect(newJobNames(jobsAtFirstFailure, configureJobNames())).NotTo(BeEmpty())
 				}).Should(Succeed())
 			})
 

--- a/test/system/reconcile_after_failure_test.go
+++ b/test/system/reconcile_after_failure_test.go
@@ -1,0 +1,123 @@
+package system_test
+
+import (
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/syntasso/kratix/test/kubeutils"
+)
+
+var _ = Describe("Reconcile after failure", Serial, func() {
+	const (
+		assetsPath    = "assets/reconcile-after-failure"
+		promiseName   = "reconcilable"
+		promiseKind   = "reconcilables"
+		rrName        = "example"
+		gateConfigMap = "reconcile-after-failure-gate"
+	)
+
+	workflowStatusJSONPath := `-o=jsonpath='{.status.conditions[?(@.type=="ConfigureWorkflowCompleted")].status}'`
+
+	configureJobCount := func() int {
+		return jobCountForResourcePipeline(promiseName, "resource-configure")
+	}
+
+	BeforeEach(func() {
+		SetDefaultEventuallyTimeout(4 * time.Minute)
+		SetDefaultEventuallyPollingInterval(2 * time.Second)
+		kubeutils.SetTimeoutAndInterval(4*time.Minute, 2*time.Second)
+
+		platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "promise.yaml"))
+		Eventually(func() string {
+			return platform.Kubectl("get", "promise", promiseName)
+		}).Should(ContainSubstring("Available"))
+	})
+
+	AfterEach(func() {
+		platform.EventuallyKubectlDelete(promiseKind, rrName)
+		platform.EventuallyKubectlDelete("promise", promiseName)
+		platform.KubectlAllowFail("delete", "configmap", gateConfigMap, "-n", "default")
+
+		platform.Kubectl("apply", "-f", kratixConfigPath)
+		restartController()
+	})
+
+	When("reconcileAfterFailure is true", func() {
+		BeforeEach(func() {
+			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "kratix-config-retry.yaml"))
+			restartController()
+		})
+
+		It("re-runs failed workflows on the schedule and resumes to success", func() {
+			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "resource-request.yaml"))
+
+			var firstFailedCount int
+			By("failing the configure workflow", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(configureJobCount()).To(BeNumerically(">=", 1))
+					g.Expect(platform.Kubectl("get", "--namespace=default", promiseKind, rrName, workflowStatusJSONPath)).
+						To(ContainSubstring("False"))
+				}).Should(Succeed())
+				firstFailedCount = configureJobCount()
+			})
+
+			By("re-running the workflow automatically", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(configureJobCount()).To(BeNumerically(">", firstFailedCount))
+				}).Should(Succeed())
+			})
+
+			By("succeeding once the gate exists", func() {
+				platform.Kubectl("create", "configmap", gateConfigMap, "-n", "default")
+				Eventually(func(g Gomega) {
+					g.Expect(platform.Kubectl("get", "--namespace=default", promiseKind, rrName, workflowStatusJSONPath)).
+						To(ContainSubstring("True"))
+				}).Should(Succeed())
+			})
+
+			By("continuing to reconcile after success", func() {
+				countAfterSuccess := configureJobCount()
+				Eventually(func(g Gomega) {
+					g.Expect(configureJobCount()).To(BeNumerically(">", countAfterSuccess))
+				}).Should(Succeed())
+			})
+		})
+	})
+
+	When("reconcileAfterFailure is false", func() {
+		BeforeEach(func() {
+			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "kratix-config-no-retry.yaml"))
+			restartController()
+		})
+
+		It("does not re-run failed workflows, but manual reconciliation works", func() {
+			platform.Kubectl("apply", "-f", filepath.Join(assetsPath, "resource-request.yaml"))
+
+			var failedCount int
+			By("failing the configure workflow", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(configureJobCount()).To(BeNumerically(">=", 1))
+					g.Expect(platform.Kubectl("get", "--namespace=default", promiseKind, rrName, workflowStatusJSONPath)).
+						To(ContainSubstring("False"))
+				}).Should(Succeed())
+				failedCount = configureJobCount()
+			})
+
+			By("not re-running on the schedule", func() {
+				Consistently(func(g Gomega) {
+					g.Expect(configureJobCount()).To(Equal(failedCount))
+				}, 30*time.Second, 3*time.Second).Should(Succeed())
+			})
+
+			By("re-running when manually labelled", func() {
+				platform.Kubectl("label", "--overwrite", "--namespace=default", promiseKind, rrName,
+					"kratix.io/manual-reconciliation=true")
+				Eventually(func(g Gomega) {
+					g.Expect(configureJobCount()).To(BeNumerically(">", failedCount))
+				}).Should(Succeed())
+			})
+		})
+	})
+})

--- a/test/system/workflow_control_test.go
+++ b/test/system/workflow_control_test.go
@@ -485,25 +485,59 @@ func jobCountForResourcePipeline(promiseName, pipelineName string) int {
 }
 
 func jobCountForWorkflow(workflowType, promiseName, pipelineName, action string) int {
-	ns := "kratix-platform-system"
-	if workflowType == "resource" {
-		ns = "default"
-	}
-	selector := strings.Join([]string{
-		"kratix.io/promise-name=" + promiseName,
-		"kratix.io/workflow-type=" + workflowType,
-		"kratix.io/workflow-action=" + action,
-		"kratix.io/pipeline-name=" + pipelineName,
-	}, ",")
 	output := platform.Kubectl(
 		"get", "jobs",
-		"-n", ns,
-		"-l", selector,
+		"-n", workflowJobNamespace(workflowType),
+		"-l", workflowJobSelector(workflowType, promiseName, pipelineName, action),
 		"-o=go-template={{len .items}}",
 	)
 	count, err := strconv.Atoi(strings.TrimSpace(output))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return count
+}
+
+// jobNamesForResourcePipeline is the pruning-resilient alternative to counting
+// jobs: numberOfJobsToKeep caps the count, and a failed run now prunes too, so a
+// re-run is only reliably visible as a job name that was not there before.
+func jobNamesForResourcePipeline(promiseName, pipelineName string) []string {
+	output := platform.Kubectl(
+		"get", "jobs",
+		"-n", workflowJobNamespace("resource"),
+		"-l", workflowJobSelector("resource", promiseName, pipelineName, "configure"),
+		"-o=jsonpath={.items[*].metadata.name}",
+	)
+	return strings.Fields(output)
+}
+
+// newJobNames returns the names in current that are absent from previous.
+func newJobNames(previous, current []string) []string {
+	seen := map[string]bool{}
+	for _, name := range previous {
+		seen[name] = true
+	}
+	var added []string
+	for _, name := range current {
+		if !seen[name] {
+			added = append(added, name)
+		}
+	}
+	return added
+}
+
+func workflowJobNamespace(workflowType string) string {
+	if workflowType == "resource" {
+		return "default"
+	}
+	return "kratix-platform-system"
+}
+
+func workflowJobSelector(workflowType, promiseName, pipelineName, action string) string {
+	return strings.Join([]string{
+		"kratix.io/promise-name=" + promiseName,
+		"kratix.io/workflow-type=" + workflowType,
+		"kratix.io/workflow-action=" + action,
+		"kratix.io/pipeline-name=" + pipelineName,
+	}, ",")
 }
 
 func workCountForResourcePipeline() int {


### PR DESCRIPTION
By default, periodic reconciliation now re-runs a resource request's configure workflows on the Default Reconciliation Interval regardless of whether the previous run succeeded or failed. A failed run no longer stops future scheduled runs — Kratix keeps reconciling towards desired state.

The fix spans two links in the resource request reconcile path: reconcileAfterConfigure now schedules the interval requeue after a failed run (previously only after success), and shouldForcePipelineRun forces the rerun when that requeue fires. Both are gated on a genuine failure via the existing workflowCompletedWithFailure helper, so an in-progress run is never restarted.

A new Kratix Config field, workflows.reconcileAfterFailure (default true), lets operators opt out: when false, a failed run is skipped by the periodic reconcile until it is manually addressed (a spec change, a Promise change, or the kratix.io/manual-reconciliation label), preserving the previous behaviour exactly. Scope is resource requests only; the Promise-workflow guard is unchanged.

Closes #858