### PR TITLE
fix: bump dependabot-auto-merge pin and pass required scripts_ref

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -18,7 +18,10 @@ permissions:
 
 jobs:
   dependabot-auto-merge:
-    uses: syntasso/ci/.github/workflows/dependabot-auto-merge.yaml@56813ff415b07475b08fdd05d5584be434a22d42 # main
+    uses: syntasso/ci/.github/workflows/dependabot-auto-merge.yaml@54007329cdcb283e1d830d7305e5d34549eecee2 # main
+    with:
+      # Must match the SHA on the uses: line above.
+      scripts_ref: 54007329cdcb283e1d830d7305e5d34549eecee2
     secrets:
       repo_token: ${{ secrets.GITHUB_TOKEN }}
       gh_action_trigger_token: ${{ secrets.GH_ACTION_TRIGGER_TOKEN }}


### PR DESCRIPTION
Bumps the reusable workflow pin to syntasso/ci@5400732 and adds the new required `scripts_ref` input (must match the `uses:` SHA).

Picks up:
- **syntasso/ci#53** — auto-merge logic extracted into tested scripts, plus correctness fixes: commit-level REST fallback when `gh pr checks` returns empty under `pull_request_target`, rerun/stale-suite handling, self-check exclusion, partial-snapshot guard.
- **syntasso/ci#54** — the 5-day supply-chain age gate for github-actions bumps **never fired** (ecosystem name mismatch: fetch-metadata emits `github_actions`, the check compared `github-actions`). This repo's pinned version has the same dead gate, so fresh action bumps currently auto-merge with no cooling-off period.

Verified end-to-end on enterprise-kratix#1401.