### PR TITLE
feat: set the reconciliation interval once on the Promise

### DIFF
--- a/api/v1alpha1/promiserevision_types.go
+++ b/api/v1alpha1/promiserevision_types.go
@@ -151,6 +151,9 @@ func (pr *PromiseRevision) ClearLatestRevisionLabel() {
 const MinReconciliationInterval = time.Minute
 
 // ReconciliationIntervalAnnotation overrides a revision's reconciliation interval.
+//
+// The revision for the Promise's current version mirrors this annotation from the Promise on
+// every reconcile. Revisions for older versions keep their annotation unchanged.
 const ReconciliationIntervalAnnotation = KratixPrefix + "reconciliation-interval"
 
 type ReconciliationIntervalSource string

--- a/api/v1alpha1/promiserevision_types.go
+++ b/api/v1alpha1/promiserevision_types.go
@@ -153,7 +153,8 @@ const MinReconciliationInterval = time.Minute
 // ReconciliationIntervalAnnotation overrides a revision's reconciliation interval.
 //
 // The revision for the Promise's current version mirrors this annotation from the Promise on
-// every reconcile. Revisions for older versions keep their annotation unchanged.
+// every reconcile. PromiseRelease-managed Promises and older revisions keep their annotation
+// unchanged.
 const ReconciliationIntervalAnnotation = KratixPrefix + "reconciliation-interval"
 
 type ReconciliationIntervalSource string

--- a/docs/plans/870-slice2-annotation-override.md
+++ b/docs/plans/870-slice2-annotation-override.md
@@ -106,3 +106,10 @@ Not a sweep at the end — these are known now, so they are a task. Each needs i
 ## Amended during implementation
 
 Nothing yet. Deltas go here before hand-off; where this section and a task disagree, this section wins.
+
+1. **Slice 3 closed the friction this plan's briefing describes.** The "Friction it leaves her"
+   paragraph above says Penny must annotate each revision because annotating the Promise does
+   nothing. That is now only true for archived revisions: slice 3 mirrors the Promise's
+   `kratix.io/reconciliation-interval` onto the revision for its current version, so annotating
+   the Promise once is sufficient there. Hand-annotating that latest revision directly no longer
+   sticks — the mirror overwrites it on the next Promise reconcile.

--- a/docs/plans/870-slice3-promise-annotation-sync.md
+++ b/docs/plans/870-slice3-promise-annotation-sync.md
@@ -1,0 +1,76 @@
+# 870 slice 3 — Penny sets it once
+
+## Delivery state
+
+| | |
+|---|---|
+| Stage | Plan written; build not started |
+| Tier | **standard** — ~40 production lines, raised on risk (see below). Budget 150 min |
+| Issue | [#870](https://github.com/syntasso/kratix/issues/870) |
+| Base | `39669e54` (slice 2 tip, PR #878, itself stacked on #877). 14 ahead / **0 behind** `main` |
+| Workspace | jj workspace `kratix-870-s3` |
+| Baseline gate | captured to scratchpad |
+| Tasks green | 0 / 3 |
+| Open findings | none |
+| Parked | The briefing below could not be posted to #870 — GitHub returning 503. Post at land time. |
+| Release level | Unreleased — branch and PR, no tag |
+
+### Why standard, when size says light
+
+Size reads light: roughly forty production lines inside `handlePromiseVersion`'s `CreateOrUpdate` mutate function. Three risks outrank it.
+
+- **It makes the promise controller a new writer of revision annotations.** Until now the controller owned a revision's spec, labels and owner ref; annotations were the operator's. That changes here.
+- **The delete arm destroys state a user set by hand.** Set-always means the latest revision's annotation mirrors the Promise's exactly, so a value Penny typed onto the latest revision is wiped on the next reconcile. That is the workflow slice 2 shipped and documented.
+- **It can wedge a Promise.** Slice 2's PromiseRevision webhook rejects an out-of-policy annotation. If a Promise carries a bad value, the controller's own sync write fails admission, and with it every subsequent revision update for that Promise. Slice 2's adversarial pass recorded this as latent; this slice makes it reachable, which is why task 2 exists.
+
+## Briefing
+
+**Decision.** No ADR governs this; resolved live during slice 1 and unchanged since. [ADR0008 — Workflow Controls](https://github.com/syntasso/adrs/blob/main/0008_workflow_controls.md) is adjacent and **Draft**. Slice 2 fixed the gate ordering, so an elapsed interval no longer strips a suspension; keep it that way.
+
+**Persona.** [Penny](https://app.notion.com/p/36e85a0225cc818e8989e275cd32c666), Platform Engineer, Champion, Active. This closes the friction slice 2 left her: she currently annotates *each* revision she wants to affect. After this she annotates the Promise once, and the latest revision mirrors it — surviving version bumps, because `PromiseRelease` merges annotations rather than replacing them.
+
+*Friction it leaves her:* hand-annotating the **latest** revision stops sticking. Revisions for older versions are never re-synced, so those stay hand-pinnable. The asymmetry is deliberate and was chosen when the sync semantics were settled, but it partly walks back what slice 2's PR told her to do — task 3 owns saying so.
+
+**Vanessa** is unaffected: her spec value still governs wherever no annotation exists.
+
+## Global constraints
+
+- Stacked on slice 2. The resolution chain does not change: `revision annotation → revision spec snapshot → global default`. This slice only changes **how the revision annotation gets there**.
+- One key: `kratix.io/reconciliation-interval`. No other annotation is synced, copied or deleted.
+- Only the revision for the Promise's current version is touched. Archived revisions keep whatever they carry.
+- Gate in CI's form: `make lint` (`.golangci-required.yml`) and `make test`. Agents run the covering package only.
+
+## Tasks
+
+### Task 1 — The latest revision mirrors the Promise's annotation
+
+Constraint: when the Promise carries `kratix.io/reconciliation-interval`, the revision for its current version carries the same value; when the Promise does not, the revision does not either. Mirroring means the delete arm as well as the set arm — without it there is no way to undo an override through the interface that created it.
+
+Touch that key only. An unrelated annotation on the revision, whoever set it, survives.
+
+Goes **red** on three assertions, and the second is the one implementations skip: a Promise with the annotation produces a revision carrying it; **removing it from the Promise removes it from the revision**; an unrelated annotation on the revision is untouched by either arm.
+
+Also assert what must *not* happen: a revision for an older version is not modified. That is a property of which object the mutate function targets, and it is the guarantee that keeps slice 2's per-revision pinning alive.
+
+### Task 2 — Admission rejects a bad annotation on the Promise
+
+Constraint: the Promise validating webhook rejects `kratix.io/reconciliation-interval` values that do not parse, or fall below `MinReconciliationInterval`, on create and update. Absent stays valid.
+
+This is not symmetry for its own sake. Without it, a Promise annotated `30s` makes the controller's own sync write fail slice 2's PromiseRevision admission — and since that write happens inside `handlePromiseVersion`, the Promise stops accepting revision updates entirely. The floor has to be enforced where the value enters, not only where it lands.
+
+Reuse `MinReconciliationInterval` and match the rejection-message shape already used for the spec field and for the revision annotation. One floor, one constant, now three write paths.
+
+Goes **red** on: a Promise annotated below the floor is rejected on create; one annotated with an unparseable value is rejected with a distinguishable message; exactly the floor is accepted.
+
+### Task 3 — Claims this slice falsifies
+
+Known now, so they are a task rather than a sweep:
+
+- `api/v1alpha1/promiserevision_types.go` — `ReconciliationIntervalAnnotation`'s doc describes a revision-level override. It is now also mirrored from the Promise, and the mirror wins on the latest revision.
+- `api/v1alpha1/promiserevision_types.go` — `MinReconciliationInterval`'s doc names three enforcement points. Task 2 adds a fourth.
+- `docs/plans/870-slice2-annotation-override.md` — tells Penny to annotate revisions. True for archived ones, no longer true for the latest.
+- Anything in `promise_controller.go` describing what `handlePromiseVersion`'s `CreateOrUpdate` owns — it now owns an annotation as well as spec, labels and the owner ref.
+
+## Amended during implementation
+
+Nothing yet. Deltas go here before hand-off; where this section and a task disagree, this section wins.

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -189,7 +189,7 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, r.Client.Update(opts.ctx, promise)
 	}
 
-	result, err := r.handlePromiseVersion(ctx, promise)
+	result, err := r.handlePromiseVersion(ctx, promise, logger)
 	if err != nil || !result.IsZero() {
 		return result, err
 	}
@@ -371,7 +371,7 @@ func shouldRemoveDeleteWorkflowsFinalizer(promise *v1alpha1.Promise) bool {
 		controllerutil.ContainsFinalizer(promise, runDeleteWorkflowsFinalizer)
 }
 
-func (r *PromiseReconciler) handlePromiseVersion(ctx context.Context, promise *v1alpha1.Promise) (ctrl.Result, error) {
+func (r *PromiseReconciler) handlePromiseVersion(ctx context.Context, promise *v1alpha1.Promise, logger logr.Logger) (ctrl.Result, error) {
 	var promiseVersion string
 	var found bool
 	if promiseVersion, found = promise.Labels[v1alpha1.PromiseVersionLabel]; found {
@@ -406,6 +406,15 @@ func (r *PromiseReconciler) handlePromiseVersion(ctx context.Context, promise *v
 			}
 			annotations[v1alpha1.ReconciliationIntervalAnnotation] = interval
 			revision.SetAnnotations(annotations)
+
+			// A Promise can carry an out-of-policy value from before the admission check
+			// existed; mirroring it here would fail the write on the revision's own
+			// webhook and abort this reconcile before the Promise's status is written.
+			if revision.ReconciliationIntervalAnnotationDeclined() {
+				delete(revision.GetAnnotations(), v1alpha1.ReconciliationIntervalAnnotation)
+				logging.Warn(logger, "Promise reconciliation-interval annotation declined; not mirrored onto revision",
+					"promise", promise.GetName(), "annotation", v1alpha1.ReconciliationIntervalAnnotation)
+			}
 		} else {
 			delete(revision.GetAnnotations(), v1alpha1.ReconciliationIntervalAnnotation)
 		}

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -399,24 +399,31 @@ func (r *PromiseReconciler) handlePromiseVersion(ctx context.Context, promise *v
 		revision.SetLabels(labels.Merge(l, promise.GenerateSharedLabels()))
 		revision.SetLatestRevisionLabel()
 
-		if interval, ok := promise.GetAnnotations()[v1alpha1.ReconciliationIntervalAnnotation]; ok {
-			annotations := revision.GetAnnotations()
-			if annotations == nil {
-				annotations = map[string]string{}
-			}
-			annotations[v1alpha1.ReconciliationIntervalAnnotation] = interval
-			revision.SetAnnotations(annotations)
+		// A PromiseRelease-managed Promise gets this annotation from installPromise merging
+		// the artefact's annotations onto the live Promise, not from an operator; mirroring
+		// it here would overwrite the one override path that works for that population, and
+		// the delete arm would erase it the moment the artefact stops carrying a value.
+		if _, managedByPromiseRelease := promise.Labels[promiseReleaseNameLabel]; !managedByPromiseRelease {
+			if interval, ok := promise.GetAnnotations()[v1alpha1.ReconciliationIntervalAnnotation]; ok {
+				annotations := revision.GetAnnotations()
+				if annotations == nil {
+					annotations = map[string]string{}
+				}
+				annotations[v1alpha1.ReconciliationIntervalAnnotation] = interval
+				revision.SetAnnotations(annotations)
 
-			// A Promise can carry an out-of-policy value from before the admission check
-			// existed; mirroring it here would fail the write on the revision's own
-			// webhook and abort this reconcile before the Promise's status is written.
-			if revision.ReconciliationIntervalAnnotationDeclined() {
+				// A Promise can carry an out-of-policy value from before the admission check
+				// existed; mirroring it here would fail the write on the revision's own
+				// webhook and abort this reconcile before the Promise's status is written.
+				_, reconciliationIntervalSource := revision.ReconciliationInterval(r.ReconciliationInterval)
+				if reconciliationIntervalSource != v1alpha1.ReconciliationIntervalFromAnnotation {
+					delete(revision.GetAnnotations(), v1alpha1.ReconciliationIntervalAnnotation)
+					logging.Warn(logger, "Promise reconciliation-interval annotation declined; not mirrored onto revision",
+						"promise", promise.GetName(), "annotation", v1alpha1.ReconciliationIntervalAnnotation)
+				}
+			} else {
 				delete(revision.GetAnnotations(), v1alpha1.ReconciliationIntervalAnnotation)
-				logging.Warn(logger, "Promise reconciliation-interval annotation declined; not mirrored onto revision",
-					"promise", promise.GetName(), "annotation", v1alpha1.ReconciliationIntervalAnnotation)
 			}
-		} else {
-			delete(revision.GetAnnotations(), v1alpha1.ReconciliationIntervalAnnotation)
 		}
 
 		return controllerutil.SetControllerReference(promise, revision, scheme.Scheme)

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -399,6 +399,17 @@ func (r *PromiseReconciler) handlePromiseVersion(ctx context.Context, promise *v
 		revision.SetLabels(labels.Merge(l, promise.GenerateSharedLabels()))
 		revision.SetLatestRevisionLabel()
 
+		if interval, ok := promise.GetAnnotations()[v1alpha1.ReconciliationIntervalAnnotation]; ok {
+			annotations := revision.GetAnnotations()
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+			annotations[v1alpha1.ReconciliationIntervalAnnotation] = interval
+			revision.SetAnnotations(annotations)
+		} else {
+			delete(revision.GetAnnotations(), v1alpha1.ReconciliationIntervalAnnotation)
+		}
+
 		return controllerutil.SetControllerReference(promise, revision, scheme.Scheme)
 	})
 	if err != nil {

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -2595,6 +2595,20 @@ var _ = Describe("PromiseController", func() {
 					Expect(revision.GetAnnotations()).To(HaveKeyWithValue("example.com/unrelated", "keep-me"))
 				})
 
+				It("declines to mirror an out-of-policy value onto the revision, and still reconciles", func() {
+					promise.SetAnnotations(map[string]string{v1alpha1.ReconciliationIntervalAnnotation: "30s"})
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					result, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
+
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).NotTo(HaveKey(v1alpha1.ReconciliationIntervalAnnotation))
+				})
+
 				It("does not modify the revision for an older Promise version", func() {
 					oldRevisionRef := revisionRef
 

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -2525,6 +2525,100 @@ var _ = Describe("PromiseController", func() {
 				})
 			})
 
+			When("the Promise carries the reconciliation-interval annotation", func() {
+				It("mirrors the annotation onto the revision for the current version", func() {
+					promise.SetAnnotations(map[string]string{v1alpha1.ReconciliationIntervalAnnotation: "5m"})
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					result, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
+
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).To(HaveKeyWithValue(v1alpha1.ReconciliationIntervalAnnotation, "5m"))
+				})
+
+				It("removes the annotation from the revision once removed from the Promise", func() {
+					promise.SetAnnotations(map[string]string{v1alpha1.ReconciliationIntervalAnnotation: "5m"})
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					_, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).To(HaveKeyWithValue(v1alpha1.ReconciliationIntervalAnnotation, "5m"))
+
+					Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+					delete(promise.Annotations, v1alpha1.ReconciliationIntervalAnnotation)
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					_, err = t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).NotTo(HaveKey(v1alpha1.ReconciliationIntervalAnnotation))
+				})
+
+				It("leaves an unrelated annotation on the revision untouched by either arm", func() {
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					revision.SetAnnotations(map[string]string{"example.com/unrelated": "keep-me"})
+					Expect(fakeK8sClient.Update(ctx, revision)).To(Succeed())
+
+					promise.SetAnnotations(map[string]string{v1alpha1.ReconciliationIntervalAnnotation: "5m"})
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					_, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).To(HaveKeyWithValue("example.com/unrelated", "keep-me"))
+					Expect(revision.GetAnnotations()).To(HaveKeyWithValue(v1alpha1.ReconciliationIntervalAnnotation, "5m"))
+
+					Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+					delete(promise.Annotations, v1alpha1.ReconciliationIntervalAnnotation)
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					_, err = t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).NotTo(HaveKey(v1alpha1.ReconciliationIntervalAnnotation))
+					Expect(revision.GetAnnotations()).To(HaveKeyWithValue("example.com/unrelated", "keep-me"))
+				})
+
+				It("does not modify the revision for an older Promise version", func() {
+					oldRevisionRef := revisionRef
+
+					promise.Labels[v1alpha1.PromiseVersionLabel] = "v1.0.1"
+					promise.SetAnnotations(map[string]string{v1alpha1.ReconciliationIntervalAnnotation: "5m"})
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					result, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
+
+					newRevisionName := objectutil.GenerateDeterministicObjectName(promise.GetName(), "v1.0.1")
+					newRevision := &v1alpha1.PromiseRevision{}
+					Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: newRevisionName}, newRevision)).To(Succeed())
+					Expect(newRevision.GetAnnotations()).To(HaveKeyWithValue(v1alpha1.ReconciliationIntervalAnnotation, "5m"))
+
+					oldRevision := &v1alpha1.PromiseRevision{}
+					Expect(fakeK8sClient.Get(ctx, oldRevisionRef, oldRevision)).To(Succeed())
+					Expect(oldRevision.GetAnnotations()).NotTo(HaveKey(v1alpha1.ReconciliationIntervalAnnotation))
+				})
+			})
+
 			When("the Promise Version is not a valid Object Name", func() {
 				BeforeEach(func() {
 					promise.Labels[v1alpha1.PromiseVersionLabel] = "v1.ALLCAPS"

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -2633,6 +2633,43 @@ var _ = Describe("PromiseController", func() {
 				})
 			})
 
+			When("the Promise is managed by a PromiseRelease", func() {
+				BeforeEach(func() {
+					Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+					promise.Labels["kratix.io/promise-release-name"] = "redis"
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+				})
+
+				It("does not mirror the Promise's reconciliation-interval annotation onto the revision", func() {
+					Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+					promise.SetAnnotations(map[string]string{v1alpha1.ReconciliationIntervalAnnotation: "5m"})
+					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+					_, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).NotTo(HaveKey(v1alpha1.ReconciliationIntervalAnnotation))
+				})
+
+				It("leaves a hand-set annotation on the latest revision untouched by a reconcile", func() {
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					revision.SetAnnotations(map[string]string{v1alpha1.ReconciliationIntervalAnnotation: "10m"})
+					Expect(fakeK8sClient.Update(ctx, revision)).To(Succeed())
+
+					Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+					_, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeK8sClient.Get(ctx, revisionRef, revision)).To(Succeed())
+					Expect(revision.GetAnnotations()).To(HaveKeyWithValue(v1alpha1.ReconciliationIntervalAnnotation, "10m"))
+				})
+			})
+
 			When("the Promise Version is not a valid Object Name", func() {
 				BeforeEach(func() {
 					promise.Labels[v1alpha1.PromiseVersionLabel] = "v1.ALLCAPS"

--- a/internal/webhook/v1alpha1/promise_webhook.go
+++ b/internal/webhook/v1alpha1/promise_webhook.go
@@ -73,12 +73,29 @@ var _ admission.Validator[*v1alpha1.Promise] = &PromiseCustomValidator{}
 
 func (v PromiseCustomValidator) ValidateCreate(ctx context.Context, promise *v1alpha1.Promise) (warnings admission.Warnings, err error) {
 	promiselog.Info("validating promise create", "name", promise.Name)
+
+	if err := validateReconciliationIntervalAnnotation(promise.GetAnnotations()); err != nil {
+		return nil, err
+	}
+
 	return validatePromise(promise)
 }
 
+// ValidateUpdate validates the reconciliation-interval annotation only when its value changes,
+// grandfathering an existing out-of-policy value instead of rejecting every future update to a
+// Promise that carried one before this check existed - including the Kratix controllers' own
+// status writes, which would otherwise wedge the Promise's reconciliation permanently.
 func (v PromiseCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *v1alpha1.Promise) (warnings admission.Warnings, err error) {
 	promise := newObj
 	oldPromise := oldObj
+
+	oldValue := oldPromise.GetAnnotations()[v1alpha1.ReconciliationIntervalAnnotation]
+	newValue := promise.GetAnnotations()[v1alpha1.ReconciliationIntervalAnnotation]
+	if oldValue != newValue {
+		if err := validateReconciliationIntervalAnnotation(promise.GetAnnotations()); err != nil {
+			return nil, err
+		}
+	}
 
 	warnings, err = validatePromise(promise)
 	if err != nil {
@@ -96,6 +113,10 @@ func (v PromiseCustomValidator) ValidateDelete(ctx context.Context, obj *v1alpha
 	return nil, nil
 }
 
+// validatePromise runs the checks shared by ValidateCreate and ValidateUpdate. The
+// reconciliation-interval annotation is not among them: it is validated unconditionally by
+// ValidateCreate and conditionally by ValidateUpdate, since only the latter needs to grandfather
+// an existing out-of-policy value.
 func validatePromise(p *v1alpha1.Promise) ([]string, error) {
 	if err := validateCRD(p); err != nil {
 		return nil, err
@@ -106,10 +127,6 @@ func validatePromise(p *v1alpha1.Promise) ([]string, error) {
 	}
 
 	if err := validateReconciliationInterval(p); err != nil {
-		return nil, err
-	}
-
-	if err := validateReconciliationIntervalAnnotation(p.GetAnnotations()); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/v1alpha1/promise_webhook.go
+++ b/internal/webhook/v1alpha1/promise_webhook.go
@@ -109,6 +109,10 @@ func validatePromise(p *v1alpha1.Promise) ([]string, error) {
 		return nil, err
 	}
 
+	if err := validateReconciliationIntervalAnnotation(p.GetAnnotations()); err != nil {
+		return nil, err
+	}
+
 	return validateRequiredPromisesAreAvailable(p), nil
 }
 

--- a/internal/webhook/v1alpha1/promise_webhook_test.go
+++ b/internal/webhook/v1alpha1/promise_webhook_test.go
@@ -358,6 +358,43 @@ var _ = Describe("PromiseWebhook", func() {
 			_, err := validator.ValidateCreate(ctx, promise)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		When("updating a Promise", func() {
+			It("accepts an update that leaves an existing out-of-policy value untouched", func() {
+				oldPromise := newPromise()
+				oldPromise.Annotations = map[string]string{
+					v1alpha1.ReconciliationIntervalAnnotation: "30s",
+				}
+				promise := newPromise()
+				promise.Annotations = map[string]string{
+					v1alpha1.ReconciliationIntervalAnnotation: "30s",
+				}
+				_, err := validator.ValidateUpdate(ctx, oldPromise, promise)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("rejects an update that changes an out-of-policy value to a different out-of-policy value", func() {
+				oldPromise := newPromise()
+				oldPromise.Annotations = map[string]string{
+					v1alpha1.ReconciliationIntervalAnnotation: "30s",
+				}
+				promise := newPromise()
+				promise.Annotations = map[string]string{
+					v1alpha1.ReconciliationIntervalAnnotation: "10s",
+				}
+				_, err := validator.ValidateUpdate(ctx, oldPromise, promise)
+				Expect(err).To(MatchError(ContainSubstring("must be at least 1m0s")))
+			})
+
+			It("still rejects a create with an out-of-policy value", func() {
+				promise := newPromise()
+				promise.Annotations = map[string]string{
+					v1alpha1.ReconciliationIntervalAnnotation: "30s",
+				}
+				_, err := validator.ValidateCreate(ctx, promise)
+				Expect(err).To(MatchError(ContainSubstring("must be at least 1m0s")))
+			})
+		})
 	})
 
 	When("Required Promises", func() {

--- a/internal/webhook/v1alpha1/promise_webhook_test.go
+++ b/internal/webhook/v1alpha1/promise_webhook_test.go
@@ -325,6 +325,41 @@ var _ = Describe("PromiseWebhook", func() {
 		})
 	})
 
+	Context("metadata.annotations[kratix.io/reconciliation-interval]", func() {
+		It("rejects a value below the floor on create", func() {
+			promise := newPromise()
+			promise.Annotations = map[string]string{
+				v1alpha1.ReconciliationIntervalAnnotation: "30s",
+			}
+			_, err := validator.ValidateCreate(ctx, promise)
+			Expect(err).To(MatchError(ContainSubstring("must be at least 1m0s")))
+		})
+
+		It("rejects an unparseable value with a distinguishable message", func() {
+			promise := newPromise()
+			promise.Annotations = map[string]string{
+				v1alpha1.ReconciliationIntervalAnnotation: "soon",
+			}
+			_, err := validator.ValidateCreate(ctx, promise)
+			Expect(err).To(MatchError(ContainSubstring("must be a valid duration")))
+		})
+
+		It("accepts a value exactly at the floor", func() {
+			promise := newPromise()
+			promise.Annotations = map[string]string{
+				v1alpha1.ReconciliationIntervalAnnotation: "1m",
+			}
+			_, err := validator.ValidateCreate(ctx, promise)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("accepts a promise without the annotation", func() {
+			promise := newPromise()
+			_, err := validator.ValidateCreate(ctx, promise)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	When("Required Promises", func() {
 		When("the required promise revision cannot be found", func() {
 			It("returns warnings", func() {

--- a/internal/webhook/v1alpha1/promiserevision_webhook.go
+++ b/internal/webhook/v1alpha1/promiserevision_webhook.go
@@ -32,7 +32,7 @@ var _ admission.Validator[*platformv1alpha1.PromiseRevision] = &PromiseRevisionC
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type PromiseRevision.
 func (v *PromiseRevisionCustomValidator) ValidateCreate(_ context.Context, obj *platformv1alpha1.PromiseRevision) (admission.Warnings, error) {
-	return nil, validateReconciliationIntervalAnnotation(obj)
+	return nil, validateReconciliationIntervalAnnotation(obj.GetAnnotations())
 }
 
 // ValidateUpdate validates a changed reconciliation interval annotation.
@@ -42,12 +42,12 @@ func (v *PromiseRevisionCustomValidator) ValidateUpdate(_ context.Context, oldOb
 	if oldValue == newValue {
 		return nil, nil
 	}
-	return nil, validateReconciliationIntervalAnnotation(newObj)
+	return nil, validateReconciliationIntervalAnnotation(newObj.GetAnnotations())
 }
 
 // validateReconciliationIntervalAnnotation validates the reconciliation interval annotation.
-func validateReconciliationIntervalAnnotation(revision *platformv1alpha1.PromiseRevision) error {
-	raw, ok := revision.GetAnnotations()[platformv1alpha1.ReconciliationIntervalAnnotation]
+func validateReconciliationIntervalAnnotation(annotations map[string]string) error {
+	raw, ok := annotations[platformv1alpha1.ReconciliationIntervalAnnotation]
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
**Stacked on #878.** Third of four — see #877 for the stack map. This completes the feature.

Set the interval once on the Promise instead of on every revision:

```bash
kubectl annotate promise postgres kratix.io/reconciliation-interval=30m
```

The revision for the Promise's current version mirrors it, and loses it when you remove it from the Promise. Revisions for older versions keep whatever they carry, so resources pinned to an old version stay individually tunable.

### How the interval resolves, with all three slices in

Every object reads from the PromiseRevision it is bound to:

```mermaid
flowchart TD
    R["The PromiseRevision this object is bound to"] --> A
    A{"annotation set,<br/>parses, ≥ 1m?"} -->|yes| U1["that value"]
    A -->|no| S{"spec snapshot<br/>set, ≥ 1m?"}
    S -->|yes| U2["that value"]
    S -->|no| U3["platform default"]
```

Two things can put that annotation on a revision: an operator, by hand on any revision; or this PR's mirror, copying it from the Promise onto the current version's revision.

### PromiseRelease-managed Promises are not mirrored

For those, `installPromise` merges the artefact's annotations over the live Promise on every resync — so the value would be the artefact author's, not yours, and your edit would be reverted by the reconcile it triggers. Annotate the revision directly instead; that path is deliberately left working for them.

### Validation

Admission rejects unparseable and sub-minute values on the Promise, sharing one validator with the PromiseRevision webhook. An existing out-of-policy value is grandfathered on update, so raising the floor later can't lock a Promise out of every edit. The mirror declines a bad value rather than propagating it into a write admission would reject.

### Known limitations

- **An override can be stranded on an archived revision.** Set the annotation, ship a new Promise version, then remove it: resources pinned to the old version keep the old interval, and nothing surfaces that. Doesn't affect PromiseRelease-managed Promises, which aren't mirrored.
- **No ceiling.** `8760h` is accepted and effectively stops periodic re-runs while everything still reports Healthy.
- **No surface.** The effective interval and where it came from appear only in logs.
- Carried from #877: the floor isn't operator-configurable, and failure retries are flat at the interval.

### Verification

`make lint` 0 issues, `make test` 15 suites. Reviewed for correctness, adversarially, and against #870's acceptance criteria — both Gherkin scenarios are proven by tests at both the Promise and resource-request layers.
