### PR TITLE
fix: correct the Reconciled reason on resource requests when it changes

### DIFF
--- a/internal/controller/dynamic_resource_request_controller.go
+++ b/internal/controller/dynamic_resource_request_controller.go
@@ -833,36 +833,26 @@ func (r *DynamicResourceRequestController) generateResourceStatus(ctx context.Co
 }
 
 func (r *DynamicResourceRequestController) updateWorksSucceededCondition(rr *unstructured.Unstructured, failed, pending, _, misplaced []string) bool {
-	cond := resourceutil.GetCondition(rr, resourceutil.WorksSucceededCondition)
-	if len(failed) > 0 {
-		if cond == nil || cond.Status == v1.ConditionTrue {
-			resourceutil.MarkResourceRequestAsWorksFailed(rr, failed)
-			r.EventRecorder.Eventf(rr, nil, v1.EventTypeWarning, "WorksFailing", "WorksFailing", "%s", fmt.Sprintf("Some works associated with this resource failed: [%s]", strings.Join(failed, ",")))
-			return true
+	switch {
+	case len(failed) > 0:
+		if !resourceutil.MarkResourceRequestAsWorksFailed(rr, failed) {
+			return false
 		}
-		return false
-	}
-	if len(pending) > 0 {
-		if cond == nil || cond.Status != v1.ConditionUnknown {
-			resourceutil.MarkResourceRequestAsWorksPending(rr, pending)
-			return true
+		r.EventRecorder.Eventf(rr, nil, v1.EventTypeWarning, "WorksFailing", "WorksFailing", "%s", fmt.Sprintf("Some works associated with this resource failed: [%s]", strings.Join(failed, ",")))
+	case len(pending) > 0:
+		return resourceutil.MarkResourceRequestAsWorksPending(rr, pending)
+	case len(misplaced) > 0:
+		if !resourceutil.MarkResourceRequestAsWorksMisplaced(rr, misplaced) {
+			return false
 		}
-		return false
-	}
-	if len(misplaced) > 0 {
-		if cond == nil || cond.Status != v1.ConditionFalse || cond.Reason != "WorksMisplaced" {
-			resourceutil.MarkResourceRequestAsWorksMisplaced(rr, misplaced)
-			r.EventRecorder.Eventf(rr, nil, v1.EventTypeWarning, "WorksMisplaced", "WorksMisplaced", "%s", fmt.Sprintf("Some works associated with this resource are misplaced: [%s]", strings.Join(misplaced, ",")))
-			return true
+		r.EventRecorder.Eventf(rr, nil, v1.EventTypeWarning, "WorksMisplaced", "WorksMisplaced", "%s", fmt.Sprintf("Some works associated with this resource are misplaced: [%s]", strings.Join(misplaced, ",")))
+	default:
+		if !resourceutil.MarkResourceRequestAsWorksSucceeded(rr) {
+			return false
 		}
-		return false
-	}
-	if cond == nil || cond.Status != v1.ConditionTrue {
-		resourceutil.MarkResourceRequestAsWorksSucceeded(rr)
 		r.EventRecorder.Eventf(rr, nil, v1.EventTypeNormal, "WorksSucceeded", "WorksSucceeded", "%s", "All works associated with this resource are ready")
-		return true
 	}
-	return false
+	return true
 }
 
 // isDryRun reports whether this resource request is a dry run. Always false
@@ -1023,58 +1013,43 @@ func (r *DynamicResourceRequestController) ensureDryRunSummary(
 func (r *DynamicResourceRequestController) updateReconciledCondition(rr *unstructured.Unstructured) bool {
 	worksSucceeded := resourceutil.GetCondition(rr, resourceutil.WorksSucceededCondition)
 	workflowCompleted := resourceutil.GetCondition(rr, resourceutil.ConfigureWorkflowCompletedCondition)
-	reconciled := resourceutil.GetCondition(rr, resourceutil.ReconciledCondition)
 
-	var updated bool
-	if workflowCompleted != nil &&
-		workflowCompleted.Status == v1.ConditionFalse && workflowCompleted.Reason == resourceutil.PipelinesInProgressReason {
-		if reconciled == nil || reconciled.Status != v1.ConditionUnknown {
-			resourceutil.MarkReconciledPending(rr, "WorkflowPending")
-			updated = true
-		}
-	} else if workflowCompleted != nil && workflowCompleted.Status == v1.ConditionFalse {
-		if reconciled == nil || reconciled.Status != v1.ConditionFalse ||
-			reconciled.Reason != resourceutil.ConfigureWorkflowCompletedFailedReason {
-			resourceutil.MarkReconciledFailing(rr, resourceutil.ConfigureWorkflowCompletedFailedReason)
-			updated = true
-		}
-	} else if worksSucceeded != nil && worksSucceeded.Status == v1.ConditionUnknown {
-		if reconciled == nil || reconciled.Status != v1.ConditionUnknown {
-			resourceutil.MarkReconciledPending(rr, "WorksPending")
-			updated = true
-		}
-	} else if worksSucceeded != nil && worksSucceeded.Status == v1.ConditionFalse {
-		if reconciled == nil || reconciled.Status != v1.ConditionFalse {
-			resourceutil.MarkReconciledFailing(rr, "WorksFailing")
-			updated = true
-		}
-	} else if workflowCompleted != nil && worksSucceeded != nil &&
-		workflowCompleted.Status == v1.ConditionTrue && worksSucceeded.Status == v1.ConditionTrue {
-		updated = r.markReconciledSucceeded(rr, reconciled)
+	workflowRunning := workflowCompleted != nil && workflowCompleted.Status == v1.ConditionFalse &&
+		workflowCompleted.Reason == resourceutil.PipelinesInProgressReason
+	workflowFailed := workflowCompleted != nil && workflowCompleted.Status == v1.ConditionFalse && !workflowRunning
+	workflowDone := workflowCompleted != nil && workflowCompleted.Status == v1.ConditionTrue
+
+	worksPending := worksSucceeded != nil && worksSucceeded.Status == v1.ConditionUnknown
+	worksFailed := worksSucceeded != nil && worksSucceeded.Status == v1.ConditionFalse
+	worksReady := worksSucceeded != nil && worksSucceeded.Status == v1.ConditionTrue
+
+	switch {
+	case workflowRunning:
+		return resourceutil.MarkReconciledPending(rr, "WorkflowPending")
+	case workflowFailed:
+		return resourceutil.MarkReconciledFailing(rr, resourceutil.ConfigureWorkflowCompletedFailedReason)
+	case worksPending:
+		return resourceutil.MarkReconciledPending(rr, "WorksPending")
+	case worksFailed:
+		return resourceutil.MarkReconciledFailing(rr, "WorksFailing")
+	case workflowDone && worksReady:
+		return r.markReconciledSucceeded(rr)
 	}
-	return updated
+	return false
 }
 
 // markReconciledSucceeded sets Reconciled to True, using the dry-run reason when the
 // request is a dry run so a preview is never reported as a real reconciliation. It
 // returns whether the condition changed.
-func (r *DynamicResourceRequestController) markReconciledSucceeded(
-	rr *unstructured.Unstructured, reconciled *clusterv1.Condition,
-) bool {
-	isDryRun := r.isDryRun(rr)
-	expectedReason := "Reconciled"
-	if isDryRun {
-		expectedReason = resourceutil.DryRunWorksSucceededReason
-	}
-
-	if reconciled != nil && reconciled.Status == v1.ConditionTrue && reconciled.Reason == expectedReason {
-		return false
-	}
-
-	if isDryRun {
-		resourceutil.MarkReconciledAsDryRun(rr)
+func (r *DynamicResourceRequestController) markReconciledSucceeded(rr *unstructured.Unstructured) bool {
+	var updated bool
+	if r.isDryRun(rr) {
+		updated = resourceutil.MarkReconciledAsDryRun(rr)
 	} else {
-		resourceutil.MarkReconciledTrue(rr)
+		updated = resourceutil.MarkReconciledTrue(rr)
+	}
+	if !updated {
+		return false
 	}
 	r.EventRecorder.Eventf(rr, nil, v1.EventTypeNormal, "ReconcileSucceeded", "ReconcileSucceeded", "%s", "Successfully reconciled")
 	return true

--- a/internal/controller/dynamic_resource_request_controller_test.go
+++ b/internal/controller/dynamic_resource_request_controller_test.go
@@ -864,6 +864,30 @@ var _ = Describe("DynamicResourceRequestController", func() {
 					Expect(condition.Message).To(ContainSubstring("Some works associated with this resource are not ready: [test]"))
 				})
 
+				It("relists the pending works when a different work becomes pending", func() {
+					setWorksSucceededCondition(resReq, v1.ConditionUnknown, "WorksPending",
+						"Some works associated with this resource are not ready: [an-older-work]")
+					work.Status = v1alpha1.WorkStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    "Ready",
+								Status:  metav1.ConditionFalse,
+								Message: "Pending",
+							},
+						},
+					}
+					Expect(fakeK8sClient.Create(ctx, work)).To(Succeed())
+					Expect(fakeK8sClient.Status().Update(ctx, work)).To(Succeed())
+
+					_, err := t.reconcileUntilCompletion(reconciler, resReq)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+
+					condition := resourceutil.GetCondition(resReq, resourceutil.WorksSucceededCondition)
+					Expect(condition).NotTo(BeNil())
+					Expect(condition.Message).To(ContainSubstring("Some works associated with this resource are not ready: [test]"))
+				})
+
 				It("set to unknown when works condition is not set", func() {
 					work.Status = v1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{},
@@ -1106,6 +1130,67 @@ var _ = Describe("DynamicResourceRequestController", func() {
 						Expect(string(condition.Status)).To(Equal("Unknown"))
 						Expect(condition.Reason).To(Equal("WorksPending"))
 						Expect(condition.Message).To(ContainSubstring("Pending"))
+					})
+				})
+
+				When("the workflow finishes while the works are still pending", func() {
+					BeforeEach(func() {
+						setReconciledCondition(resReq, v1.ConditionUnknown, "WorkflowPending", "Pending")
+						setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
+						setReconcileConfigureWorkflowToReturnFinished()
+						work.Status = v1alpha1.WorkStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:    "Ready",
+									Status:  metav1.ConditionFalse,
+									Message: "Pending",
+								},
+							},
+						}
+						Expect(fakeK8sClient.Create(ctx, work)).To(Succeed())
+						Expect(fakeK8sClient.Status().Update(ctx, work)).To(Succeed())
+					})
+
+					It("replaces the WorkflowPending reason with WorksPending", func() {
+						_, err := t.reconcileUntilCompletion(reconciler, resReq)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+
+						condition := resourceutil.GetCondition(resReq, resourceutil.ReconciledCondition)
+						Expect(condition).NotTo(BeNil())
+						Expect(string(condition.Status)).To(Equal("Unknown"))
+						Expect(condition.Reason).To(Equal("WorksPending"))
+					})
+				})
+
+				When("the works fail after the workflow has already failed", func() {
+					BeforeEach(func() {
+						setReconciledCondition(resReq, v1.ConditionFalse,
+							resourceutil.ConfigureWorkflowCompletedFailedReason, "Failing")
+						setConfigureWorkflowStatus(resReq, v1.ConditionTrue)
+						setReconcileConfigureWorkflowToReturnFinished()
+						work.Status = v1alpha1.WorkStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:    "Ready",
+									Status:  metav1.ConditionFalse,
+									Message: "Failing",
+								},
+							},
+						}
+						Expect(fakeK8sClient.Create(ctx, work)).To(Succeed())
+						Expect(fakeK8sClient.Status().Update(ctx, work)).To(Succeed())
+					})
+
+					It("replaces the ConfigureWorkflowFailed reason with WorksFailing", func() {
+						_, err := t.reconcileUntilCompletion(reconciler, resReq)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(fakeK8sClient.Get(ctx, resReqNameNamespace, resReq)).To(Succeed())
+
+						condition := resourceutil.GetCondition(resReq, resourceutil.ReconciledCondition)
+						Expect(condition).NotTo(BeNil())
+						Expect(string(condition.Status)).To(Equal("False"))
+						Expect(condition.Reason).To(Equal("WorksFailing"))
 					})
 				})
 			})
@@ -2492,6 +2577,30 @@ func setConfigureWorkflowStatus(resReq *unstructured.Unstructured, status v1.Con
 		Reason:             resourceutil.PipelinesExecutedSuccessfully,
 		Message:            fmt.Sprintf("some-reason-%s", t.Format(time.RFC3339)),
 		LastTransitionTime: metav1.NewTime(t),
+	})
+	Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
+}
+
+func setReconciledCondition(resReq *unstructured.Unstructured, status v1.ConditionStatus, reason, message string) {
+	setConditionOnResourceRequest(resReq, resourceutil.ReconciledCondition, status, reason, message)
+}
+
+func setWorksSucceededCondition(resReq *unstructured.Unstructured, status v1.ConditionStatus, reason, message string) {
+	setConditionOnResourceRequest(resReq, resourceutil.WorksSucceededCondition, status, reason, message)
+}
+
+func setConditionOnResourceRequest(resReq *unstructured.Unstructured, conditionType clusterv1.ConditionType,
+	status v1.ConditionStatus, reason, message string,
+) {
+	if resReq.Object["status"] == nil {
+		resReq.Object["status"] = map[string]interface{}{}
+	}
+	resourceutil.SetCondition(resReq, &clusterv1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(time.Now()),
 	})
 	Expect(fakeK8sClient.Status().Update(ctx, resReq)).To(Succeed())
 }

--- a/lib/resourceutil/conditions.go
+++ b/lib/resourceutil/conditions.go
@@ -22,6 +22,21 @@ func SetCondition(obj *unstructured.Unstructured, condition *clusterv1.Condition
 	conditionsutil.Set(setter, condition)
 }
 
+// SetConditionIfChanged writes condition onto obj when it differs in status, reason or
+// message, and reports whether it wrote. Comparing status alone leaves a condition that
+// stays Unknown reporting whichever reason it was first given.
+func SetConditionIfChanged(obj *unstructured.Unstructured, condition *clusterv1.Condition) bool {
+	existing := GetCondition(obj, condition.Type)
+	if existing != nil &&
+		existing.Status == condition.Status &&
+		existing.Reason == condition.Reason &&
+		existing.Message == condition.Message {
+		return false
+	}
+	SetCondition(obj, condition)
+	return true
+}
+
 func HasReconcilePausedCondition(obj *unstructured.Unstructured) bool {
 	cond := GetCondition(obj, ReconciledCondition)
 	return cond != nil && cond.Status == v1.ConditionUnknown && cond.Reason == pausedReconciliationReason

--- a/lib/resourceutil/util.go
+++ b/lib/resourceutil/util.go
@@ -71,8 +71,8 @@ func MarkConfigureWorkflowAsFailed(logger logr.Logger, obj *unstructured.Unstruc
 	logging.Warn(logger, "marking configure workflow as failed", "condition", ConfigureWorkflowCompletedCondition, "value", v1.ConditionFalse, "reason", ConfigureWorkflowCompletedFailedReason)
 }
 
-func MarkResourceRequestAsWorksFailed(obj *unstructured.Unstructured, works []string) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkResourceRequestAsWorksFailed(obj *unstructured.Unstructured, works []string) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               WorksSucceededCondition,
 		Status:             v1.ConditionFalse,
 		Message:            fmt.Sprintf("Some works associated with this resource failed: [%s]", strings.Join(works, ",")),
@@ -81,8 +81,8 @@ func MarkResourceRequestAsWorksFailed(obj *unstructured.Unstructured, works []st
 	})
 }
 
-func MarkResourceRequestAsWorksMisplaced(obj *unstructured.Unstructured, works []string) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkResourceRequestAsWorksMisplaced(obj *unstructured.Unstructured, works []string) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               WorksSucceededCondition,
 		Status:             v1.ConditionFalse,
 		Message:            fmt.Sprintf("Some works associated with this resource are misplaced: [%s]", strings.Join(works, ",")),
@@ -91,8 +91,8 @@ func MarkResourceRequestAsWorksMisplaced(obj *unstructured.Unstructured, works [
 	})
 }
 
-func MarkResourceRequestAsWorksPending(obj *unstructured.Unstructured, works []string) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkResourceRequestAsWorksPending(obj *unstructured.Unstructured, works []string) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               WorksSucceededCondition,
 		Status:             v1.ConditionUnknown,
 		Message:            fmt.Sprintf("Some works associated with this resource are not ready: [%s]", strings.Join(works, ",")),
@@ -101,8 +101,8 @@ func MarkResourceRequestAsWorksPending(obj *unstructured.Unstructured, works []s
 	})
 }
 
-func MarkResourceRequestAsWorksSucceeded(obj *unstructured.Unstructured) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkResourceRequestAsWorksSucceeded(obj *unstructured.Unstructured) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               WorksSucceededCondition,
 		Status:             v1.ConditionTrue,
 		Message:            "All works associated with this resource are ready",
@@ -111,8 +111,8 @@ func MarkResourceRequestAsWorksSucceeded(obj *unstructured.Unstructured) {
 	})
 }
 
-func MarkReconciledAsDryRun(obj *unstructured.Unstructured) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkReconciledAsDryRun(obj *unstructured.Unstructured) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               ReconciledCondition,
 		Status:             v1.ConditionTrue,
 		Message:            "Dry run completed",
@@ -121,8 +121,8 @@ func MarkReconciledAsDryRun(obj *unstructured.Unstructured) {
 	})
 }
 
-func MarkReconciledPending(obj *unstructured.Unstructured, reason string) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkReconciledPending(obj *unstructured.Unstructured, reason string) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               ReconciledCondition,
 		Status:             v1.ConditionUnknown,
 		Message:            "Pending",
@@ -131,8 +131,8 @@ func MarkReconciledPending(obj *unstructured.Unstructured, reason string) {
 	})
 }
 
-func MarkReconciledFailing(obj *unstructured.Unstructured, reason string) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkReconciledFailing(obj *unstructured.Unstructured, reason string) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               ReconciledCondition,
 		Status:             v1.ConditionFalse,
 		Message:            "Failing",
@@ -141,8 +141,8 @@ func MarkReconciledFailing(obj *unstructured.Unstructured, reason string) {
 	})
 }
 
-func MarkReconciledTrue(obj *unstructured.Unstructured) {
-	SetCondition(obj, &clusterv1.Condition{
+func MarkReconciledTrue(obj *unstructured.Unstructured) bool {
+	return SetConditionIfChanged(obj, &clusterv1.Condition{
 		Type:               ReconciledCondition,
 		Status:             v1.ConditionTrue,
 		Message:            "Reconciled",


### PR DESCRIPTION
Stacked on #899. Same kind of bug, on resource requests instead of promises.

## What's broken

A resource request keeps saying it is waiting for its configure workflow, long after that workflow finished. The thing it is really waiting for is a Work, and nothing tells you that.

```
| Reconciled                 | WorkflowPending                                          |
| (Unknown)                  | Last Transition: 1 week ago  (2026-08-25T02:07:04+01:00)  |
| WorksSucceeded             | WorksPending                                             |
| (Unknown)                  | ... not ready: [kafka-catka-instance-configure-1b6b2]     |
| ConfigureWorkflowCompleted | PipelinesExecutedSuccessfully                            |
| (True)                     | Last Transition: 1 hour ago  (2026-09-02T09:26:31+01:00)  |
```

The workflow finished an hour ago, `Reconciled` says it is waiting for the workflow, and `Reconciled` claims nothing has changed since before that workflow ever ran. Anyone debugging this goes and stares at a green pipeline.

## How to see it

**1. Point a promise's resource workflow at a destination that does not exist.**

Take any working promise and set its selector to a label no destination carries:

```
destinationSelectors:
  - matchLabels:
      target: nowhere
```

**2. Request a resource from it.**

```
kubectl apply -f resource-request.yaml
```

**3. While the pipeline is still running, look at the conditions.**

```
kubectl get <resource> <name> -o yaml
```

`Reconciled` says `Unknown` / `WorkflowPending`. Correct — the pipeline is still going.

**4. Wait for the pipeline pod to finish, then look again.**

The pipeline succeeds. It produces a Work, but there is no destination to place it on, so the Work never becomes ready.

```
kubectl get <resource> <name> -o yaml
```

- `ConfigureWorkflowCompleted` — True, just now ✅
- `WorksSucceeded` — Unknown, `WorksPending`, naming the Work ✅
- `Reconciled` — **still `WorkflowPending`** ❌
- `Reconciled` last transition — **older than the workflow that just finished** ❌

It never corrects itself. It stays wrong until the Work becomes ready or fails.

## Why it happens

Kratix works out what each condition should say, then asks "is that different from what is already there?" before writing it. That question only ever compared `True` / `False` / `Unknown`. It never compared the reason.

"Waiting for the workflow" and "waiting for a Work" are both `Unknown`. So when the reason should change from one to the other, Kratix sees `Unknown` on both sides, decides nothing changed, and writes nothing. The old reason stays. And because nothing was written, the last transition time was never touched either — which is why it reads as older than the workflow that has already finished.

The fix is to compare the reason and message too. The timestamp still only moves when the status genuinely changes, so correcting a reason does not reset the clock.

## Two more the same check was hiding

**A failed workflow keeps the blame after the Works fail too.** Both are `False`, so the reason is never corrected and it goes on pointing at the workflow.

**`WorksSucceeded` freezes the list of Works it is waiting on.** That list is whatever was pending the first time it went `Unknown`, so it can name a Work that is long gone. Worse: a Work that *failed* while other Works were pending was never noticed at all — the condition stayed on "pending" and no event was raised.

One change in behaviour falls out of this: events for failing and misplaced Works now also fire when the set of affected Works changes, not only the first time something goes wrong.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
