### PR TITLE
chore: remove workflow counters from Promise and resource request status

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -156,12 +156,6 @@ type PromiseStatus struct {
 	Message string `json:"message,omitempty"`
 	// Kratix-managed status for this Promise. This field contains fields set by Kratix controllers.
 	Kratix KratixPromiseStatus `json:"kratix,omitempty"`
-	// Total number of Promise-level workflow pipelines
-	Workflows int64 `json:"workflows"`
-	// Number of Promise-level workflow pipelines that have completed successfully
-	WorkflowsSucceeded int64 `json:"workflowsSucceeded"`
-	// Number of Promise-level workflow pipelines that have failed
-	WorkflowsFailed int64 `json:"workflowsFailed"`
 	// Status of each required Promise dependency
 	RequiredPromises []RequiredPromiseStatus `json:"requiredPromises,omitempty"`
 	// List of other Promises that depend on this Promise
@@ -535,14 +529,8 @@ const (
 )
 
 func (p *Promise) ClearPipelineExecutionStatus() bool {
-	changed := p.Status.Workflows != 0 ||
-		p.Status.WorkflowsSucceeded != 0 ||
-		p.Status.WorkflowsFailed != 0 ||
-		len(p.Status.Kratix.Workflows.Pipelines) != 0
+	changed := len(p.Status.Kratix.Workflows.Pipelines) != 0
 
-	p.Status.Workflows = 0
-	p.Status.WorkflowsSucceeded = 0
-	p.Status.WorkflowsFailed = 0
 	p.Status.Kratix.Workflows.Pipelines = nil
 	return changed
 }

--- a/config/crd/bases/platform.kratix.io_promises.yaml
+++ b/config/crd/bases/platform.kratix.io_promises.yaml
@@ -349,24 +349,6 @@ spec:
                 description: Version of the Promise, derived from the PromiseRelease
                   if installed via one
                 type: string
-              workflows:
-                description: Total number of Promise-level workflow pipelines
-                format: int64
-                type: integer
-              workflowsFailed:
-                description: Number of Promise-level workflow pipelines that have
-                  failed
-                format: int64
-                type: integer
-              workflowsSucceeded:
-                description: Number of Promise-level workflow pipelines that have
-                  completed successfully
-                format: int64
-                type: integer
-            required:
-            - workflows
-            - workflowsFailed
-            - workflowsSucceeded
             type: object
         type: object
     served: true

--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -243,7 +243,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	if updated, err := r.ensureConfigureWorkflowStatus(ctx, logger, rr, pipelineResources); updated || err != nil {
+	if updated, err := r.ensureConfigureWorkflowStatus(ctx, rr, pipelineResources); updated || err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -289,7 +289,7 @@ func (r *DynamicResourceRequestController) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, nil
 	}
 
-	return r.reconcileAfterConfigure(ctx, logger, opts, rr, promise, pipelineResources, bindingVersion, promiseRevisionUsed)
+	return r.reconcileAfterConfigure(ctx, logger, opts, rr, promise, bindingVersion, promiseRevisionUsed)
 }
 
 func (r *DynamicResourceRequestController) syncResourceBindingUpgradeStatusOnPassiveRequeue(ctx context.Context, logger logr.Logger, promiseName string, rr *unstructured.Unstructured, promiseRevisionUsed *v1alpha1.PromiseRevision) error {
@@ -320,7 +320,6 @@ func (r *DynamicResourceRequestController) reconcileAfterConfigure(
 	opts opts,
 	rr *unstructured.Unstructured,
 	promise *v1alpha1.Promise,
-	pipelineResources []v1alpha1.PipelineJobResources,
 	bindingVersion string,
 	promiseRevisionUsed *v1alpha1.PromiseRevision,
 ) (ctrl.Result, error) {
@@ -337,10 +336,10 @@ func (r *DynamicResourceRequestController) reconcileAfterConfigure(
 		if versionUpdated {
 			return ctrl.Result{}, r.Client.Status().Update(ctx, rr)
 		}
-		return r.nextReconciliation(logger, promiseRevisionUsed), r.cleanupWorkflowCountersAndExecution(ctx, logger, rr)
+		return r.nextReconciliation(logger, promiseRevisionUsed), nil
 	}
 
-	statusUpdated, err := r.ensureResourceStatus(ctx, logger, rr, promise, pipelineResources, bindingVersion, promiseRevisionUsed)
+	statusUpdated, err := r.ensureResourceStatus(ctx, logger, rr, promise, bindingVersion, promiseRevisionUsed)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -427,7 +426,6 @@ func (r *DynamicResourceRequestController) ensureResourceStatus(
 	logger logr.Logger,
 	rr *unstructured.Unstructured,
 	promise *v1alpha1.Promise,
-	pipelineResources []v1alpha1.PipelineJobResources,
 	bindingVersion string,
 	promiseRevisionUsed *v1alpha1.PromiseRevision,
 ) (bool, error) {
@@ -437,7 +435,7 @@ func (r *DynamicResourceRequestController) ensureResourceStatus(
 	}
 	workLabels := resourceutil.GetWorkLabels(r.PromiseIdentifier, rr.GetName(), rrNamespace, "", v1alpha1.WorkTypeResource)
 
-	statusUpdate, err := r.generateResourceStatus(ctx, logger, rr, int64(len(pipelineResources)), workLabels, bindingVersion, promiseRevisionUsed)
+	statusUpdate, err := r.generateResourceStatus(ctx, logger, rr, workLabels, bindingVersion, promiseRevisionUsed)
 	if err != nil {
 		return false, err
 	}
@@ -726,15 +724,10 @@ func (r *DynamicResourceRequestController) determineResourceBindingVersion(ctx c
 
 func (r *DynamicResourceRequestController) ensureConfigureWorkflowStatus(
 	ctx context.Context,
-	logger logr.Logger,
 	rr *unstructured.Unstructured,
 	pipelineResources []v1alpha1.PipelineJobResources,
 ) (updated bool, err error) {
-	statusChanged := false
-	if resourceutil.GetWorkflowsCounterStatus(rr, "workflows") != int64(len(pipelineResources)) {
-		resourceutil.SetStatus(rr, logger, "workflows", int64(len(pipelineResources)))
-		statusChanged = true
-	}
+	statusChanged := removeWorkflowCounters(rr)
 
 	workflowStatusChanged, err := ensureRRKratixWorkflowStatusIsSetup(rr, pipelineResources)
 	if err != nil {
@@ -818,7 +811,7 @@ func (r *DynamicResourceRequestController) reconcileSuspendedWorkflow(
 }
 
 func (r *DynamicResourceRequestController) generateResourceStatus(ctx context.Context, logger logr.Logger, rr *unstructured.Unstructured,
-	numberOfPipelines int64, workLabels map[string]string, bindingVersion string, promiseRevision *v1alpha1.PromiseRevision,
+	workLabels map[string]string, bindingVersion string, promiseRevision *v1alpha1.PromiseRevision,
 ) (bool, error) {
 	failed, misplaced, pending, ready, err := r.getWorksStatus(ctx, logger, rr, workLabels)
 	if err != nil {
@@ -826,10 +819,9 @@ func (r *DynamicResourceRequestController) generateResourceStatus(ctx context.Co
 	}
 	worksSucceededUpdate := r.updateWorksSucceededCondition(rr, failed, pending, ready, misplaced)
 	reconciledUpdate := r.updateReconciledCondition(rr)
-	workflowsCounterStatusUpdate := r.generateWorkflowsCounterStatus(logger, rr, numberOfPipelines)
 	promiseVersionUpdate := r.updatePromiseVersionStatus(logger, rr, bindingVersion, promiseRevision)
 
-	return worksSucceededUpdate || reconciledUpdate || workflowsCounterStatusUpdate || promiseVersionUpdate, nil
+	return worksSucceededUpdate || reconciledUpdate || promiseVersionUpdate, nil
 }
 
 func (r *DynamicResourceRequestController) updateWorksSucceededCondition(rr *unstructured.Unstructured, failed, pending, _, misplaced []string) bool {
@@ -1153,42 +1145,17 @@ func (r *DynamicResourceRequestController) getWorksStatus(ctx context.Context, l
 	return failed, misplaced, pending, ready, nil
 }
 
-func (r *DynamicResourceRequestController) generateWorkflowsCounterStatus(logger logr.Logger, rr *unstructured.Unstructured, numOfPipelines int64) bool {
-	completedCond := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
-
-	desiredWorkflows := numOfPipelines
-	var desiredWorkflowsSucceeded int64
-
-	if completedCond != nil && completedCond.Status == v1.ConditionTrue {
-		desiredWorkflowsSucceeded = numOfPipelines
+// The resource request status schema preserves unknown fields, so the workflow
+// counters written by older versions of Kratix stay until they are removed here.
+func removeWorkflowCounters(rr *unstructured.Unstructured) bool {
+	removed := false
+	for _, counter := range []string{"workflows", "workflowsSucceeded", "workflowsFailed"} {
+		if _, found, _ := unstructured.NestedFieldNoCopy(rr.Object, "status", counter); found {
+			unstructured.RemoveNestedField(rr.Object, "status", counter)
+			removed = true
+		}
 	}
-
-	if resourceutil.GetWorkflowsCounterStatus(rr, "workflows") != desiredWorkflows ||
-		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsSucceeded") != desiredWorkflowsSucceeded {
-
-		resourceutil.SetStatus(rr, logger,
-			"workflows", desiredWorkflows,
-			"workflowsSucceeded", desiredWorkflowsSucceeded,
-			"workflowsFailed", int64(0),
-		)
-
-		return true
-	}
-	return false
-}
-
-func (r *DynamicResourceRequestController) cleanupWorkflowCountersAndExecution(ctx context.Context, logger logr.Logger,
-	rr *unstructured.Unstructured,
-) error {
-	if resourceutil.GetWorkflowsCounterStatus(rr, "workflows") != 0 ||
-		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsSucceeded") != 0 ||
-		resourceutil.GetWorkflowsCounterStatus(rr, "workflowsFailed") != 0 {
-
-		resourceutil.SetStatus(rr, logger, "workflows", int64(0), "workflowsSucceeded", int64(0), "workflowsFailed", int64(0))
-		unstructured.RemoveNestedField(rr.Object, "status", "kratix", "workflows", "pipelines")
-		return r.Client.Status().Update(ctx, rr)
-	}
-	return nil
+	return removed
 }
 
 func ensureRRKratixWorkflowStatusIsSetup(rr *unstructured.Unstructured, pipelines []v1alpha1.PipelineJobResources) (bool, error) {

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -135,23 +135,9 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				Expect(strings.TrimSpace(destinationSelectors)).To(Equal(`- matchlabels: environment: dev source: promise`))
 			})
 
-			// TODO: remove deprecated workflows counter in the next release
-			By("setting the workflows counter to the number of pipelines", func() {
-				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
-				Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflows")).To(Equal(int64(1)))
-			})
-
 			By("not requeuing, since the controller is watching the job", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
-			})
-
-			By("setting status.workflows to the number of configure pipelines", func() {
-				setReconcileConfigureWorkflowToReturnFinished()
-				_, err = t.reconcileUntilCompletion(reconciler, resReq)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
-				Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflows")).To(Equal(int64(1)))
 			})
 
 			By("finishing the creation once the job is finished", func() {
@@ -461,7 +447,6 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			setConfigureWorkflowStatus(resReq, v1.ConditionTrue, lastTransitionTime)
 			setWorksSucceeded(resReq)
 			setReconciled(resReq)
-			setWorkflowsCounterStatus(resReq)
 			Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
 
 			request = ctrl.Request{NamespacedName: types.NamespacedName{Name: resReqNameNamespace.Name, Namespace: resReqNameNamespace.Namespace}}
@@ -543,7 +528,6 @@ var _ = Describe("DynamicResourceRequestController", func() {
 			})
 			setWorksSucceeded(resReq)
 			setReconciled(resReq)
-			setWorkflowsCounterStatus(resReq)
 			Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
 
 			request = ctrl.Request{NamespacedName: types.NamespacedName{Name: resReqNameNamespace.Name, Namespace: resReqNameNamespace.Namespace}}
@@ -1198,17 +1182,39 @@ var _ = Describe("DynamicResourceRequestController", func() {
 
 		Describe("Workflows", func() {
 			When("there are no resource configure pipelines", func() {
-				It("sets all workflows counter status to 0", func() {
+				BeforeEach(func() {
 					promise.Spec.Workflows.Resource.Configure = nil
 					Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
 					createPromiseRevision(fakeK8sClient, promise, "v1.1.0")
+				})
+
+				It("clears the workflow pipeline status", func() {
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+
+					pipelines, _, err := unstructured.NestedSlice(resReq.Object, "status", "kratix", "workflows", "pipelines")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pipelines).To(BeEmpty())
+				})
+
+				It("removes workflow counters left behind by an older Kratix", func() {
+					resourceutil.SetStatus(resReq, l,
+						"workflows", int64(1),
+						"workflowsSucceeded", int64(1),
+						"workflowsFailed", int64(0),
+					)
+					Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
 
 					_, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
-					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflows")).To(Equal(int64(0)))
-					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflowsSucceeded")).To(Equal(int64(0)))
-					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflowsFailed")).To(Equal(int64(0)))
+
+					Expect(resReq.Object["status"]).NotTo(SatisfyAny(
+						HaveKey("workflows"),
+						HaveKey("workflowsSucceeded"),
+						HaveKey("workflowsFailed"),
+					))
 				})
 			})
 
@@ -1230,8 +1236,8 @@ var _ = Describe("DynamicResourceRequestController", func() {
 				))
 			})
 
-			When("all configure pipelines are successful", func() {
-				It("sets workflowsFailed to 0 and workflows should match workflowsSucceeded", func() {
+			When("the resource request has workflow counters left behind by an older Kratix", func() {
+				It("removes them from the status", func() {
 					resourceutil.SetStatus(resReq, l,
 						"workflows", int64(1),
 						"workflowsSucceeded", int64(0),
@@ -1239,12 +1245,16 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					)
 					Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
 					setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
+
 					_, err := t.reconcileUntilCompletion(reconciler, resReq)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
-					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflows")).To(Equal(int64(1)))
-					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflowsSucceeded")).To(Equal(int64(1)))
-					Expect(resourceutil.GetWorkflowsCounterStatus(resReq, "workflowsFailed")).To(Equal(int64(0)))
+
+					Expect(resReq.Object["status"]).NotTo(SatisfyAny(
+						HaveKey("workflows"),
+						HaveKey("workflowsSucceeded"),
+						HaveKey("workflowsFailed"),
+					))
 				})
 			})
 		})
@@ -2655,15 +2665,6 @@ func setReconciled(resReq *unstructured.Unstructured) {
 		Reason:  "Reconciled",
 		Message: "Reconciled",
 	})
-	Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
-}
-
-func setWorkflowsCounterStatus(resReq *unstructured.Unstructured) {
-	if resReq.Object["status"] == nil {
-		resReq.Object["status"] = map[string]interface{}{}
-	}
-	resourceutil.SetStatus(resReq, l, "workflows", int64(1),
-		"workflowsSucceeded", int64(1), "workflowsFailed", int64(0))
 	Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
 }
 

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -320,7 +320,7 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 	updateConditionOnPromise(promise, promiseAvailableStatusCondition(timeStamp))
 
-	statusUpdate, err := r.generateConditions(ctx, promise, r.getWorkflowsCount(promise))
+	statusUpdate, err := r.generateConditions(ctx, promise)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -517,35 +517,15 @@ func resetPromiseWorkflowPipelinesToPending(promise *v1alpha1.Promise) {
 	}
 }
 
-func (r *PromiseReconciler) generateConditions(ctx context.Context, promise *v1alpha1.Promise, numberOfPipelines int64) (bool, error) {
+func (r *PromiseReconciler) generateConditions(ctx context.Context, promise *v1alpha1.Promise) (bool, error) {
 	failed, misplaced, pending, ready, err := r.getWorksStatus(ctx, promise)
 	if err != nil {
 		return false, err
 	}
 	worksSucceededUpdate := r.updateWorksSucceededCondition(promise, failed, pending, ready, misplaced)
 	reconciledUpdate := r.updateReconciledCondition(promise)
-	workflowsCounterStatusUpdate := r.generateWorkflowsCounterStatus(promise, numberOfPipelines)
 
-	return worksSucceededUpdate || reconciledUpdate || workflowsCounterStatusUpdate, nil
-}
-
-func (r *PromiseReconciler) generateWorkflowsCounterStatus(promise *v1alpha1.Promise, numOfPipelines int64) bool {
-	desiredWorkflows := numOfPipelines
-	var desiredWorkflowsSucceeded int64
-
-	completedCond := promise.GetCondition(string(resourceutil.ConfigureWorkflowCompletedCondition))
-	if completedCond != nil && completedCond.Status == metav1.ConditionTrue {
-		desiredWorkflowsSucceeded = numOfPipelines
-	}
-
-	// TODO: remove deprecated promise.Status.Workflows, promise.Status.WorkflowsSucceeded, promise.Status.WorkflowsFailed
-	if promise.Status.Workflows != desiredWorkflows || promise.Status.WorkflowsSucceeded != desiredWorkflowsSucceeded {
-		promise.Status.Workflows = desiredWorkflows
-		promise.Status.WorkflowsSucceeded = desiredWorkflowsSucceeded
-		promise.Status.WorkflowsFailed = 0
-		return true
-	}
-	return false
+	return worksSucceededUpdate || reconciledUpdate, nil
 }
 
 func (r *PromiseReconciler) updateReconciledCondition(promise *v1alpha1.Promise) bool {
@@ -1013,12 +993,6 @@ func (r *PromiseReconciler) reconcileDependenciesAndPromiseWorkflows(o opts, pro
 
 		// No workflow to run, abort
 		return false, nil, nil
-	}
-
-	if promise.Status.Workflows != pipelineCount {
-		/* New pipelines have been added, regenerate the pipelines execution statuses */
-		promise.Status.Workflows = pipelineCount
-		return false, nil, r.Client.Status().Update(o.ctx, promise)
 	}
 
 	if requeue, err := r.ensureKratixWorkflowStatusIsSetup(promise); err != nil || requeue {
@@ -2075,18 +2049,6 @@ func setStatusFieldsOnCRD(rrCRD *apiextensionsv1.CustomResourceDefinition) {
 					Type: "string",
 				},
 				"observedGeneration": {
-					Type:   "integer",
-					Format: "int64",
-				},
-				"workflows": {
-					Type:   "integer",
-					Format: "int64",
-				},
-				"workflowsSucceeded": {
-					Type:   "integer",
-					Format: "int64",
-				},
-				"workflowsFailed": {
 					Type:   "integer",
 					Format: "int64",
 				},

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -117,21 +117,6 @@ var _ = Describe("PromiseController", func() {
 						Expect(ok).To(BeTrue(), ".status.message did not exist. Spec %v", status)
 						Expect(message.Type).To(Equal("string"))
 
-						workflows, ok := status.Properties["workflows"]
-						Expect(ok).To(BeTrue(), ".status.workflows did not exist. Spec %v", status)
-						Expect(workflows.Type).To(Equal("integer"))
-						Expect(workflows.Format).To(Equal("int64"))
-
-						workflowsSucceeded, ok := status.Properties["workflowsSucceeded"]
-						Expect(ok).To(BeTrue(), ".status.workflowsSucceeded did not exist. Spec %v", status)
-						Expect(workflowsSucceeded.Type).To(Equal("integer"))
-						Expect(workflowsSucceeded.Format).To(Equal("int64"))
-
-						workflowsFailed, ok := status.Properties["workflowsFailed"]
-						Expect(ok).To(BeTrue(), ".status.workflowsFailed did not exist. Spec %v", status)
-						Expect(workflowsFailed.Type).To(Equal("integer"))
-						Expect(workflowsFailed.Format).To(Equal("int64"))
-
 						kratixStatus, ok := status.Properties["kratix"]
 						Expect(ok).To(BeTrue(), ".status.kratix did not exist. Spec %v", status)
 						Expect(kratixStatus.Type).To(Equal("object"))
@@ -210,12 +195,6 @@ var _ = Describe("PromiseController", func() {
 						Expect(promise.Status.Kind).To(Equal("redis"))
 						Expect(promise.Status.Kratix.Kind).To(Equal("redis"))
 						Expect(promise.Status.Kratix.Version).To(Equal("v1.1.0"))
-					})
-
-					By("updating the status with workflow counters all to zero", func() {
-						Expect(promise.Status.Workflows).To(Equal(int64(0)))
-						Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(0)))
-						Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
 					})
 
 					By("creating the resources for the dynamic controller", func() {
@@ -806,10 +785,6 @@ var _ = Describe("PromiseController", func() {
 						Expect(role.GetLabels()).To(Equal(promiseCommonLabels))
 					})
 
-					By("setting the workflows counter to the number of pipelines", func() {
-						Expect(promise.Status.Workflows).To(Equal(int64(2)))
-					})
-
 					By("associates the new role with the new service account", func() {
 						Expect(resources[3]).To(BeAssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
 						binding := resources[3].(*rbacv1.ClusterRoleBinding)
@@ -828,15 +803,6 @@ var _ = Describe("PromiseController", func() {
 						Expect(err).NotTo(HaveOccurred())
 					})
 
-					By("setting status.workflows to the number of configure pipelines", func() {
-						setReconcileConfigureWorkflowToReturnFinished()
-						_, err = t.reconcileUntilCompletion(reconciler, promise)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
-
-						Expect(promise.Status.Workflows).To(Equal(int64(2)))
-					})
-
 					By("finishing the creation once the job is finished and publishes event", func() {
 						setReconcileConfigureWorkflowToReturnFinished()
 						markPromiseWorkflowAsCompleted(fakeK8sClient, promise)
@@ -850,13 +816,6 @@ var _ = Describe("PromiseController", func() {
 						Eventually(eventRecorder.Events).Should(Receive(ContainSubstring(
 							"Normal ConfigureWorkflowCompleted All workflows completed",
 						)))
-					})
-
-					By("updating the status of the promise workflow", func() {
-						Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
-						Expect(promise.Status.Workflows).To(Equal(int64(2)))
-						Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
-						Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(2)))
 					})
 
 					By("not creating a Work for the empty static dependencies", func() {

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -339,25 +339,31 @@ func GetStatus(rr *unstructured.Unstructured, key string) string {
 	return nestedMap[key].(string)
 }
 
-func GetWorkflowsCounterStatus(rr *unstructured.Unstructured, key string) int64 {
-	if rr.Object["status"] == nil {
+// CountPipelinesInPhase returns how many workflow pipelines are in the given
+// phase, or -1 when the pipeline status has not been initialised yet.
+func CountPipelinesInPhase(obj *unstructured.Unstructured, phase string) int64 {
+	pipelines, found, err := unstructured.NestedSlice(obj.Object, "status", "kratix", "workflows", "pipelines")
+	if err != nil || !found {
 		return -1
 	}
 
-	nestedMap := rr.Object["status"].(map[string]interface{})
-	value := nestedMap[key]
-	if value == nil {
-		return -1
+	var count int64
+	for _, p := range pipelines {
+		pipeline, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if pipeline["phase"] == phase {
+			count++
+		}
 	}
 
-	switch v := value.(type) {
-	case float64:
-		return int64(v)
-	case int64:
-		return v
-	}
+	return count
+}
 
-	return -1
+// HasPipelineInPhase reports whether any workflow pipeline is in the given phase.
+func HasPipelineInPhase(obj *unstructured.Unstructured, phase string) bool {
+	return CountPipelinesInPhase(obj, phase) > 0
 }
 
 func MarkCurrentPipelineAsSucceeded(rr *unstructured.Unstructured, logger logr.Logger, job *batchv1.Job) error {
@@ -432,7 +438,39 @@ func MarkCurrentPipelineAs(status string, rr *unstructured.Unstructured, logger 
 	return unstructured.SetNestedSlice(rr.Object, workflows, "status", "kratix", "workflows", "pipelines")
 }
 
+// MarkPipelinesAsSucceeded marks the first count pipelines as succeeded, so the
+// status catches up with pipeline completions no reconciliation ever observed.
+func MarkPipelinesAsSucceeded(obj *unstructured.Unstructured, count int64) error {
+	pipelines, found, err := unstructured.NestedSlice(obj.Object, "status", "kratix", "workflows", "pipelines")
+	if err != nil || !found {
+		return err
+	}
+
+	for i := range min(int(count), len(pipelines)) {
+		pipeline, ok := pipelines[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		previousPhase, _ := pipeline["phase"].(string)
+		if previousPhase == v1alpha1.WorkflowPhaseSucceeded {
+			continue
+		}
+		if previousPhase == v1alpha1.WorkflowPhaseSuspended {
+			delete(pipeline, "message")
+		}
+		pipeline["phase"] = v1alpha1.WorkflowPhaseSucceeded
+		pipeline["lastTransitionTime"] = metav1.Now().Format(time.RFC3339)
+		pipelines[i] = pipeline
+	}
+
+	return unstructured.SetNestedSlice(obj.Object, pipelines, "status", "kratix", "workflows", "pipelines")
+}
+
 func ResetPipelineStatusToPending(obj *unstructured.Unstructured, pipelines []v1alpha1.PipelineJobResources) error {
+	if obj.Object["status"] == nil {
+		obj.Object["status"] = map[string]any{}
+	}
+
 	workflows := make([]any, 0, len(pipelines))
 	for _, pipeline := range pipelines {
 		workflows = append(workflows, map[string]any{

--- a/lib/workflow/reconciler.go
+++ b/lib/workflow/reconciler.go
@@ -180,7 +180,6 @@ type workflowState struct {
 	restartFromStart     bool
 	resumeFromSuspended  bool
 	suspendedPipelineIdx int
-	desiredFailedCount   *int64
 	desiredPipelinePhase string
 	desiredPipelineJob   *batchv1.Job
 }
@@ -295,45 +294,29 @@ func determineWorkflowState(opts Opts) (*workflowState, error) {
 }
 
 func reconcileWorkflowStatus(opts Opts, state *workflowState) (passiveRequeue bool, err error) {
-	//these are set to -1 if unset in the status
-	currentSucceededCount := resourceutil.GetWorkflowsCounterStatus(opts.parentObject, "workflowsSucceeded")
-	currentFailedCount := resourceutil.GetWorkflowsCounterStatus(opts.parentObject, "workflowsFailed")
+	//this is -1 if the pipeline status has not been initialised yet
+	succeededPipelines := resourceutil.CountPipelinesInPhase(opts.parentObject, v1alpha1.WorkflowPhaseSucceeded)
 
-	if currentFailedCount == -1 && state.desiredFailedCount == nil {
-		// this means the failed count has never been set, so we should initialise it to 0 to avoid drift
-		state.desiredFailedCount = new(int64)
-		*state.desiredFailedCount = 0
-	}
-
-	succeededCountDrifted := currentSucceededCount != state.completedCount
+	succeededCountDrifted := succeededPipelines != state.completedCount
 	shouldResetForManualRetry := (state.manualReconcile || state.restartFromStart) &&
-		(currentFailedCount != 0 || currentSucceededCount != 0)
-	failedCountDrifted := state.desiredFailedCount != nil && currentFailedCount != *state.desiredFailedCount
+		(succeededPipelines != 0 || resourceutil.HasPipelineInPhase(opts.parentObject, v1alpha1.WorkflowPhaseFailed))
 	pipelinePhaseDrifted := state.desiredPipelineJob != nil && state.desiredPipelinePhase != ""
 
-	if !succeededCountDrifted && !shouldResetForManualRetry && !failedCountDrifted && !pipelinePhaseDrifted {
+	if !succeededCountDrifted && !shouldResetForManualRetry && !pipelinePhaseDrifted {
 		return false, nil
 	}
 
-	if succeededCountDrifted {
-		resourceutil.SetStatus(opts.parentObject, opts.logger, "workflowsSucceeded", state.completedCount)
-		if state.completedCount > 0 {
-			if err = resourceutil.MarkCurrentPipelineAsSucceeded(opts.parentObject, opts.logger, state.mostRecentJob); err != nil {
-				logging.Error(opts.logger, err, "failed to mark current pipeline as succeeded")
-				return false, err
-			}
-		}
-	}
-
-	if shouldResetForManualRetry || (succeededCountDrifted && state.completedCount == 0) {
-		resourceutil.SetStatus(opts.parentObject, opts.logger, "workflowsFailed", int64(0))
-		if err = resourceutil.ResetPipelineStatusToPending(opts.parentObject, opts.Resources); err != nil {
+	if succeededCountDrifted && state.completedCount > 0 {
+		if err = resourceutil.MarkPipelinesAsSucceeded(opts.parentObject, state.completedCount); err != nil {
+			logging.Error(opts.logger, err, "failed to mark completed pipelines as succeeded")
 			return false, err
 		}
 	}
 
-	if failedCountDrifted {
-		resourceutil.SetStatus(opts.parentObject, opts.logger, "workflowsFailed", *state.desiredFailedCount)
+	if shouldResetForManualRetry || (succeededCountDrifted && state.completedCount == 0) {
+		if err = resourceutil.ResetPipelineStatusToPending(opts.parentObject, opts.Resources); err != nil {
+			return false, err
+		}
 	}
 
 	if pipelinePhaseDrifted {
@@ -430,8 +413,6 @@ func setFailedConditionAndEvents(opts Opts, state *workflowState, pipeline v1alp
 		resourceutil.MarkConfigureWorkflowAsFailed(opts.logger, opts.parentObject, pipeline.Name)
 		resourceutil.MarkReconciledFailing(opts.parentObject, resourceutil.ConfigureWorkflowCompletedFailedReason)
 
-		failedCount := int64(1)
-		state.desiredFailedCount = &failedCount
 		state.desiredPipelinePhase = v1alpha1.WorkflowPhaseFailed
 		state.desiredPipelineJob = state.mostRecentJob
 

--- a/lib/workflow/reconciler_test.go
+++ b/lib/workflow/reconciler_test.go
@@ -50,8 +50,6 @@ var _ = Describe("Workflow Reconciler", func() {
 				Kind:       "Promise",
 			},
 			Status: v1alpha1.PromiseStatus{
-				WorkflowsSucceeded: 0,
-				WorkflowsFailed:    0,
 				Kratix: v1alpha1.KratixPromiseStatus{
 					Workflows: v1alpha1.WorkflowStatus{
 						Pipelines: []v1alpha1.WorkflowPipelineStatus{
@@ -155,26 +153,6 @@ var _ = Describe("Workflow Reconciler", func() {
 							"Normal PipelineStarted Configure Pipeline started: pipeline-1")))
 					})
 				})
-			})
-		})
-
-		When("workflow counter statuses are stale", func() {
-			BeforeEach(func() {
-				resourceutil.SetStatus(uPromise, logger, "workflowsSucceeded", int64(1), "workflowsFailed", int64(1))
-				Expect(fakeK8sClient.Status().Update(ctx, uPromise)).To(Succeed())
-			})
-
-			It("resets workflow counters to match the current pipeline state", func() {
-				opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, workflowPipelines, "promise", 5, namespace)
-				passiveRequeue, err := workflow.ReconcileConfigure(opts)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(passiveRequeue).To(BeTrue())
-				Expect(listJobs(namespace)).To(BeEmpty())
-
-				updatedPromise := &v1alpha1.Promise{}
-				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: promise.Name}, updatedPromise)).To(Succeed())
-				Expect(updatedPromise.Status.WorkflowsSucceeded).To(Equal(int64(0)))
-				Expect(updatedPromise.Status.WorkflowsFailed).To(Equal(int64(0)))
 			})
 		})
 
@@ -328,8 +306,6 @@ var _ = Describe("Workflow Reconciler", func() {
 				By("correctly updating the resource status", func() {
 					requeue := reconcile(opts, &promise)
 					Expect(requeue).To(BeTrue())
-					Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(0)))
-					Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].Phase).To(Equal("Running"))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[1].Phase).To(Equal("Pending"))
 				})
@@ -352,8 +328,6 @@ var _ = Describe("Workflow Reconciler", func() {
 				By("updating the status once the job is completed", func() {
 					requeue := reconcile(opts, &promise)
 					Expect(requeue).To(BeTrue())
-					Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(1)))
-					Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].Phase).To(Equal("Succeeded"))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].LastTransitionTime).NotTo(BeZero())
 					Expect(promise.Status.Kratix.Workflows.Pipelines[1].Phase).To(Equal("Pending"))
@@ -362,8 +336,6 @@ var _ = Describe("Workflow Reconciler", func() {
 				By("updating the next pipeline status to", func() {
 					requeue := reconcile(opts, &promise)
 					Expect(requeue).To(BeTrue())
-					Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(1)))
-					Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].Phase).To(Equal("Succeeded"))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].LastTransitionTime).NotTo(BeZero())
 					Expect(promise.Status.Kratix.Workflows.Pipelines[1].Phase).To(Equal("Running"))
@@ -381,8 +353,6 @@ var _ = Describe("Workflow Reconciler", func() {
 				By("updating the status once the job is completed", func() {
 					requeue := reconcile(opts, &promise)
 					Expect(requeue).To(BeTrue())
-					Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(2)))
-					Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].Phase).To(Equal("Succeeded"))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].LastTransitionTime).NotTo(BeZero())
 					Expect(promise.Status.Kratix.Workflows.Pipelines[1].Phase).To(Equal("Succeeded"))
@@ -463,8 +433,6 @@ var _ = Describe("Workflow Reconciler", func() {
 				})
 
 				It("marks the pipeline as failed", func() {
-					Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(0)))
-					Expect(promise.Status.WorkflowsFailed).To(Equal(int64(1)))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].Phase).To(Equal("Failed"))
 					Expect(promise.Status.Kratix.Workflows.Pipelines[0].LastTransitionTime).ToNot(BeZero())
 				})
@@ -528,7 +496,7 @@ var _ = Describe("Workflow Reconciler", func() {
 						BeforeEach(func() {
 							labelPromiseForManualReconciliation("redis")
 							newWorkflowPipelines, uPromise = setupTest(promise, pipelines)
-							setParentWorkflowCountersStatus(uPromise, 0)
+							setParentPipelinesSucceeded(uPromise, newWorkflowPipelines, 0)
 							opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, newWorkflowPipelines, "promise", 5, namespace)
 							passiveRequeue, err = workflow.ReconcileConfigure(opts)
 							Expect(passiveRequeue).To(BeTrue())
@@ -556,20 +524,19 @@ var _ = Describe("Workflow Reconciler", func() {
 					When("the reconciliation is triggered and the previously failing job succeeds", func() {
 						It("updates the promise status successfully", func() {
 							Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: promise.Name}, &promise)).To(Succeed())
-							Expect(promise.Status.WorkflowsFailed).To(Equal(int64(1)))
-							Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(0)))
+							Expect(promise.Status.Kratix.Workflows.Pipelines[0].Phase).To(Equal(v1alpha1.WorkflowPhaseFailed))
 
 							// Trigger the workflow via the manual reconciliation, running the pipeline from the start
 							labelPromiseForManualReconciliation("redis")
 							newWorkflowPipelines, uPromise := setupTest(promise, pipelines)
-							setParentWorkflowCountersStatus(uPromise, 0)
+							setParentPipelinesSucceeded(uPromise, newWorkflowPipelines, 0)
 							opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, newWorkflowPipelines, "promise", 5, namespace)
 							passiveRequeue, err = workflow.ReconcileConfigure(opts)
 							Expect(passiveRequeue).To(BeTrue())
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: promise.Name}, &promise)).To(Succeed())
-							Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
+							Expect(countPromisePipelinesInPhase(&promise, v1alpha1.WorkflowPhaseFailed)).To(Equal(0))
 
 							// Mark the job created by the first pipeline as complete
 							markJobAsComplete(newWorkflowPipelines[0].Job.Name)
@@ -577,7 +544,7 @@ var _ = Describe("Workflow Reconciler", func() {
 							Expect(passiveRequeue).To(BeTrue())
 							Expect(err).NotTo(HaveOccurred())
 							Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: promise.Name}, &promise)).To(Succeed())
-							Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(1)))
+							Expect(countPromisePipelinesInPhase(&promise, v1alpha1.WorkflowPhaseSucceeded)).To(Equal(1))
 						})
 					})
 				})
@@ -674,7 +641,7 @@ var _ = Describe("Workflow Reconciler", func() {
 						Expect(jobList).To(HaveLen(5))
 
 						markJobAsComplete(originalWorkflowPipelines[0].Job.Name)
-						setParentWorkflowCountersStatus(uPromise, 1)
+						setParentPipelinesSucceeded(uPromise, originalWorkflowPipelines, 1)
 
 						passiveRequeue, err = workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
@@ -802,7 +769,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				Expect(passiveRequeue).To(BeTrue())
 
 				markJobAsComplete(workflowPipelines[0].Job.Name)
-				setParentWorkflowCountersStatus(uPromise, 1)
+				setParentPipelinesSucceeded(uPromise, workflowPipelines, 1)
 
 				passiveRequeue, err = workflow.ReconcileConfigure(opts)
 				Expect(err).NotTo(HaveOccurred())
@@ -850,9 +817,8 @@ var _ = Describe("Workflow Reconciler", func() {
 				updatedResource := &unstructured.Unstructured{}
 				updatedResource.SetGroupVersionKind(resource.GroupVersionKind())
 				Expect(fakeK8sClient.Get(ctx, client.ObjectKeyFromObject(resource), updatedResource)).To(Succeed())
-				//first reconciliation sets the workflow counters to 0
-				Expect(resourceutil.GetWorkflowsCounterStatus(updatedResource, "workflowsSucceeded")).To(Equal(int64((0))))
-				Expect(resourceutil.GetWorkflowsCounterStatus(updatedResource, "workflowsFailed")).To(Equal(int64(0)))
+				Expect(resourceutil.CountPipelinesInPhase(updatedResource, v1alpha1.WorkflowPhaseSucceeded)).To(Equal(int64(0)))
+				Expect(resourceutil.CountPipelinesInPhase(updatedResource, v1alpha1.WorkflowPhaseFailed)).To(Equal(int64(0)))
 
 				//second reconciliation creates the pipeline and updates the status to pending with the correct conditions
 				passiveRequeue, err = workflow.ReconcileConfigure(opts)
@@ -932,12 +898,12 @@ var _ = Describe("Workflow Reconciler", func() {
 					updatedWorkflowPipeline, uPromise := setupTest(updatedPromise, pipelines)
 					opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, updatedWorkflowPipeline, "promise", numberOfJobLimit, namespace)
 					for j := range 2 {
-						setParentWorkflowCountersStatus(uPromise, j)
+						setParentPipelinesSucceeded(uPromise, updatedWorkflowPipeline, j)
 						_, err := workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
 						markJobAsComplete(updatedWorkflowPipeline[j].Job.Name)
 					}
-					setParentWorkflowCountersStatus(uPromise, 2)
+					setParentPipelinesSucceeded(uPromise, updatedWorkflowPipeline, 2)
 				}
 				updatedWorkflowPipeline, uPromise := setupTest(updatedPromise, pipelines)
 				opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, updatedWorkflowPipeline, "promise", numberOfJobLimit, namespace)
@@ -960,7 +926,7 @@ var _ = Describe("Workflow Reconciler", func() {
 
 				labelPromiseForManualReconciliation(promise.Name)
 				newWorkflowPipelines, uPromise := setupTest(promise, pipelines)
-				setParentWorkflowCountersStatus(uPromise, 0)
+				setParentPipelinesSucceeded(uPromise, newWorkflowPipelines, 0)
 				opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise,
 					newWorkflowPipelines, "promise", numberOfJobsToKeep, namespace)
 
@@ -1012,7 +978,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				createFakeWorks(pipelines, promise.Name)
 
 				opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, workflowPipelines, "promise", 5, namespace)
-				setParentWorkflowCountersStatus(uPromise, 2)
+				setParentPipelinesSucceeded(uPromise, workflowPipelines, 2)
 				passiveRequeue, err := workflow.ReconcileConfigure(opts)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(passiveRequeue).To(BeFalse())
@@ -1033,7 +999,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				markJobAsComplete(updatedWorkflows[0].Job.Name)
 
 				opts = workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, updatedWorkflows, "promise", 5, namespace)
-				setParentWorkflowCountersStatus(uPromise, 1)
+				setParentPipelinesSucceeded(uPromise, updatedWorkflows, 1)
 				passiveRequeue, err = workflow.ReconcileConfigure(opts)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(passiveRequeue).To(BeFalse())
@@ -1079,13 +1045,13 @@ var _ = Describe("Workflow Reconciler", func() {
 					Expect(fakeK8sClient.Create(ctx, workflowPipelines[1].Job)).To(Succeed())
 					markJobAsComplete(workflowPipelines[0].Job.Name)
 					markJobAsComplete(workflowPipelines[1].Job.Name)
-					setParentWorkflowCountersStatus(uPromise, 1)
+					setParentPipelinesSucceeded(uPromise, workflowPipelines, 1)
 
 					opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, workflowPipelines, "promise", 5, namespace)
 					passiveRequeue, err := workflow.ReconcileConfigure(opts)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(passiveRequeue).To(BeTrue())
-					assertPromiseWorkflowCountersStatus("redis", 2)
+					assertPromisePipelinesSucceeded("redis", 2)
 
 					passiveRequeue, err = workflow.ReconcileConfigure(opts)
 					Expect(err).NotTo(HaveOccurred())
@@ -1096,7 +1062,7 @@ var _ = Describe("Workflow Reconciler", func() {
 					labelPromiseForManualReconciliation("redis")
 
 					workflowPipelines, uPromise = setupTest(promise, pipelines)
-					setParentWorkflowCountersStatus(uPromise, 1)
+					setParentPipelinesSucceeded(uPromise, workflowPipelines, 1)
 				})
 
 				It("re-triggers all the pipelines in the workflow", func() {
@@ -1106,7 +1072,7 @@ var _ = Describe("Workflow Reconciler", func() {
 						passiveRequeue, err := workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(passiveRequeue).To(BeTrue())
-						assertPromiseWorkflowCountersStatus("redis", 0)
+						assertPromisePipelinesSucceeded("redis", 0)
 						passiveRequeue, err = workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(passiveRequeue).To(BeTrue())
@@ -1181,7 +1147,7 @@ var _ = Describe("Workflow Reconciler", func() {
 						passiveRequeue, err := workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(passiveRequeue).To(BeTrue())
-						assertPromiseWorkflowCountersStatus("redis", 1)
+						assertPromisePipelinesSucceeded("redis", 1)
 						passiveRequeue, err = workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(passiveRequeue).To(BeTrue())
@@ -1205,7 +1171,7 @@ var _ = Describe("Workflow Reconciler", func() {
 						passiveRequeue, err := workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(passiveRequeue).To(BeTrue())
-						assertPromiseWorkflowCountersStatus("redis", 2)
+						assertPromisePipelinesSucceeded("redis", 2)
 
 						passiveRequeue, err = workflow.ReconcileConfigure(opts)
 						Expect(err).NotTo(HaveOccurred())
@@ -1272,7 +1238,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, workflowPipelines, "promise", 5, namespace)
 				_, err := workflow.ReconcileConfigure(opts)
 				Expect(err).NotTo(HaveOccurred())
-				assertPromiseWorkflowCountersStatus("redis", 2)
+				assertPromisePipelinesSucceeded("redis", 2)
 
 				_, err = workflow.ReconcileConfigure(opts)
 				Expect(err).NotTo(HaveOccurred())
@@ -1280,7 +1246,7 @@ var _ = Describe("Workflow Reconciler", func() {
 
 				labelPromiseWithWorkflowRestart("redis")
 				workflowPipelines, uPromise = setupTest(promise, pipelines)
-				setParentWorkflowCountersStatus(uPromise, 2)
+				setParentPipelinesSucceeded(uPromise, workflowPipelines, 2)
 			})
 
 			It("restarts the workflow from the first pipeline and removes the label", func() {
@@ -1289,7 +1255,7 @@ var _ = Describe("Workflow Reconciler", func() {
 				passiveRequeue, err := workflow.ReconcileConfigure(opts)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(passiveRequeue).To(BeTrue())
-				assertPromiseWorkflowCountersStatus("redis", 0)
+				assertPromisePipelinesSucceeded("redis", 0)
 
 				updatedPromise := v1alpha1.Promise{}
 				Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: "redis"}, &updatedPromise)).To(Succeed())
@@ -2658,12 +2624,12 @@ func setupAndReconcileUntilPipelinesCompleted(promise v1alpha1.Promise, pipeline
 	Expect(err).NotTo(HaveOccurred())
 
 	markJobAsComplete(updatedWorkflowPipeline[0].Job.Name)
-	setParentWorkflowCountersStatus(uPromise, 1)
+	setParentPipelinesSucceeded(uPromise, updatedWorkflowPipeline, 1)
 	_, err = workflow.ReconcileConfigure(opts)
 	Expect(err).NotTo(HaveOccurred())
 
 	markJobAsComplete(updatedWorkflowPipeline[1].Job.Name)
-	setParentWorkflowCountersStatus(uPromise, 2)
+	setParentPipelinesSucceeded(uPromise, updatedWorkflowPipeline, 2)
 
 	return updatedWorkflowPipeline, uPromise
 }
@@ -2725,8 +2691,21 @@ func markJobAs(conditionType batchv1.JobConditionType, name string) {
 	ExpectWithOffset(1, fakeK8sClient.Status().Update(ctx, job)).To(Succeed())
 }
 
-func setParentWorkflowCountersStatus(parent *unstructured.Unstructured, workflowsSucceeded int) {
-	resourceutil.SetStatus(parent, logger, "workflowsSucceeded", int64(workflowsSucceeded), "workflowsFailed", int64(0))
+func setParentPipelinesSucceeded(parent *unstructured.Unstructured, resources []v1alpha1.PipelineJobResources, succeeded int) {
+	GinkgoHelper()
+	pipelines := make([]any, 0, len(resources))
+	for i, resource := range resources {
+		phase := v1alpha1.WorkflowPhasePending
+		if i < succeeded {
+			phase = v1alpha1.WorkflowPhaseSucceeded
+		}
+		pipelines = append(pipelines, map[string]any{
+			"name":               resource.Name,
+			"phase":              phase,
+			"lastTransitionTime": metav1.Now().Format(time.RFC3339),
+		})
+	}
+	Expect(unstructured.SetNestedSlice(parent.Object, pipelines, "status", "kratix", "workflows", "pipelines")).To(Succeed())
 	Expect(fakeK8sClient.Status().Update(ctx, parent)).To(Succeed())
 }
 
@@ -2766,23 +2745,33 @@ func forceManualReconciliation(promise v1alpha1.Promise, pipelines []v1alpha1.Pi
 	GinkgoHelper()
 	labelPromiseForManualReconciliation(promise.GetName())
 	resources, uPromise := setupTest(promise, pipelines)
-	setParentWorkflowCountersStatus(uPromise, len(resources)-1)
+	setParentPipelinesSucceeded(uPromise, resources, len(resources)-1)
 	opts := workflow.NewOpts(ctx, fakeK8sClient, eventRecorder, logger, uPromise, resources, "promise", 5, namespace)
 	passiveRequeue, err := workflow.ReconcileConfigure(opts)
 	Expect(err).NotTo(HaveOccurred())
 	if passiveRequeue {
-		assertPromiseWorkflowCountersStatus(promise.GetName(), 0)
+		assertPromisePipelinesSucceeded(promise.GetName(), 0)
 		_, err = workflow.ReconcileConfigure(opts)
 	}
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func assertPromiseWorkflowCountersStatus(name string, workflowsSucceeded int) {
+func assertPromisePipelinesSucceeded(name string, succeeded int) {
 	GinkgoHelper()
 	promise := &v1alpha1.Promise{}
 	Expect(fakeK8sClient.Get(ctx, types.NamespacedName{Name: name}, promise)).To(Succeed())
-	Expect(promise.Status.WorkflowsSucceeded).To(Equal(int64(workflowsSucceeded)))
-	Expect(promise.Status.WorkflowsFailed).To(Equal(int64(0)))
+	Expect(countPromisePipelinesInPhase(promise, v1alpha1.WorkflowPhaseSucceeded)).To(Equal(succeeded))
+	Expect(countPromisePipelinesInPhase(promise, v1alpha1.WorkflowPhaseFailed)).To(Equal(0))
+}
+
+func countPromisePipelinesInPhase(promise *v1alpha1.Promise, phase string) int {
+	count := 0
+	for _, pipeline := range promise.Status.Kratix.Workflows.Pipelines {
+		if pipeline.Phase == phase {
+			count++
+		}
+	}
+	return count
 }
 
 func reconcile(opts workflow.Opts, promise *v1alpha1.Promise) bool {

--- a/test/core/core_test.go
+++ b/test/core/core_test.go
@@ -178,9 +178,6 @@ var _ = Describe("Core Tests", Ordered, func() {
 						reconciledCondition := `.status.conditions[?(@.type=="Reconciled")]`
 						worksSucceededCondition := `.status.conditions[?(@.type=="WorksSucceeded")]`
 						promiseStatus := ".status.status"
-						promiseWorkflows := ".status.workflows"
-						promiseWorkflowsSucceeded := ".status.workflowsSucceeded"
-						promiseWorkflowsFailed := ".status.workflowsFailed"
 
 						Eventually(func(g Gomega) {
 							g.Expect(
@@ -195,16 +192,6 @@ var _ = Describe("Core Tests", Ordered, func() {
 							g.Expect(
 								platform.Kubectl(append(promiseArgs, fmt.Sprintf(`-o=jsonpath='{%s.status}'`, worksSucceededCondition))...),
 							).To(ContainSubstring("True"))
-							g.Expect(
-								platform.Kubectl(append(promiseArgs, fmt.Sprintf(`-o=jsonpath='{%s}'`, promiseWorkflows))...),
-							).To(ContainSubstring("1"))
-							g.Expect(
-								platform.Kubectl(append(promiseArgs, fmt.Sprintf(`-o=jsonpath='{%s}'`, promiseWorkflowsFailed))...),
-							).To(ContainSubstring("0"))
-							g.Expect(
-								platform.Kubectl(append(promiseArgs, fmt.Sprintf(`-o=jsonpath='{%s}'`, promiseWorkflowsSucceeded))...),
-							).To(ContainSubstring("1"))
-
 							var parsedOutput [][]v1alpha1.WorkflowPipelineStatus // jsonpath-as-json returns a nested array of the target objects
 							jsonOutput := platform.Kubectl(append(promiseArgs, fmt.Sprintf(`-o=jsonpath-as-json={%s}`, pipelinesExecutionStatusPath))...)
 							json.Unmarshal([]byte(jsonOutput), &parsedOutput)
@@ -246,10 +233,6 @@ var _ = Describe("Core Tests", Ordered, func() {
 						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.stage}'")...)).To(ContainSubstring("two"))
 						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.completed}'")...)).To(ContainSubstring("true"))
 						g.Expect(platform.Kubectl(append(rrArgs, `-o=jsonpath='{.status.observedGeneration}'`)...)).To(Equal(generation))
-
-						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.workflows}'")...)).To(ContainSubstring("2"))
-						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.workflowsSucceeded}'")...)).To(ContainSubstring("2"))
-						g.Expect(platform.Kubectl(append(rrArgs, "-o=jsonpath='{.status.workflowsFailed}'")...)).To(ContainSubstring("0"))
 
 						if platform.Kubectl(append(rrArgs, `-o=jsonpath={.status.kratix.workflows}`)...) != "" {
 							var parsedOutput [][]v1alpha1.WorkflowPipelineStatus


### PR DESCRIPTION
Drops `.status.workflows`, `.status.workflowsSucceeded` and `.status.workflowsFailed` from Promises and resource requests. `.status.kratix.workflows.pipelines` already carries this.

Workflow drift detection now derives the succeeded count from pipeline phases. Resource request status preserves unknown fields, so the stale counters are pruned during reconcile.

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)