### PR TITLE
chore: let WORKER_STATESTORE_TYPE env override quick-start statestore

### DIFF
--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -80,11 +80,16 @@ load_options() {
         'n') LABELS=false ;;
         'i') LOCAL_IMAGES_DIR=${OPTARG} ;;
         'd') INSTALL_AND_CREATE_GITEA_REPO=true INSTALL_AND_CREATE_MINIO_BUCKET=true ;;
-        'g') INSTALL_AND_CREATE_GITEA_REPO=true INSTALL_AND_CREATE_MINIO_BUCKET=false WORKER_STATESTORE_TYPE=GitStateStore ;;
+        'g') INSTALL_AND_CREATE_MINIO_BUCKET=false WORKER_STATESTORE_TYPE=GitStateStore ;;
         *) usage 1 ;;
       esac
     done
     shift $(expr $OPTIND - 1)
+
+    # a Git worker state store needs Gitea
+    if [ "${WORKER_STATESTORE_TYPE}" = "GitStateStore" ]; then
+        INSTALL_AND_CREATE_GITEA_REPO=true
+    fi
 
     # we don't want to use the scarf images
     if [ ${KRATIX_DEVELOPER:-false} = true ]; then

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -13,7 +13,7 @@ CI=${CI:-false}
 
 INSTALL_AND_CREATE_MINIO_BUCKET=true
 INSTALL_AND_CREATE_GITEA_REPO=false
-WORKER_STATESTORE_TYPE=BucketStateStore
+WORKER_STATESTORE_TYPE="${WORKER_STATESTORE_TYPE:-BucketStateStore}"
 
 LOCAL_IMAGES_DIR=""
 VERSION=${VERSION:-"$(cd $ROOT; git branch --show-current)"}
@@ -44,7 +44,7 @@ usage() {
     echo -e "\t--git, -g                Use Gitea as local repository in place of default local MinIO"
     echo -e "\t--single-cluster, -s     Deploy Kratix on a Single cluster setup"
     echo -e "\t--third-cluster, -t      Deploy Kratix with a three cluster setup"
-    echo -e "\t--git-and-minio, -d      Install Gitea alongside the minio installation. Destinations still uses minio as statestore. Can't be used alongside --git"
+    echo -e "\t--git-and-minio, -d      Install Gitea alongside the minio installation. Destinations use minio as statestore unless WORKER_STATESTORE_TYPE=GitStateStore is set. Can't be used alongside --git"
     echo -e "\t--no-cert-manager        Don't install cert-manager"
     echo -e "\t--no-labels, -n          Don't apply any labels to the KinD clusters"
     exit "${1:-0}"
@@ -79,7 +79,7 @@ load_options() {
         'l') BUILD_KRATIX_IMAGES=true ;;
         'n') LABELS=false ;;
         'i') LOCAL_IMAGES_DIR=${OPTARG} ;;
-        'd') INSTALL_AND_CREATE_GITEA_REPO=true INSTALL_AND_CREATE_MINIO_BUCKET=true WORKER_STATESTORE_TYPE=BucketStateStore ;;
+        'd') INSTALL_AND_CREATE_GITEA_REPO=true INSTALL_AND_CREATE_MINIO_BUCKET=true ;;
         'g') INSTALL_AND_CREATE_GITEA_REPO=true INSTALL_AND_CREATE_MINIO_BUCKET=false WORKER_STATESTORE_TYPE=GitStateStore ;;
         *) usage 1 ;;
       esac


### PR DESCRIPTION
quick-start.sh unconditionally assigned `WORKER_STATESTORE_TYPE` at the top of the script and again in the `--git-and-minio` handler, so the value CI sets for the GitStateStore system-test job was silently discarded and both matrix jobs tested a bucket-backed worker destination. Respect an inherited value and only default to `BucketStateStore`.

Companion to syntasso/ci#49, which passes the matrix value into the job env — the git-backed path only becomes active once both are merged. Verified together (all specs green, git jobs confirmed running `GitStateStore`): https://github.com/syntasso/ci/actions/runs/32265820849

Fixes syntasso/kratix-private#200
