### PR TITLE
fix: clear stale Reconciled reason on promises with no configure workflow

### DIFF
--- a/api/v1alpha1/promise_types.go
+++ b/api/v1alpha1/promise_types.go
@@ -37,17 +37,18 @@ import (
 )
 
 const (
-	PromiseStatusAvailable               = "Available"
-	PromiseStatusUnavailable             = "Unavailable"
-	PromisePlural                        = "promises"
-	KratixResourceHashLabel              = "kratix.io/hash"
-	KratixPipelineHashLabel              = "kratix.io/pipeline-hash"
-	PromiseAvailableConditionType        = "Available"
-	PromiseAvailableConditionTrueReason  = "PromiseAvailable"
-	PromiseAvailableConditionFalseReason = "PromiseUnavailable"
-	PromiseWorksSucceededCondition       = "WorksSucceeded"
-	PromiseReconciledCondition           = "Reconciled"
-	WorkflowSuspendedLabel               = KratixPrefix + "workflow-suspended"
+	PromiseStatusAvailable                = "Available"
+	PromiseStatusUnavailable              = "Unavailable"
+	PromisePlural                         = "promises"
+	KratixResourceHashLabel               = "kratix.io/hash"
+	KratixPipelineHashLabel               = "kratix.io/pipeline-hash"
+	PromiseAvailableConditionType         = "Available"
+	PromiseAvailableConditionTrueReason   = "PromiseAvailable"
+	PromiseAvailableConditionFalseReason  = "PromiseUnavailable"
+	PromiseWorksSucceededCondition        = "WorksSucceeded"
+	PromiseReconciledCondition            = "Reconciled"
+	PromiseRequirementsFulfilledCondition = "RequirementsFulfilled"
+	WorkflowSuspendedLabel                = KratixPrefix + "workflow-suspended"
 	// MaxResourceNameLength is the maximum length of a resource name
 	MaxResourceNameLength int64 = 63
 )

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -207,9 +207,9 @@ func (r *PromiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// Mark the Promise.Status.Conditions to Unavailable
 	updateConditionOnPromise(promise, promiseUnavailableStatusCondition())
 
-	requirementsChanged := r.hasPromiseRequirementsChanged(ctx, promise)
+	requirementsChanged := r.refreshRequirementsStatus(ctx, promise)
 	if requirementsChanged {
-		if meta.IsStatusConditionFalse(promise.Status.Conditions, "RequirementsFulfilled") {
+		if meta.IsStatusConditionFalse(promise.Status.Conditions, v1alpha1.PromiseRequirementsFulfilledCondition) {
 			// Mark the Promise.Status.Conditions to `Message: "Pending"`
 			updateConditionOnPromise(promise, promiseReconciledPendingCondition("RequirementsNotFulfilled"))
 		}
@@ -549,48 +549,56 @@ func (r *PromiseReconciler) generateWorkflowsCounterStatus(promise *v1alpha1.Pro
 }
 
 func (r *PromiseReconciler) updateReconciledCondition(promise *v1alpha1.Promise) bool {
-	worksSucceeded := promise.GetCondition(string(resourceutil.WorksSucceededCondition))
-	workflowCompleted := promise.GetCondition(string(resourceutil.ConfigureWorkflowCompletedCondition))
-	reconciled := promise.GetCondition(string(resourceutil.ReconciledCondition))
-	requirementsFulfilled := promise.GetCondition("RequirementsFulfilled")
+	desired, ok := desiredReconciledCondition(promise)
+	if !ok || !updateConditionOnPromise(promise, desired) {
+		return false
+	}
 
-	noWorkflowToRun := workflowCompleted == nil &&
-		!promise.HasPipeline(v1alpha1.WorkflowTypePromise, v1alpha1.WorkflowActionConfigure)
+	if desired.Status == metav1.ConditionTrue {
+		r.EventRecorder.Eventf(promise, nil, v1.EventTypeNormal, "ReconcileSucceeded", "ReconcileSucceeded", "%s", "Successfully reconciled")
+	}
+	return true
+}
+
+// desiredReconciledCondition reports what the Reconciled condition should say, read off the
+// conditions the rest of the reconcile has already written. It returns false when none of the
+// cases apply, meaning the existing condition should be left as it is.
+func desiredReconciledCondition(promise *v1alpha1.Promise) (metav1.Condition, bool) {
+	workflowCompleted := promise.GetCondition(string(resourceutil.ConfigureWorkflowCompletedCondition))
+	worksSucceeded := promise.GetCondition(v1alpha1.PromiseWorksSucceededCondition)
+	requirementsFulfilled := promise.GetCondition(v1alpha1.PromiseRequirementsFulfilledCondition)
+
+	workflowRunning := workflowCompleted != nil &&
+		workflowCompleted.Status == metav1.ConditionFalse &&
+		workflowCompleted.Reason == resourceutil.PipelinesInProgressReason
+	workflowFailed := workflowCompleted != nil &&
+		workflowCompleted.Status == metav1.ConditionFalse &&
+		workflowCompleted.Reason != resourceutil.PipelinesInProgressReason
+	// Nothing writes ConfigureWorkflowCompleted for a Promise with no promise-level configure
+	// workflow, so those have no workflow left to wait on.
+	workflowDone := (workflowCompleted != nil && workflowCompleted.Status == metav1.ConditionTrue) ||
+		(workflowCompleted == nil && !promise.HasPipeline(v1alpha1.WorkflowTypePromise, v1alpha1.WorkflowActionConfigure))
+
+	worksPending := worksSucceeded != nil && worksSucceeded.Status == metav1.ConditionUnknown
+	worksFailed := worksSucceeded != nil && worksSucceeded.Status == metav1.ConditionFalse
+	worksReady := worksSucceeded != nil && worksSucceeded.Status == metav1.ConditionTrue
+
 	requirementsMet := requirementsFulfilled == nil || requirementsFulfilled.Status == metav1.ConditionTrue
 
-	var updated bool
-	if workflowCompleted != nil &&
-		workflowCompleted.Status == "False" && workflowCompleted.Reason == resourceutil.PipelinesInProgressReason {
-		if reconciled == nil || reconciled.Status != "Unknown" {
-			updateConditionOnPromise(promise, promiseReconciledPendingCondition("WorkflowPending"))
-			updated = true
-		}
-	} else if workflowCompleted != nil && workflowCompleted.Status == metav1.ConditionFalse {
-		if reconciled == nil || reconciled.Status != metav1.ConditionFalse ||
-			reconciled.Reason != resourceutil.ConfigureWorkflowCompletedFailedReason {
-			updateConditionOnPromise(promise, promiseReconciledFailingCondition(resourceutil.ConfigureWorkflowCompletedFailedReason))
-			updated = true
-		}
-	} else if worksSucceeded != nil && worksSucceeded.Status == "Unknown" {
-		if reconciled == nil || reconciled.Status != "Unknown" {
-			updateConditionOnPromise(promise, promiseReconciledPendingCondition("WorksPending"))
-			updated = true
-		}
-	} else if worksSucceeded != nil && worksSucceeded.Status == metav1.ConditionFalse {
-		if reconciled == nil || reconciled.Status != metav1.ConditionFalse {
-			updateConditionOnPromise(promise, promiseReconciledFailingCondition("WorksFailing"))
-			updated = true
-		}
-	} else if requirementsMet && worksSucceeded != nil && worksSucceeded.Status == "True" &&
-		(noWorkflowToRun || (workflowCompleted != nil && workflowCompleted.Status == "True")) {
-
-		if reconciled == nil || reconciled.Status != "True" {
-			updateConditionOnPromise(promise, promiseReconciledCondition())
-			updated = true
-			r.EventRecorder.Eventf(promise, nil, v1.EventTypeNormal, "ReconcileSucceeded", "ReconcileSucceeded", "%s", "Successfully reconciled")
-		}
+	switch {
+	case workflowRunning:
+		return promiseReconciledPendingCondition("WorkflowPending"), true
+	case workflowFailed:
+		return promiseReconciledFailingCondition(resourceutil.ConfigureWorkflowCompletedFailedReason), true
+	case worksPending:
+		return promiseReconciledPendingCondition("WorksPending"), true
+	case worksFailed:
+		return promiseReconciledFailingCondition("WorksFailing"), true
+	case workflowDone && worksReady && requirementsMet:
+		return promiseReconciledCondition(), true
 	}
-	return updated
+
+	return metav1.Condition{}, false
 }
 
 func (r *PromiseReconciler) getWorksStatus(ctx context.Context,
@@ -653,7 +661,7 @@ func (r *PromiseReconciler) updateWorksSucceededCondition(
 ) bool {
 	cond := promise.GetCondition(string(resourceutil.WorksSucceededCondition))
 	if len(failed) > 0 {
-		if cond == nil || cond.Status == "True" {
+		if cond == nil || cond.Status == metav1.ConditionTrue {
 			updateConditionOnPromise(promise, promiseWorksSucceededFailedCondition(failed))
 			r.EventRecorder.Eventf(promise, nil, v1.EventTypeWarning, "WorksFailing", "WorksFailing", "Some works associated with this promise has failed: [%s]", strings.Join(failed, ","))
 			return true
@@ -661,21 +669,21 @@ func (r *PromiseReconciler) updateWorksSucceededCondition(
 		return false
 	}
 	if len(pending) > 0 {
-		if cond == nil || cond.Status != "Unknown" {
+		if cond == nil || cond.Status != metav1.ConditionUnknown {
 			updateConditionOnPromise(promise, promiseWorksSucceededUnknownCondition(pending))
 			return true
 		}
 		return false
 	}
 	if len(misplaced) > 0 {
-		if cond == nil || cond.Status != "False" || cond.Reason != "WorksMisplaced" {
+		if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorksMisplaced" {
 			updateConditionOnPromise(promise, promiseWorksSucceededMisplacedCondition(misplaced))
 			r.EventRecorder.Eventf(promise, nil, v1.EventTypeWarning, "WorksMisplaced", "WorksMisplaced", "Some works associated with this promise are misplaced: [%s]", strings.Join(misplaced, ","))
 			return true
 		}
 		return false
 	}
-	if cond == nil || cond.Status != "True" {
+	if cond == nil || cond.Status != metav1.ConditionTrue {
 		updateConditionOnPromise(promise, promiseWorksSucceededStatusCondition())
 		r.EventRecorder.Eventf(promise, nil, v1.EventTypeNormal, "WorksSucceeded", "WorksSucceeded", "%s", "All works associated with this promise are ready")
 		return true
@@ -864,13 +872,13 @@ func promiseReconciledCondition() metav1.Condition {
 	}
 }
 
-func (r *PromiseReconciler) hasPromiseRequirementsChanged(ctx context.Context, promise *v1alpha1.Promise) bool {
+func (r *PromiseReconciler) refreshRequirementsStatus(ctx context.Context, promise *v1alpha1.Promise) bool {
 	previousRequiredPromises := promise.Status.RequiredPromises
 	if len(promise.Spec.RequiredPromises) == 0 && len(previousRequiredPromises) == 0 {
 		return false
 	}
 
-	latestCondition, latestRequirements := r.generateStatusAndMarkRequirements(ctx, promise)
+	latestCondition, latestRequirements := r.evaluateRequirements(ctx, promise)
 
 	requirementsFieldChanged := updateRequirementsStatusOnPromise(promise, promise.Status.RequiredPromises, latestRequirements)
 	conditionsFieldChanged := updateConditionOnPromise(promise, latestCondition)
@@ -910,9 +918,9 @@ func updateRequirementsStatusOnPromise(promise *v1alpha1.Promise, oldReqs, newRe
 	return true
 }
 
-func (r *PromiseReconciler) generateStatusAndMarkRequirements(ctx context.Context, promise *v1alpha1.Promise) (metav1.Condition, []v1alpha1.RequiredPromiseStatus) {
+func (r *PromiseReconciler) evaluateRequirements(ctx context.Context, promise *v1alpha1.Promise) (metav1.Condition, []v1alpha1.RequiredPromiseStatus) {
 	condition := metav1.Condition{
-		Type:               "RequirementsFulfilled",
+		Type:               v1alpha1.PromiseRequirementsFulfilledCondition,
 		Status:             metav1.ConditionTrue,
 		Reason:             "RequirementsInstalled",
 		Message:            "Requirements fulfilled",

--- a/internal/controller/promise_controller.go
+++ b/internal/controller/promise_controller.go
@@ -552,6 +552,11 @@ func (r *PromiseReconciler) updateReconciledCondition(promise *v1alpha1.Promise)
 	worksSucceeded := promise.GetCondition(string(resourceutil.WorksSucceededCondition))
 	workflowCompleted := promise.GetCondition(string(resourceutil.ConfigureWorkflowCompletedCondition))
 	reconciled := promise.GetCondition(string(resourceutil.ReconciledCondition))
+	requirementsFulfilled := promise.GetCondition("RequirementsFulfilled")
+
+	noWorkflowToRun := workflowCompleted == nil &&
+		!promise.HasPipeline(v1alpha1.WorkflowTypePromise, v1alpha1.WorkflowActionConfigure)
+	requirementsMet := requirementsFulfilled == nil || requirementsFulfilled.Status == metav1.ConditionTrue
 
 	var updated bool
 	if workflowCompleted != nil &&
@@ -576,8 +581,8 @@ func (r *PromiseReconciler) updateReconciledCondition(promise *v1alpha1.Promise)
 			updateConditionOnPromise(promise, promiseReconciledFailingCondition("WorksFailing"))
 			updated = true
 		}
-	} else if workflowCompleted != nil && worksSucceeded != nil &&
-		workflowCompleted.Status == "True" && worksSucceeded.Status == "True" {
+	} else if requirementsMet && worksSucceeded != nil && worksSucceeded.Status == "True" &&
+		(noWorkflowToRun || (workflowCompleted != nil && workflowCompleted.Status == "True")) {
 
 		if reconciled == nil || reconciled.Status != "True" {
 			updateConditionOnPromise(promise, promiseReconciledCondition())

--- a/internal/controller/promise_controller_test.go
+++ b/internal/controller/promise_controller_test.go
@@ -359,6 +359,33 @@ var _ = Describe("PromiseController", func() {
 						Expect(reconciler.StartedDynamicControllers).To(HaveLen(1))
 						Expect(*reconciler.StartedDynamicControllers[promise.GetDynamicControllerName(logr.Logger{})].CanCreateResources).To(BeFalse())
 					})
+
+					When("the requirements are installed later", func() {
+						BeforeEach(func() {
+							installRequiredPromise("kafka", "v1.2.0", "Available")
+							installRequiredPromise("telemetry", "v1.1.0", "Available")
+
+							_, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+								funcs: []func(client.Object) error{autoMarkCRDAsEstablished},
+							})
+							Expect(err).NotTo(HaveOccurred())
+							Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+						})
+
+						It("marks the promise as reconciled", func() {
+							requirementsCond, condErr := getCondition(promise, "RequirementsFulfilled")
+							Expect(condErr).NotTo(HaveOccurred())
+							Expect(requirementsCond.Status).To(Equal(metav1.ConditionTrue))
+
+							Expect(promise.Status.Status).To(Equal(v1alpha1.PromiseStatusAvailable))
+
+							reconciledCond, condErr := getCondition(promise, "Reconciled")
+							Expect(condErr).NotTo(HaveOccurred())
+							Expect(reconciledCond.Status).To(Equal(metav1.ConditionTrue))
+							Expect(reconciledCond.Reason).To(Equal("Reconciled"))
+							Expect(reconciledCond.Message).To(Equal("Reconciled"))
+						})
+					})
 				})
 
 				When("the a required promise version does not exist", func() {
@@ -589,7 +616,7 @@ var _ = Describe("PromiseController", func() {
 							Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
 
 							By("updating the status to indicate the requirements are fulfilled", func() {
-								Expect(promise.Status.Conditions).To(HaveLen(3))
+								Expect(promise.Status.Conditions).To(HaveLen(4))
 
 								requirementsCond, condErr := getCondition(promise, "RequirementsFulfilled")
 								Expect(condErr).NotTo(HaveOccurred())
@@ -883,6 +910,36 @@ var _ = Describe("PromiseController", func() {
 							Source: "promise",
 						},
 					))
+				})
+
+				When("it also requires a promise that is not installed", func() {
+					BeforeEach(func() {
+						Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+						promise.Spec.RequiredPromises = []v1alpha1.RequiredPromise{{Name: "kafka", Version: "v1.2.0"}}
+						Expect(fakeK8sClient.Update(ctx, promise)).To(Succeed())
+
+						_, err := t.reconcileUntilCompletion(reconciler, promise, &opts{
+							funcs:           []func(client.Object) error{markAllWorksAsReady},
+							requeueExpected: true,
+						})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(fakeK8sClient.Get(ctx, promiseName, promise)).To(Succeed())
+					})
+
+					It("does not report the promise as reconciled, even though its Works are ready", func() {
+						worksCond, condErr := getCondition(promise, "WorksSucceeded")
+						Expect(condErr).NotTo(HaveOccurred())
+						Expect(worksCond.Status).To(Equal(metav1.ConditionTrue))
+
+						requirementsCond, condErr := getCondition(promise, "RequirementsFulfilled")
+						Expect(condErr).NotTo(HaveOccurred())
+						Expect(requirementsCond.Status).To(Equal(metav1.ConditionFalse))
+
+						reconciledCond, condErr := getCondition(promise, "Reconciled")
+						Expect(condErr).NotTo(HaveOccurred())
+						Expect(reconciledCond.Status).NotTo(Equal(metav1.ConditionTrue))
+						Expect(reconciledCond.Reason).To(Equal("RequirementsNotFulfilled"))
+					})
 				})
 
 				It("preserves third-party finalizers and does not prune existing Kratix finalizers", func() {
@@ -3123,6 +3180,29 @@ func installPromiseRevision(promiseName, version string) {
 	revision := v1alpha1.NewPromiseRevision(
 		&v1alpha1.Promise{ObjectMeta: metav1.ObjectMeta{Name: promiseName}}, version)
 	Expect(fakeK8sClient.Create(ctx, revision)).To(Succeed())
+}
+
+// markAllWorksAsReady stands in for the Work reconciler, which does not run in these tests.
+// It ignores the object it is handed; reconcileUntilCompletion calls it once per pass, which
+// is enough to catch Works the Promise controller has only just created.
+func markAllWorksAsReady(client.Object) error {
+	works := &v1alpha1.WorkList{}
+	if err := fakeK8sClient.List(ctx, works); err != nil {
+		return err
+	}
+	for i := range works.Items {
+		work := &works.Items[i]
+		apimeta.SetStatusCondition(&work.Status.Conditions, metav1.Condition{
+			Type:    "Ready",
+			Status:  metav1.ConditionTrue,
+			Reason:  "Ready",
+			Message: "Ready",
+		})
+		if err := fakeK8sClient.Status().Update(ctx, work); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func createAndUpdateWork(work *v1alpha1.Work, status metav1.ConditionStatus, message string) {

--- a/test/system/compound_promise_test.go
+++ b/test/system/compound_promise_test.go
@@ -49,6 +49,13 @@ var _ = Describe("Compound Promise", Label("compound-promise"), Serial, func() {
 				}).Should(ContainSubstring("Available"))
 			})
 
+			By("clearing the RequirementsNotFulfilled reason it was given before its requirements existed", func() {
+				Eventually(func() string {
+					return platform.Kubectl("get", "promise", "compound-promise", "-o",
+						`jsonpath={.status.conditions[?(@.type=="Reconciled")].status}`)
+				}).Should(Equal("True"))
+			})
+
 			By("fulfilling the Resource Request", func() {
 				Eventually(func() string {
 					return platform.Kubectl("get", "compound", "example-compound-rr")


### PR DESCRIPTION
## What's broken

Install a compound promise before the promises it requires, and it keeps saying its requirements are missing forever, long after they are installed and everything else about it looks healthy.

## How to see it

**1. Install a promise that requires another one, without installing what it requires.**

```
kubectl apply -f test/system/assets/compound-promise/promise.yaml
kubectl get promise compound-promise
```

It reports `Unavailable`, and its `Reconciled` condition says `RequirementsNotFulfilled`. Both correct — the promise it needs isn't there yet.

**2. Now install the promise it needs.**

```
kubectl apply -f test/system/assets/compound-promise/sub-promise.yaml
```

**3. Wait for it all to settle, then look again.**

```
kubectl get promise compound-promise -o yaml
```

- `sub-promise` — Available ✅
- `compound-promise` — Available ✅
- `RequirementsFulfilled` — True ✅
- `requiredPromises[].state` — Requirement installed ✅
- `Reconciled` — **still `RequirementsNotFulfilled`** ❌

## Why it happens

Kratix decides whether a promise is reconciled by checking whether that promise's own configure workflow finished.

In cases where a compound promise doesn't have one, Kratix never revisits `Reconciled`, and whatever it wrote there first is what stays. So a Promise that was in RequirementsNotFulfilled state would never change.

## Second commit

A tidy-up of the code that decides all this: it was a five-branch chain that worked out the answer and separately hand-checked whether the answer had changed, in the same breath.