### PR TITLE
fix: "fix: reap orphaned git helper processes with tini as PID 1"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,6 @@ RUN --mount=target=. \
 FROM alpine/git
 WORKDIR /
 
-# tini is PID 1 so orphaned `git remote-https` helpers (left behind by every
-# `git fetch`/`git push`) get reaped instead of piling up as zombies until
-# the container hits its PID limit (kratix issue #892).
-RUN apk add --no-cache tini
-
 COPY --from=builder /out/manager /manager
 COPY --from=builder /out/pipeline-adapter /bin/pipeline-adapter
 
@@ -43,4 +38,4 @@ ENV HOME=/home/appuser
 
 USER 65532:65532
 
-ENTRYPOINT ["/sbin/tini", "--", "/manager"]
+ENTRYPOINT ["/manager"]

--- a/charts/kratix/templates/distribution.yaml
+++ b/charts/kratix/templates/distribution.yaml
@@ -304,8 +304,6 @@ spec:
             - --health-probe-bind-address=:8081
             - --leader-elect
           command:
-            - /sbin/tini
-            - --
             - /manager
           env:
             - name: PIPELINE_ADAPTER_IMG

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,8 +26,6 @@ spec:
         runAsNonRoot: true
       containers:
       - command:
-        - /sbin/tini
-        - --
         - /manager
         args:
           - "--health-probe-bind-address=:8081"


### PR DESCRIPTION
Reverts syntasso/kratix#893