### PR TITLE
fix: allow deleting a WorkPlacement that never wrote to the state store

### DIFF
--- a/internal/controller/workplacement_controller.go
+++ b/internal/controller/workplacement_controller.go
@@ -616,7 +616,7 @@ func (w *workPlacementReconcileContext) deleteWorkPlacement(repo *Repository) (c
 
 		case v1alpha1.FilepathModeNone:
 			logging.Trace(w.logger, "handling file path mode none")
-			stateFile, err := w.readKratixStateFile(repo, false)
+			stateFile, err := w.readKratixStateFile(repo, true)
 			if err != nil {
 				logging.Debug(w.logger, "failed to read .kratix state file", "error", err)
 				return defaultRequeue, nil

--- a/internal/controller/workplacement_controller_test.go
+++ b/internal/controller/workplacement_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/syntasso/kratix/api/v1alpha1"
 	"github.com/syntasso/kratix/lib/compression"
 	"github.com/syntasso/kratix/lib/hash"
+	"github.com/syntasso/kratix/lib/writers"
 	"github.com/syntasso/kratix/lib/writers/writersfakes"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -214,6 +215,10 @@ var _ = Describe("WorkPlacementReconciler", func() {
 				Expect(workloadsToCreate).To(ConsistOf(expectedWorkloads))
 				Expect(workloadsToDelete).To(BeNil())
 
+				By("writing the state file before the workloads")
+				Expect(workloadsToCreate[0].Filepath).To(
+					Equal(fmt.Sprintf("%s.kratix/%s-%s.yaml", pathPrefix, workPlacement.Namespace, workPlacement.Name)))
+
 				By("fetching the right repository")
 				Expect(repositoryCache.GetRepositoryByTypeAndNameCallCount()).To(BeNumerically(">=", 1))
 				stateStoreType, stateStoreName := repositoryCache.GetRepositoryByTypeAndNameArgsForCall(0)
@@ -252,6 +257,58 @@ var _ = Describe("WorkPlacementReconciler", func() {
 				counts := collectWorkPlacementWriteMetrics(ctx, metricsReader)
 				Expect(counts).To(HaveKeyWithValue(telemetry.WorkPlacementWriteResultFailure, int64(30)))
 				Expect(counts).NotTo(HaveKey(telemetry.WorkPlacementWriteResultSuccess))
+			})
+
+			When("the work placement is deleted before its first successful write", func() {
+				It("cleans up without requiring the .kratix state file", func() {
+					_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+						Name: workPlacement.GetName(), Namespace: workPlacement.GetNamespace()}})
+					Expect(err).NotTo(HaveOccurred())
+
+					fakeWriter.ReadFileReturns(nil, writers.ErrFileNotFound)
+					Expect(fakeK8sClient.Delete(ctx, &workPlacement)).To(Succeed())
+
+					result, err := t.reconcileUntilCompletion(reconciler, &workPlacement)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					Expect(fakeWriter.DeleteFilesCallCount()).To(Equal(1))
+					workPlacementName, workloadsToDelete := fakeWriter.DeleteFilesArgsForCall(0)
+					Expect(workPlacementName).To(Equal(workPlacement.Name))
+					Expect(workloadsToDelete).To(ConsistOf(
+						fmt.Sprintf("%s/.kratix/%s-%s.yaml", destination.Spec.Path, workPlacement.Namespace, workPlacement.Name),
+					))
+
+					err = fakeK8sClient.Get(ctx, types.NamespacedName{
+						Name: workPlacement.GetName(), Namespace: workPlacement.GetNamespace()}, &v1alpha1.WorkPlacement{})
+					Expect(errors.IsNotFound(err)).To(BeTrue(), "work placement should be gone")
+				})
+			})
+
+			When("the .kratix state file goes missing after a successful write", func() {
+				It("deletes only the marker, never files it cannot account for", func() {
+					result, err := t.reconcileUntilCompletion(reconciler, &workPlacement)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					fakeWriter.ReadFileReturns(nil, writers.ErrFileNotFound)
+					Expect(fakeK8sClient.Delete(ctx, &workPlacement)).To(Succeed())
+
+					result, err = t.reconcileUntilCompletion(reconciler, &workPlacement)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+
+					Expect(fakeWriter.DeleteFilesCallCount()).To(Equal(1))
+					workPlacementName, workloadsToDelete := fakeWriter.DeleteFilesArgsForCall(0)
+					Expect(workPlacementName).To(Equal(workPlacement.Name))
+					Expect(workloadsToDelete).To(ConsistOf(
+						fmt.Sprintf("%s/.kratix/%s-%s.yaml", destination.Spec.Path, workPlacement.Namespace, workPlacement.Name),
+					))
+
+					err = fakeK8sClient.Get(ctx, types.NamespacedName{
+						Name: workPlacement.GetName(), Namespace: workPlacement.GetNamespace()}, &v1alpha1.WorkPlacement{})
+					Expect(errors.IsNotFound(err)).To(BeTrue(), "work placement should be gone")
+				})
 			})
 
 			When("deleting a work placement", func() {

--- a/util/git/git.go
+++ b/util/git/git.go
@@ -208,7 +208,7 @@ func serverNameWithoutPort(serverName string) string {
 }
 
 func parseTLSCertificatesFromPath(sourceFile string) ([]string, error) {
-	data, err := os.ReadFile(sourceFile) //nolint:gosec // G703: path validated in getCertificateForConnect
+	data, err := os.ReadFile(sourceFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On a `filepathMode: none` destination, cleanup reads the `.kratix` state file to know what to delete, and treats a missing file as an error. Only the first write creates that file, so a WorkPlacement deleted before its first write can never be removed. The resource request and the Work disappear normally, leaving nothing that points at the orphan.

A missing state file means the first write never happened, so there is nothing to clean up. We will accept deletions without the state file to avoid deadlocks, as the write to create the state file won't be hit after the resource is marked as deleted.

Closes #886