### PR TITLE
fix: only update the dep Work when it changes

### DIFF
--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1cs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2175,18 +2176,17 @@ func (r *PromiseReconciler) applyWorkForStaticDependencies(o opts, promise *v1al
 	var op string
 	if existingWork == nil {
 		op = "created"
+		setLastUpdatedAt(work)
 		err = r.Client.Create(o.ctx, work)
 	} else {
+		// An unconditional update would bump resourceVersion and retrigger this reconcile.
+		if equality.Semantic.DeepEqual(existingWork.Spec, work.Spec) {
+			return nil
+		}
+
 		op = "updated"
 		existingWork.Spec = work.Spec
-
-		ann := existingWork.GetAnnotations()
-		if ann == nil {
-			ann = map[string]string{}
-		}
-		ann[lastUpdatedAtAnnotation] = time.Now().Local().String()
-		existingWork.SetAnnotations(ann)
-
+		setLastUpdatedAt(existingWork)
 		err = r.Client.Update(o.ctx, existingWork)
 	}
 
@@ -2196,6 +2196,15 @@ func (r *PromiseReconciler) applyWorkForStaticDependencies(o opts, promise *v1al
 
 	logging.Debug(o.logger, "resource reconciled", "operation", op, "namespace", work.GetNamespace(), "name", work.GetName(), "gvk", work.GroupVersionKind().String())
 	return nil
+}
+
+func setLastUpdatedAt(work *v1alpha1.Work) {
+	ann := work.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	ann[lastUpdatedAtAnnotation] = time.Now().Local().String()
+	work.SetAnnotations(ann)
 }
 
 func (r *PromiseReconciler) deleteWorkForStaticDependencies(o opts, promise *v1alpha1.Promise) error {

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -1624,6 +1624,21 @@ var _ = Describe("PromiseController", func() {
 			})
 
 			When("it contains static dependencies", func() {
+				It("does not update the work when the dependencies are unchanged", func() {
+					work := getWork("kratix-platform-system", promise.GetName(), "", "")
+					resourceVersion := work.GetResourceVersion()
+
+					setReconcileConfigureWorkflowToReturnFinished()
+					result, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+						funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
+
+					updatedWork := getWork("kratix-platform-system", promise.GetName(), "", "")
+					Expect(updatedWork.GetResourceVersion()).To(Equal(resourceVersion))
+				})
+
 				It("re-reconciles until completion", func() {
 					Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
 					updatedPromise := promiseFromFile(promiseWithOnlyDepsUpdatedPath)

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -1625,8 +1625,10 @@ var _ = Describe("PromiseController", func() {
 
 			When("it contains static dependencies", func() {
 				It("does not update the work when the dependencies are unchanged", func() {
-					work := getWork("kratix-platform-system", promise.GetName(), "", "")
-					resourceVersion := work.GetResourceVersion()
+					works := &v1alpha1.WorkList{}
+					Expect(fakeK8sClient.List(ctx, works)).To(Succeed())
+					Expect(works.Items).To(HaveLen(1))
+					resourceVersion := works.Items[0].GetResourceVersion()
 
 					setReconcileConfigureWorkflowToReturnFinished()
 					result, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
@@ -1635,8 +1637,10 @@ var _ = Describe("PromiseController", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.ReconciliationInterval}))
 
-					updatedWork := getWork("kratix-platform-system", promise.GetName(), "", "")
-					Expect(updatedWork.GetResourceVersion()).To(Equal(resourceVersion))
+					updatedWorks := &v1alpha1.WorkList{}
+					Expect(fakeK8sClient.List(ctx, updatedWorks)).To(Succeed())
+					Expect(updatedWorks.Items).To(HaveLen(1))
+					Expect(updatedWorks.Items[0].GetResourceVersion()).To(Equal(resourceVersion))
 				})
 
 				It("re-reconciles until completion", func() {

--- a/test/system/assets/reconciliation/deps-promise-updated.yaml
+++ b/test/system/assets/reconciliation/deps-promise-updated.yaml
@@ -1,0 +1,16 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  name: depstest
+spec:
+  destinationSelectors:
+    - matchLabels:
+        environment: dev
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: depstest-defaults
+        namespace: default
+      data:
+        key1: value2

--- a/test/system/assets/reconciliation/deps-promise.yaml
+++ b/test/system/assets/reconciliation/deps-promise.yaml
@@ -1,0 +1,16 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  name: depstest
+spec:
+  destinationSelectors:
+    - matchLabels:
+        environment: dev
+  dependencies:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: depstest-defaults
+        namespace: default
+      data:
+        key1: value1

--- a/test/system/reconciliation_test.go
+++ b/test/system/reconciliation_test.go
@@ -131,4 +131,41 @@ var _ = Describe("Reconciliation", func() {
 		})
 
 	})
+
+	When("a Promise declares dependencies", func() {
+		var promiseName = "depstest"
+
+		workResourceVersion := func() string {
+			return platform.Kubectl("get", "work",
+				"-n", "kratix-platform-system",
+				"-l", "kratix.io/promise-name="+promiseName+",kratix.io/work-type=static-dependency",
+				"-o=jsonpath={.items[0].metadata.resourceVersion}")
+		}
+
+		BeforeEach(func() {
+			platform.Kubectl("apply", "-f", "assets/reconciliation/deps-promise.yaml")
+			Eventually(func() string {
+				return platform.Kubectl("get", "promise", promiseName)
+			}).Should(ContainSubstring("Available"))
+			Eventually(workResourceVersion).ShouldNot(BeEmpty())
+		})
+
+		AfterEach(func() {
+			platform.EventuallyKubectlDelete("promise", promiseName)
+		})
+
+		It("only updates the dependency Work when the dependencies change", func() {
+			By("not updating the Work while the dependencies are unchanged")
+			resourceVersion := workResourceVersion()
+			Consistently(workResourceVersion, 60*time.Second, 5*time.Second).Should(Equal(resourceVersion))
+
+			By("updating the Work once the dependencies change")
+			platform.Kubectl("apply", "-f", "assets/reconciliation/deps-promise-updated.yaml")
+			Eventually(workResourceVersion).ShouldNot(Equal(resourceVersion))
+
+			By("leaving the Work untouched once the Work is updated")
+			resourceVersion = workResourceVersion()
+			Consistently(workResourceVersion, 60*time.Second, 5*time.Second).Should(Equal(resourceVersion))
+		})
+	})
 })


### PR DESCRIPTION
## Context

do not update the timestamp annotation `kratix.io/last-updated-at` on every reconcile; update when there is a change or else keep it as it is.

closes #890 