### PR TITLE
fix: only aggregate health records from the same promise

### DIFF
--- a/internal/controller/healthrecord_controller.go
+++ b/internal/controller/healthrecord_controller.go
@@ -146,8 +146,7 @@ func (r *HealthRecordReconciler) updateResourceStatus(
 
 	var resourceHealthRecords []platformv1alpha1.HealthRecord
 	for _, record := range healthRecords.Items {
-		if record.Data.ResourceRef.Name == healthRecord.Data.ResourceRef.Name &&
-			record.Data.ResourceRef.Namespace == healthRecord.Data.ResourceRef.Namespace {
+		if referToSameResource(&record, healthRecord) {
 			resourceHealthRecords = append(resourceHealthRecords, record)
 		}
 	}
@@ -222,6 +221,12 @@ func (r *HealthRecordReconciler) getInitialHealthStatusState(resReq *unstructure
 	return initialHealthStatusState
 }
 
+func referToSameResource(a, b *platformv1alpha1.HealthRecord) bool {
+	return a.Data.PromiseRef.Name == b.Data.PromiseRef.Name &&
+		a.Data.ResourceRef.Name == b.Data.ResourceRef.Name &&
+		a.Data.ResourceRef.Namespace == b.Data.ResourceRef.Namespace
+}
+
 func getHealthDataAndStates(healthRecords []platformv1alpha1.HealthRecord) ([]any, string, error) {
 	var healthData []any
 	var statePriority = map[string]int{
@@ -291,7 +296,7 @@ func (r *HealthRecordReconciler) deleteHealthRecord(
 	}
 
 	for _, record := range healthRecords.Items {
-		if record.GetName() != healthRecord.GetName() {
+		if record.GetName() != healthRecord.GetName() && referToSameResource(&record, healthRecord) {
 			logging.Debug(r.Log, "updating health records list", "item", record.GetName())
 
 			updatedHealthRecords = append(updatedHealthRecords, record)

--- a/internal/controller/healthrecord_controller_test.go
+++ b/internal/controller/healthrecord_controller_test.go
@@ -258,6 +258,38 @@ var _ = Describe("HealthRecordController", func() {
 		})
 	})
 
+	When("another promise has a resource with the same name and namespace", func() {
+		BeforeEach(func() {
+			otherPromiseRecord := &v1alpha1.HealthRecord{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1alpha1.GroupVersion.String(),
+					Kind:       "HealthRecord",
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "other-promise-record", Namespace: "default"},
+				Data: v1alpha1.HealthRecordData{
+					PromiseRef:  v1alpha1.PromiseRef{Name: "other-promise"},
+					ResourceRef: v1alpha1.ResourceRef{Name: resource.GetName(), Namespace: resource.GetNamespace()},
+					State:       "unhealthy",
+					LastRun:     now,
+					Details:     details,
+				},
+			}
+
+			Expect(fakeK8sClient.Create(ctx, otherPromiseRecord)).To(Succeed())
+		})
+
+		It("only considers records with a matching promiseRef", func() {
+			updatedResource := reconcile()
+
+			status := getResourceStatus(updatedResource)
+			records := getHealthRecordsList(status)
+
+			Expect(records).To(HaveLen(1))
+			Expect(records[0]).To(HaveKeyWithValue("source", HaveKeyWithValue("name", healthRecord.GetName())))
+			Expect(getHealthStatusState(status)).To(Equal("ready"))
+		})
+	})
+
 	When("a healthRecord is deleted", func() {
 		var updatedResource *unstructured.Unstructured
 


### PR DESCRIPTION
HealthRecords were matched to resources by resourceRef name and namespace only, so resources from different promises sharing a name and namespace absorbed each other's health records. Match on promiseRef.name as well, in both the aggregation and delete paths.

Fixes #907