### PR TITLE
chore: add no-op pipeline for workflow tests

### DIFF
--- a/test/system/assets/reconcile-after-failure/promise-workflow.yaml
+++ b/test/system/assets/reconcile-after-failure/promise-workflow.yaml
@@ -60,3 +60,18 @@ spec:
                     fi
                     echo "gate absent; configure fails"
                     exit 1
+    resource:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: nop
+          spec:
+            jobOptions:
+              backoffLimit: 0
+            containers:
+              - name: nop
+                image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+                command: ["/bin/sh", "-c"]
+                args:
+                  - echo "resource configure completed"


### PR DESCRIPTION
## What changed

- add a no-op resource configure pipeline to the reconcile-after-failure Promise workflow fixture
- disable retries for the no-op job with `backoffLimit: 0`

## Why

This keeps the workflow retry system-test fixture representative of a Promise that defines both Promise and resource configure pipelines. The change is limited to test assets and has no production behavior impact.

This is an additional piece to #866 